### PR TITLE
perf: parallelize KV reads in getAllStatuses()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",

--- a/src/status.ts
+++ b/src/status.ts
@@ -3,14 +3,12 @@ import type { CIStatus } from "./webhook";
 
 export async function getAllStatuses(env: Env): Promise<CIStatus[]> {
   const list = await env.CI_STATUS.list({ prefix: "run:" });
-  const all: CIStatus[] = [];
-
-  for (const key of list.keys) {
-    const value = await env.CI_STATUS.get(key.name);
-    if (value) {
-      all.push(JSON.parse(value) as CIStatus);
-    }
-  }
+  const values = await Promise.all(
+    list.keys.map((key) => env.CI_STATUS.get(key.name))
+  );
+  const all = values
+    .filter((v): v is string => v !== null)
+    .map((v) => JSON.parse(v) as CIStatus);
 
   // Keep only the latest per repo per status group
   const latestInProgress = new Map<string, CIStatus>();


### PR DESCRIPTION
## Summary
- `getAllStatuses()` の KV 読み込みを逐次→`Promise.all()` 並列化
- ダッシュボード初期表示の高速化

## Test plan
- [x] vitest 全17テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)