### PR TITLE
chore: add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .wrangler/
 coverage/
 .dev.vars
+.env


### PR DESCRIPTION
秘密情報を含む .env ファイルをバージョン管理から除外