### PR TITLE
feat: add re-check button to refresh run status from GitHub API

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -217,6 +217,19 @@ export function handleDashboard(): Response {
       white-space: nowrap;
     }
     .dismiss-btn:hover { color: #f85149; border-color: #f85149; }
+    .recheck-btn {
+      background: transparent;
+      color: #8b949e;
+      border: 1px solid #30363d;
+      border-radius: 6px;
+      padding: 4px 8px;
+      font-size: 11px;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+    .recheck-btn:hover { color: #58a6ff; border-color: #58a6ff; }
+    .recheck-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+    .recheck-btn.loading { animation: pulse 1.5s infinite; }
     .btn-group { display: flex; gap: 6px; }
   </style>
 </head>
@@ -349,6 +362,7 @@ export function handleDashboard(): Response {
         const deployBtn = (s.repo.startsWith("ippoan/") || s.repo.startsWith("ohishi-exp/"))
           ? '<button class="deploy-btn" data-repo="' + s.repo + '" onclick="deployTag(this)">Deploy</button>'
           : '';
+        const recheckBtn = '<button class="recheck-btn" data-run-id="' + s.run_id + '" data-repo="' + s.repo + '" onclick="recheckRun(this)">&#x21bb;</button>';
         const dismissBtn = '<button class="dismiss-btn" data-run-id="' + s.run_id + '" onclick="dismissRun(this)">&times;</button>';
         return \`
           <div class="card \${cls}">
@@ -356,7 +370,7 @@ export function handleDashboard(): Response {
               <div class="repo">
                 <a href="\${s.run_url}" target="_blank" rel="noopener">\${s.repo}</a>
               </div>
-              <div class="btn-group">\${deployBtn}\${dismissBtn}</div>
+              <div class="btn-group">\${deployBtn}\${recheckBtn}\${dismissBtn}</div>
             </div>
             <div>
               <span class="badge \${cls}">\${label}</span>
@@ -437,6 +451,29 @@ export function handleDashboard(): Response {
         btn.textContent = "Error";
         btn.classList.remove("loading");
         setTimeout(() => { btn.textContent = "Deploy"; btn.disabled = false; }, 3000);
+      }
+    }
+
+    async function recheckRun(btn) {
+      const runId = btn.dataset.runId;
+      const repo = btn.dataset.repo;
+      btn.disabled = true;
+      btn.classList.add("loading");
+      try {
+        const res = await fetch("/api/recheck", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ run_id: Number(runId), repo }),
+        });
+        if (!res.ok) {
+          const data = await res.json();
+          alert("Re-check failed: " + (data.error || res.statusText));
+        }
+      } catch (e) {
+        alert("Re-check failed");
+      } finally {
+        btn.disabled = false;
+        btn.classList.remove("loading");
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { handleWebhook } from "./webhook";
 
 import { handleDashboard } from "./dashboard";
+import { handleRecheck } from "./recheck";
 import { handleTagRelease } from "./tag-release";
 
 export { CIDashboardHub } from "./hub";
@@ -57,6 +58,12 @@ export default {
           return new Response("Method Not Allowed", { status: 405 });
         }
         return handleTagRelease(request, env);
+
+      case "/api/recheck":
+        if (request.method !== "POST") {
+          return new Response("Method Not Allowed", { status: 405 });
+        }
+        return handleRecheck(request, env, getHub(env));
 
       case "/api/dismiss": {
         if (request.method !== "POST") {

--- a/src/recheck.ts
+++ b/src/recheck.ts
@@ -1,0 +1,108 @@
+import type { Env } from "./index";
+
+interface GitHubRun {
+  id: number;
+  name: string;
+  head_branch: string;
+  status: string;
+  conclusion: string | null;
+  html_url: string;
+  actor: { login: string };
+  updated_at: string;
+  run_started_at: string;
+}
+
+interface GitHubJob {
+  run_id: number;
+  name: string;
+  status: string;
+  conclusion: string | null;
+  html_url: string;
+  started_at: string | null;
+  completed_at: string | null;
+}
+
+export async function handleRecheck(
+  request: Request,
+  env: Env,
+  hub: DurableObjectStub,
+): Promise<Response> {
+  const { run_id, repo } = await request.json<{
+    run_id: number;
+    repo: string;
+  }>();
+
+  const allowedOrgs = ["ippoan/", "ohishi-exp/"];
+  if (!repo || !allowedOrgs.some((org) => repo.startsWith(org))) {
+    return Response.json({ error: "Org not allowed" }, { status: 403 });
+  }
+
+  const headers = {
+    Authorization: `Bearer ${env.GITHUB_TOKEN}`,
+    Accept: "application/vnd.github+json",
+    "User-Agent": "ci-dashboard",
+  };
+
+  // Fetch run status
+  const runRes = await fetch(
+    `https://api.github.com/repos/${repo}/actions/runs/${run_id}`,
+    { headers },
+  );
+  if (!runRes.ok) {
+    const text = await runRes.text();
+    return Response.json(
+      { error: `GitHub API ${runRes.status}: ${text}` },
+      { status: 502 },
+    );
+  }
+
+  const run = (await runRes.json()) as GitHubRun;
+  await hub.fetch(
+    new Request("http://hub/update-run", {
+      method: "POST",
+      body: JSON.stringify({
+        run: {
+          id: run.id,
+          name: run.name,
+          head_branch: run.head_branch,
+          status: run.status,
+          conclusion: run.conclusion,
+          html_url: run.html_url,
+          actor: { login: run.actor.login },
+          updated_at: run.updated_at,
+          run_started_at: run.run_started_at,
+        },
+        repo,
+      }),
+    }),
+  );
+
+  // Fetch jobs (non-fatal if this fails)
+  const jobsRes = await fetch(
+    `https://api.github.com/repos/${repo}/actions/runs/${run_id}/jobs`,
+    { headers },
+  );
+  if (jobsRes.ok) {
+    const { jobs } = (await jobsRes.json()) as { jobs: GitHubJob[] };
+    for (const job of jobs) {
+      await hub.fetch(
+        new Request("http://hub/update-job", {
+          method: "POST",
+          body: JSON.stringify({
+            job: {
+              run_id: job.run_id,
+              name: job.name,
+              status: job.status,
+              conclusion: job.conclusion,
+              html_url: job.html_url,
+              started_at: job.started_at,
+              completed_at: job.completed_at,
+            },
+          }),
+        }),
+      );
+    }
+  }
+
+  return Response.json({ ok: true, run_id });
+}


### PR DESCRIPTION
## Summary
- Webhook イベントが欠損・遅延した際に、GitHub API から最新ステータスを手動で再取得する ↻ ボタンを追加
- カードの Deploy ボタンと × ボタンの間に配置
- 既存の Hub の updateRun/updateJob をそのまま利用するため hub.ts の変更なし

## 変更ファイル
- `src/recheck.ts` (新規): GitHub API から run + jobs を取得し Hub に転送
- `src/index.ts`: `/api/recheck` ルート追加
- `src/dashboard.ts`: CSS + ボタン + `recheckRun()` 関数追加

## Test plan
- [x] `npx tsc --noEmit` パス
- [x] `npm test` 全17テストパス
- [ ] デプロイ後、↻ ボタンクリックでカードが最新ステータスに更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)