### PR TITLE
feat: allow ohishi-exp org for Deploy button

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -202,7 +202,7 @@ export function handleDashboard(): Response {
       grid.innerHTML = statuses.map(s => {
         const cls = badgeClass(s.status, s.conclusion);
         const label = s.status === "completed" ? (s.conclusion || "unknown") : s.status;
-        const deployBtn = s.repo.startsWith("ippoan/")
+        const deployBtn = (s.repo.startsWith("ippoan/") || s.repo.startsWith("ohishi-exp/"))
           ? '<button class="deploy-btn" data-repo="' + s.repo + '" onclick="deployTag(this)">Deploy</button>'
           : '';
         const dismissBtn = '<button class="dismiss-btn" data-run-id="' + s.run_id + '" onclick="dismissRun(this)">&times;</button>';

--- a/src/tag-release.ts
+++ b/src/tag-release.ts
@@ -6,9 +6,10 @@ export async function handleTagRelease(
 ): Promise<Response> {
   const { repo } = await request.json<{ repo: string }>();
 
-  if (!repo || !repo.startsWith("ippoan/")) {
+  const allowedOrgs = ["ippoan/", "ohishi-exp/"];
+  if (!repo || !allowedOrgs.some((org) => repo.startsWith(org))) {
     return Response.json(
-      { error: "Only ippoan org repos allowed" },
+      { error: "Org not allowed" },
       { status: 403 },
     );
   }

--- a/test/tag-release.test.ts
+++ b/test/tag-release.test.ts
@@ -32,7 +32,7 @@ describe("POST /api/tag-release", () => {
     await waitOnExecutionContext(ctx);
     expect(res.status).toBe(403);
     const data = await res.json<{ error: string }>();
-    expect(data.error).toContain("ippoan");
+    expect(data.error).toContain("not allowed");
   });
 
   it("returns 200 on successful dispatch", async () => {


### PR DESCRIPTION
## Summary
- Deploy ボタンとタグリリース API で ohishi-exp org も許可
- ippoan + ohishi-exp の両方のリポジトリカードに Deploy ボタン表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)