### PR TITLE
ci: add tag-release caller workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,11 @@
+name: Tag Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: ippoan/ci-workflows/.github/workflows/tag-release.yml@main


### PR DESCRIPTION
## Summary
- ci-dashboard 自身の tag-release workflow を追加
- Dashboard の Deploy ボタンから自分自身もデプロイ可能に

🤖 Generated with [Claude Code](https://claude.com/claude-code)