### PR TITLE
feat: add Deploy button for tag-release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,5 +18,6 @@ jobs:
     with:
       install_command: 'npm install'
       typecheck_command: 'npx tsc --noEmit'
+      deploy_staging_script: 'npx wrangler deploy --env staging'
       deploy_release_script: 'npx wrangler deploy'
     secrets: inherit

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -101,6 +101,21 @@ export function handleDashboard(): Response {
     .job-icon.queued { color: #58a6ff; }
     .job-icon.skipped { color: #484f58; }
     .job-icon.cancelled { color: #484f58; }
+    .card-header { display: flex; justify-content: space-between; align-items: flex-start; }
+    .deploy-btn {
+      background: #238636;
+      color: #fff;
+      border: 1px solid #2ea043;
+      border-radius: 6px;
+      padding: 4px 10px;
+      font-size: 11px;
+      font-weight: 600;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+    .deploy-btn:hover { background: #2ea043; }
+    .deploy-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+    .deploy-btn.loading { animation: pulse 1.5s infinite; }
   </style>
 </head>
 <body>
@@ -175,10 +190,16 @@ export function handleDashboard(): Response {
       grid.innerHTML = statuses.map(s => {
         const cls = badgeClass(s.status, s.conclusion);
         const label = s.status === "completed" ? (s.conclusion || "unknown") : s.status;
+        const deployBtn = s.repo.startsWith("ippoan/")
+          ? '<button class="deploy-btn" data-repo="' + s.repo + '" onclick="deployTag(this)">Deploy</button>'
+          : '';
         return \`
           <div class="card \${cls}">
-            <div class="repo">
-              <a href="\${s.run_url}" target="_blank" rel="noopener">\${s.repo}</a>
+            <div class="card-header">
+              <div class="repo">
+                <a href="\${s.run_url}" target="_blank" rel="noopener">\${s.repo}</a>
+              </div>
+              \${deployBtn}
             </div>
             <div>
               <span class="badge \${cls}">\${label}</span>
@@ -221,6 +242,38 @@ export function handleDashboard(): Response {
       ws.onerror = () => {
         ws.close();
       };
+    }
+
+    async function deployTag(btn) {
+      const repo = btn.dataset.repo;
+      if (!confirm("Create patch release for " + repo + "?")) return;
+
+      btn.disabled = true;
+      btn.textContent = "Creating...";
+      btn.classList.add("loading");
+
+      try {
+        const res = await fetch("/api/tag-release", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ repo }),
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          btn.textContent = "Error";
+          btn.classList.remove("loading");
+          alert("Failed: " + (data.error || res.statusText));
+          setTimeout(() => { btn.textContent = "Deploy"; btn.disabled = false; }, 3000);
+          return;
+        }
+        btn.textContent = "Triggered!";
+        btn.classList.remove("loading");
+        setTimeout(() => { btn.textContent = "Deploy"; btn.disabled = false; }, 5000);
+      } catch (e) {
+        btn.textContent = "Error";
+        btn.classList.remove("loading");
+        setTimeout(() => { btn.textContent = "Deploy"; btn.disabled = false; }, 3000);
+      }
     }
 
     connect();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,14 @@
 import { handleWebhook } from "./webhook";
 import { handleStatus } from "./status";
 import { handleDashboard } from "./dashboard";
+import { handleTagRelease } from "./tag-release";
 
 export { CIDashboardHub } from "./hub";
 
 export interface Env {
   CI_STATUS: KVNamespace;
   WEBHOOK_SECRET: string;
+  GITHUB_TOKEN: string;
   CI_HUB: DurableObjectNamespace;
 }
 
@@ -41,6 +43,12 @@ export default {
 
       case "/status":
         return handleStatus(env);
+
+      case "/api/tag-release":
+        if (request.method !== "POST") {
+          return new Response("Method Not Allowed", { status: 405 });
+        }
+        return handleTagRelease(request, env);
 
       case "/":
         return handleDashboard();

--- a/src/tag-release.ts
+++ b/src/tag-release.ts
@@ -1,0 +1,38 @@
+import type { Env } from "./index";
+
+export async function handleTagRelease(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  const { repo } = await request.json<{ repo: string }>();
+
+  if (!repo || !repo.startsWith("ippoan/")) {
+    return Response.json(
+      { error: "Only ippoan org repos allowed" },
+      { status: 403 },
+    );
+  }
+
+  const res = await fetch(
+    `https://api.github.com/repos/${repo}/actions/workflows/tag-release.yml/dispatches`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env.GITHUB_TOKEN}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": "ci-dashboard",
+      },
+      body: JSON.stringify({ ref: "main" }),
+    },
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    return Response.json(
+      { error: `GitHub API ${res.status}: ${text}` },
+      { status: 502 },
+    );
+  }
+
+  return Response.json({ ok: true, repo });
+}

--- a/test/status.test.ts
+++ b/test/status.test.ts
@@ -10,6 +10,7 @@ function testEnv(): Env {
   return {
     CI_STATUS: env.CI_STATUS,
     WEBHOOK_SECRET,
+    GITHUB_TOKEN: "test-token",
     CI_HUB: {} as unknown as DurableObjectNamespace,
   };
 }

--- a/test/tag-release.test.ts
+++ b/test/tag-release.test.ts
@@ -1,0 +1,85 @@
+import { createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { describe, it, expect, vi } from "vitest";
+import worker from "../src/index";
+import type { Env } from "../src/index";
+
+function testEnv(): Env {
+  return {
+    CI_STATUS: {} as unknown as KVNamespace,
+    WEBHOOK_SECRET: "test-secret",
+    GITHUB_TOKEN: "ghp_test_token",
+    CI_HUB: {} as unknown as DurableObjectNamespace,
+  };
+}
+
+describe("POST /api/tag-release", () => {
+  it("returns 405 for GET", async () => {
+    const req = new Request("http://localhost/api/tag-release");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(405);
+  });
+
+  it("returns 403 for non-ippoan repo", async () => {
+    const req = new Request("http://localhost/api/tag-release", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ repo: "other-org/repo" }),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(403);
+    const data = await res.json<{ error: string }>();
+    expect(data.error).toContain("ippoan");
+  });
+
+  it("returns 200 on successful dispatch", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(null, { status: 204 }),
+    );
+
+    const req = new Request("http://localhost/api/tag-release", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ repo: "ippoan/rust-alc-api" }),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const data = await res.json<{ ok: boolean; repo: string }>();
+    expect(data.ok).toBe(true);
+    expect(data.repo).toBe("ippoan/rust-alc-api");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.github.com/repos/ippoan/rust-alc-api/actions/workflows/tag-release.yml/dispatches",
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    fetchSpy.mockRestore();
+  });
+
+  it("returns 502 when GitHub API fails", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("Not Found", { status: 404 }),
+    );
+
+    const req = new Request("http://localhost/api/tag-release", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ repo: "ippoan/some-repo" }),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(502);
+    const data = await res.json<{ error: string }>();
+    expect(data.error).toContain("404");
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -51,6 +51,7 @@ function testEnv(): Env {
   return {
     CI_STATUS: env.CI_STATUS,
     WEBHOOK_SECRET,
+    GITHUB_TOKEN: "test-token",
     CI_HUB: { idFromName: () => ({}), get: () => mockHub() } as unknown as DurableObjectNamespace,
   };
 }


### PR DESCRIPTION
## Summary
- ippoan org のリポジトリカードに Deploy ボタンを追加
- ボタンクリック → `workflow_dispatch` で `tag-release.yml` を起動
- Worker は `actions:write` scope のみ（`contents:write` 不要でセキュア）
- confirm ダイアログ、loading/success/error 表示

## Architecture
```
Deploy ボタン → POST /api/tag-release
  → GitHub API: workflow_dispatch (tag-release.yml)
    → CI 内で patch tag 作成 + push
      → 既存 CI が v* tag を検知 → 自動デプロイ
```

## Setup
```bash
wrangler secret put GITHUB_TOKEN  # actions:write scope の PAT
```

## Test plan
- [x] typecheck 通過
- [x] 17 tests passed
- [ ] デプロイ後に実際のボタン動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)