### PR TITLE
fix: serialize KV mutations through Hub DO

### DIFF
--- a/src/hub.ts
+++ b/src/hub.ts
@@ -1,9 +1,10 @@
 import { DurableObject } from "cloudflare:workers";
+import type { CIStatus, JobStatus } from "./webhook";
+import type { Env } from "./index";
 
-export class CIDashboardHub extends DurableObject<Record<string, unknown>> {
-  constructor(ctx: DurableObjectState, env: Record<string, unknown>) {
+export class CIDashboardHub extends DurableObject<Env> {
+  constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
-    // Auto ping/pong for keepalive
     this.ctx.setWebSocketAutoResponse(
       new WebSocketRequestResponsePair("ping", "pong")
     );
@@ -25,7 +26,152 @@ export class CIDashboardHub extends DurableObject<Record<string, unknown>> {
       return new Response("OK");
     }
 
+    // Serialized KV mutations — all go through the singleton DO
+    if (url.pathname === "/update-run") {
+      const payload = await request.json<{
+        run: {
+          id: number;
+          name: string;
+          head_branch: string;
+          status: string;
+          conclusion: string | null;
+          html_url: string;
+          actor: { login: string };
+          updated_at: string;
+          run_started_at: string;
+        };
+        repo: string;
+      }>();
+      await this.updateRun(payload);
+      await this.broadcastStatuses();
+      return new Response("OK");
+    }
+
+    if (url.pathname === "/update-job") {
+      const payload = await request.json<{
+        job: {
+          run_id: number;
+          name: string;
+          status: string;
+          conclusion: string | null;
+          html_url: string;
+          started_at: string | null;
+          completed_at: string | null;
+        };
+      }>();
+      await this.updateJob(payload);
+      await this.broadcastStatuses();
+      return new Response("OK");
+    }
+
+    if (url.pathname === "/delete-run") {
+      const { run_id } = await request.json<{ run_id: number }>();
+      await this.env.CI_STATUS.delete(`run:${run_id}`);
+      await this.broadcastStatuses();
+      return new Response("OK");
+    }
+
     return new Response("Not Found", { status: 404 });
+  }
+
+  private async updateRun(payload: {
+    run: {
+      id: number;
+      name: string;
+      head_branch: string;
+      status: string;
+      conclusion: string | null;
+      html_url: string;
+      actor: { login: string };
+      updated_at: string;
+      run_started_at: string;
+    };
+    repo: string;
+  }): Promise<void> {
+    const { run, repo } = payload;
+    const key = `run:${run.id}`;
+    const existing = await this.env.CI_STATUS.get(key);
+
+    if (existing) {
+      const prev = JSON.parse(existing) as CIStatus;
+      prev.status = run.status;
+      prev.conclusion = run.conclusion;
+      prev.updated_at = run.updated_at;
+      // When run completes, fix stale in_progress/queued jobs
+      if (run.status === "completed" && prev.jobs) {
+        for (const job of prev.jobs) {
+          if (job.status === "in_progress" || job.status === "queued") {
+            job.status = "completed";
+            job.conclusion = job.conclusion ?? "skipped";
+          }
+        }
+      }
+      await this.env.CI_STATUS.put(key, JSON.stringify(prev), {
+        expirationTtl: 86400,
+      });
+    } else {
+      const status: CIStatus = {
+        repo,
+        workflow: run.name,
+        branch: run.head_branch,
+        status: run.status,
+        conclusion: run.conclusion,
+        run_id: run.id,
+        run_url: run.html_url,
+        actor: run.actor.login,
+        updated_at: run.updated_at,
+        started_at: run.run_started_at,
+      };
+      await this.env.CI_STATUS.put(key, JSON.stringify(status), {
+        expirationTtl: 86400,
+      });
+    }
+  }
+
+  private async updateJob(payload: {
+    job: {
+      run_id: number;
+      name: string;
+      status: string;
+      conclusion: string | null;
+      html_url: string;
+      started_at: string | null;
+      completed_at: string | null;
+    };
+  }): Promise<void> {
+    const { job } = payload;
+    const key = `run:${job.run_id}`;
+    const existing = await this.env.CI_STATUS.get(key);
+    if (!existing) return;
+
+    const status = JSON.parse(existing) as CIStatus;
+    const jobStatus: JobStatus = {
+      name: job.name,
+      status: job.status,
+      conclusion: job.conclusion,
+      url: job.html_url,
+      started_at: job.started_at,
+      completed_at: job.completed_at,
+    };
+
+    const jobs = status.jobs ?? [];
+    const idx = jobs.findIndex((j) => j.name === job.name);
+    if (idx >= 0) {
+      jobs[idx] = jobStatus;
+    } else {
+      jobs.push(jobStatus);
+    }
+    status.jobs = jobs;
+
+    await this.env.CI_STATUS.put(key, JSON.stringify(status), {
+      expirationTtl: 86400,
+    });
+  }
+
+  private async broadcastStatuses(): Promise<void> {
+    const { getAllStatuses } = await import("./status");
+    const statuses = await getAllStatuses(this.env);
+    this.broadcast(JSON.stringify(statuses));
   }
 
   broadcast(data: string): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { handleWebhook } from "./webhook";
-import { handleStatus, getAllStatuses } from "./status";
+import { handleStatus } from "./status";
 import { handleDashboard } from "./dashboard";
 import { handleTagRelease } from "./tag-release";
 
@@ -55,12 +55,9 @@ export default {
           return new Response("Method Not Allowed", { status: 405 });
         }
         const { run_id } = await request.json<{ run_id: number }>();
-        await env.CI_STATUS.delete(`run:${run_id}`);
-        const statuses = await getAllStatuses(env);
-        const hub = getHub(env);
-        await hub.fetch(new Request("http://hub/broadcast", {
+        await getHub(env).fetch(new Request("http://hub/delete-run", {
           method: "POST",
-          body: JSON.stringify(statuses),
+          body: JSON.stringify({ run_id }),
         }));
         return Response.json({ ok: true });
       }

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -78,92 +78,6 @@ async function verifySignature(
   return signature === digest;
 }
 
-function runKey(runId: number): string {
-  return `run:${runId}`;
-}
-
-async function handleWorkflowRun(
-  payload: WorkflowRunPayload,
-  env: Env
-): Promise<void> {
-  const run = payload.workflow_run;
-  const key = runKey(run.id);
-
-  const existing = await env.CI_STATUS.get(key);
-
-  if (existing) {
-    // Update only run-level fields, preserve jobs from workflow_job events
-    const prev = JSON.parse(existing) as CIStatus;
-    prev.status = run.status;
-    prev.conclusion = run.conclusion;
-    prev.updated_at = run.updated_at;
-    await env.CI_STATUS.put(key, JSON.stringify(prev), {
-      expirationTtl: 86400,
-    });
-  } else {
-    // First event for this run — create new entry
-    const status: CIStatus = {
-      repo: payload.repository.full_name,
-      workflow: run.name,
-      branch: run.head_branch,
-      status: run.status,
-      conclusion: run.conclusion,
-      run_id: run.id,
-      run_url: run.html_url,
-      actor: run.actor.login,
-      updated_at: run.updated_at,
-      started_at: run.run_started_at,
-    };
-    await env.CI_STATUS.put(key, JSON.stringify(status), {
-      expirationTtl: 86400,
-    });
-  }
-}
-
-async function handleWorkflowJob(
-  payload: WorkflowJobPayload,
-  env: Env
-): Promise<void> {
-  const job = payload.workflow_job;
-  const key = runKey(job.run_id);
-
-  const existing = await env.CI_STATUS.get(key);
-  if (!existing) return;
-
-  const status = JSON.parse(existing) as CIStatus;
-
-  const jobStatus: JobStatus = {
-    name: job.name,
-    status: job.status,
-    conclusion: job.conclusion,
-    url: job.html_url,
-    started_at: job.started_at,
-    completed_at: job.completed_at,
-  };
-
-  const jobs = status.jobs ?? [];
-  const idx = jobs.findIndex((j) => j.name === job.name);
-  if (idx >= 0) {
-    jobs[idx] = jobStatus;
-  } else {
-    jobs.push(jobStatus);
-  }
-  status.jobs = jobs;
-
-  await env.CI_STATUS.put(key, JSON.stringify(status), {
-    expirationTtl: 86400,
-  });
-}
-
-async function broadcastUpdate(env: Env, hub: DurableObjectStub): Promise<void> {
-  const { getAllStatuses } = await import("./status");
-  const statuses = await getAllStatuses(env);
-  await hub.fetch(new Request("http://hub/broadcast", {
-    method: "POST",
-    body: JSON.stringify(statuses),
-  }));
-}
-
 export async function handleWebhook(
   request: Request,
   env: Env,
@@ -185,15 +99,23 @@ export async function handleWebhook(
 
   if (event === "workflow_run") {
     const payload: WorkflowRunPayload = JSON.parse(body);
-    await handleWorkflowRun(payload, env);
-    await broadcastUpdate(env, hub);
+    // Route through Hub DO for serialized KV access
+    await hub.fetch(new Request("http://hub/update-run", {
+      method: "POST",
+      body: JSON.stringify({
+        run: payload.workflow_run,
+        repo: payload.repository.full_name,
+      }),
+    }));
     return new Response("OK", { status: 200 });
   }
 
   if (event === "workflow_job") {
     const payload: WorkflowJobPayload = JSON.parse(body);
-    await handleWorkflowJob(payload, env);
-    await broadcastUpdate(env, hub);
+    await hub.fetch(new Request("http://hub/update-job", {
+      method: "POST",
+      body: JSON.stringify({ job: payload.workflow_job }),
+    }));
     return new Response("OK", { status: 200 });
   }
 

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -2,6 +2,7 @@ import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:
 import { describe, it, expect } from "vitest";
 import worker from "../src/index";
 import type { Env } from "../src/index";
+import type { CIStatus, JobStatus } from "../src/webhook";
 
 const WEBHOOK_SECRET = "test-secret";
 
@@ -41,18 +42,93 @@ function makePayload(overrides: Record<string, unknown> = {}) {
   });
 }
 
-function mockHub(): DurableObjectStub {
+// Mock Hub DO that performs KV operations like the real Hub
+function mockHub(kv: KVNamespace): DurableObjectStub {
   return {
-    fetch: async () => new Response("OK"),
+    fetch: async (req: Request) => {
+      const url = new URL(req.url);
+
+      if (url.pathname === "/update-run") {
+        const payload = await req.json() as {
+          run: {
+            id: number; name: string; head_branch: string;
+            status: string; conclusion: string | null; html_url: string;
+            actor: { login: string }; updated_at: string; run_started_at: string;
+          };
+          repo: string;
+        };
+        const { run, repo } = payload;
+        const key = `run:${run.id}`;
+        const existing = await kv.get(key);
+        if (existing) {
+          const prev = JSON.parse(existing) as CIStatus;
+          prev.status = run.status;
+          prev.conclusion = run.conclusion;
+          prev.updated_at = run.updated_at;
+          if (run.status === "completed" && prev.jobs) {
+            for (const job of prev.jobs) {
+              if (job.status === "in_progress" || job.status === "queued") {
+                job.status = "completed";
+                job.conclusion = job.conclusion ?? "skipped";
+              }
+            }
+          }
+          await kv.put(key, JSON.stringify(prev), { expirationTtl: 86400 });
+        } else {
+          const status: CIStatus = {
+            repo, workflow: run.name, branch: run.head_branch,
+            status: run.status, conclusion: run.conclusion,
+            run_id: run.id, run_url: run.html_url, actor: run.actor.login,
+            updated_at: run.updated_at, started_at: run.run_started_at,
+          };
+          await kv.put(key, JSON.stringify(status), { expirationTtl: 86400 });
+        }
+        return new Response("OK");
+      }
+
+      if (url.pathname === "/update-job") {
+        const payload = await req.json() as {
+          job: {
+            run_id: number; name: string; status: string;
+            conclusion: string | null; html_url: string;
+            started_at: string | null; completed_at: string | null;
+          };
+        };
+        const { job } = payload;
+        const key = `run:${job.run_id}`;
+        const existing = await kv.get(key);
+        if (!existing) return new Response("OK");
+        const status = JSON.parse(existing) as CIStatus;
+        const jobStatus: JobStatus = {
+          name: job.name, status: job.status, conclusion: job.conclusion,
+          url: job.html_url, started_at: job.started_at, completed_at: job.completed_at,
+        };
+        const jobs = status.jobs ?? [];
+        const idx = jobs.findIndex((j) => j.name === job.name);
+        if (idx >= 0) { jobs[idx] = jobStatus; } else { jobs.push(jobStatus); }
+        status.jobs = jobs;
+        await kv.put(key, JSON.stringify(status), { expirationTtl: 86400 });
+        return new Response("OK");
+      }
+
+      if (url.pathname === "/delete-run") {
+        const { run_id } = await req.json() as { run_id: number };
+        await kv.delete(`run:${run_id}`);
+        return new Response("OK");
+      }
+
+      return new Response("OK");
+    },
   } as unknown as DurableObjectStub;
 }
 
 function testEnv(): Env {
+  const hub = mockHub(env.CI_STATUS);
   return {
     CI_STATUS: env.CI_STATUS,
     WEBHOOK_SECRET,
     GITHUB_TOKEN: "test-token",
-    CI_HUB: { idFromName: () => ({}), get: () => mockHub() } as unknown as DurableObjectNamespace,
+    CI_HUB: { idFromName: () => ({}), get: () => hub } as unknown as DurableObjectNamespace,
   };
 }
 
@@ -137,19 +213,20 @@ describe("POST /webhook", () => {
   });
 
   it("stores workflow_job and attaches to existing run", async () => {
+    const te = testEnv();
     // First, create a workflow_run
     const runBody = makePayload();
     const runSig = await sign(runBody, WEBHOOK_SECRET);
-    const runReq = new Request("http://localhost/webhook", {
-      method: "POST",
-      body: runBody,
-      headers: {
-        "X-Hub-Signature-256": runSig,
-        "X-GitHub-Event": "workflow_run",
-      },
-    });
     const ctx1 = createExecutionContext();
-    await worker.fetch(runReq, testEnv(), ctx1);
+    await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST",
+        body: runBody,
+        headers: { "X-Hub-Signature-256": runSig, "X-GitHub-Event": "workflow_run" },
+      }),
+      te,
+      ctx1
+    );
     await waitOnExecutionContext(ctx1);
 
     // Then, send a workflow_job event
@@ -168,16 +245,16 @@ describe("POST /webhook", () => {
       repository: { full_name: "ippoan/rust-alc-api" },
     });
     const jobSig = await sign(jobBody, WEBHOOK_SECRET);
-    const jobReq = new Request("http://localhost/webhook", {
-      method: "POST",
-      body: jobBody,
-      headers: {
-        "X-Hub-Signature-256": jobSig,
-        "X-GitHub-Event": "workflow_job",
-      },
-    });
     const ctx2 = createExecutionContext();
-    const res = await worker.fetch(jobReq, testEnv(), ctx2);
+    const res = await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST",
+        body: jobBody,
+        headers: { "X-Hub-Signature-256": jobSig, "X-GitHub-Event": "workflow_job" },
+      }),
+      te,
+      ctx2
+    );
     await waitOnExecutionContext(ctx2);
     expect(res.status).toBe(200);
 
@@ -189,7 +266,8 @@ describe("POST /webhook", () => {
   });
 
   it("updates existing job instead of duplicating", async () => {
-    // Create run with unique repo
+    const te = testEnv();
+    // Create run
     const runBody = makePayload({
       repository: { full_name: "ippoan/test-update" },
       workflow_run: {
@@ -209,7 +287,7 @@ describe("POST /webhook", () => {
         body: runBody,
         headers: { "X-Hub-Signature-256": runSig, "X-GitHub-Event": "workflow_run" },
       }),
-      testEnv(),
+      te,
       ctx1
     );
     await waitOnExecutionContext(ctx1);
@@ -233,7 +311,7 @@ describe("POST /webhook", () => {
         body: job1,
         headers: { "X-Hub-Signature-256": sig1, "X-GitHub-Event": "workflow_job" },
       }),
-      testEnv(),
+      te,
       ctx2
     );
     await waitOnExecutionContext(ctx2);
@@ -257,7 +335,7 @@ describe("POST /webhook", () => {
         body: job2,
         headers: { "X-Hub-Signature-256": sig2, "X-GitHub-Event": "workflow_job" },
       }),
-      testEnv(),
+      te,
       ctx3
     );
     await waitOnExecutionContext(ctx3);


### PR DESCRIPTION
## Summary
- 全 KV mutation を singleton Hub DO 経由に変更し、read-modify-write の race condition を解消
- `workflow_run` completed 時に残った in_progress/queued job を skipped にマーク
- webhook.ts から KV 直接操作を削除、Hub DO に集約

## Test plan
- [ ] CI 全テスト通過 (17/17)
- [ ] webhook 受信後に job ステータスが正しく反映される
- [ ] completed run で stale な in_progress job が残らない

🤖 Generated with [Claude Code](https://claude.com/claude-code)