### PR TITLE
fix: drop stale in_progress when completed is newer

### DIFF
--- a/src/status.ts
+++ b/src/status.ts
@@ -22,6 +22,14 @@ export async function getAllStatuses(env: Env): Promise<CIStatus[]> {
     }
   }
 
+  // Drop stale in_progress: if completed is newer, the run already finished
+  for (const [repo, ip] of latestInProgress) {
+    const completed = latestCompleted.get(repo);
+    if (completed && completed.updated_at > ip.updated_at) {
+      latestInProgress.delete(repo);
+    }
+  }
+
   // Combine: in_progress first, then latest completed per repo
   const result = [...latestInProgress.values(), ...latestCompleted.values()];
 


### PR DESCRIPTION
## Summary
- 同じリポで completed の方が新しい場合、古い in_progress エントリを除外
- サイドバーに stale な in_progress のブランチが表示される問題を解消

## Test plan
- [ ] stale in_progress カードが消えることを確認
- [ ] サイドバーにバージョンタグ（v0.0.x）が正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)