### PR TITLE
ci: disable staging deploy, keep release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,6 @@ jobs:
     with:
       install_command: 'npm install'
       typecheck_command: 'npx tsc --noEmit'
-      deploy_staging_script: 'npx wrangler deploy --env staging'
+      has_staging_deploy: false
       deploy_release_script: 'npx wrangler deploy'
     secrets: inherit


### PR DESCRIPTION
## Summary
- `has_staging_deploy: false` で staging deploy をスキップ
- release deploy は維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)