### PR TITLE
feat: color-code sidebar branches (green=tag, yellow=branch)

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -75,11 +75,12 @@ export function handleDashboard(): Response {
     }
     .repo-item .repo-branch {
       font-size: 11px;
-      color: #8b949e;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
     }
+    .repo-item .repo-branch.is-tag { color: #3fb950; }
+    .repo-item .repo-branch.is-branch { color: #d29922; }
     .repo-item .sidebar-deploy {
       background: #238636;
       color: #fff;
@@ -306,12 +307,14 @@ export function handleDashboard(): Response {
         const shortName = s.repo.includes("/") ? s.repo.split("/").pop() : s.repo;
         const isActive = activeFilter === s.repo ? " active" : "";
         const canDeploy = s.repo.startsWith("ippoan/") || s.repo.startsWith("ohishi-exp/");
-        const deployBtn = canDeploy
+        const isTag = /^v\\d/.test(s.branch);
+        const branchCls = isTag ? "is-tag" : "is-branch";
+        const deployBtn = canDeploy && !isTag
           ? '<button class="sidebar-deploy" data-repo="' + s.repo + '" onclick="event.stopPropagation();deployTag(this)">Deploy</button>'
           : '';
         return '<div class="repo-item' + isActive + '" data-filter-repo="' + s.repo + '" onclick="toggleFilter(this)">'
           + '<div class="repo-name"><span class="repo-dot ' + cls + '"></span>' + shortName + '</div>'
-          + '<div class="repo-meta"><span class="repo-branch">' + s.branch + '</span>' + deployBtn + '</div>'
+          + '<div class="repo-meta"><span class="repo-branch ' + branchCls + '">' + s.branch + '</span>' + deployBtn + '</div>'
           + '</div>';
       }).join("");
     }


### PR DESCRIPTION
## Summary
- バージョンタグ (`v*`) は緑、ブランチ名は黄色で表示
- Deploy ボタンはタグ未リリース（ブランチ表示）のリポにのみ表示
- tag-release を促す UI に

## Test plan
- [ ] タグ付きリポ (v0.0.3 等) が緑で表示される
- [ ] ブランチ表示のリポ (main, fix/xxx 等) が黄色 + Deploy ボタン付き

🤖 Generated with [Claude Code](https://claude.com/claude-code)