### PR TITLE
feat: add repository exploration MCP tools (8 new tools)

### DIFF
--- a/src/github-api.ts
+++ b/src/github-api.ts
@@ -41,6 +41,7 @@ export async function githubApi<T>(
   path: string,
   body?: unknown,
   params?: Record<string, string>,
+  extraHeaders?: Record<string, string>,
 ): Promise<T> {
   const url = new URL(`${GITHUB_API}${path}`);
   if (params) {
@@ -51,7 +52,7 @@ export async function githubApi<T>(
 
   const res = await fetch(url.toString(), {
     method,
-    headers: headers(token),
+    headers: { ...headers(token), ...extraHeaders },
     body: body ? JSON.stringify(body) : undefined,
   });
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -4,6 +4,9 @@ import { registerActionsTools } from "./tools/actions";
 import { registerPullsTools } from "./tools/pulls";
 import { registerReleasesTools } from "./tools/releases";
 import { registerLogsTools } from "./tools/logs";
+import { registerRepositoryTools } from "./tools/repository";
+import { registerCommitsTools } from "./tools/commits";
+import { registerIssuesTools } from "./tools/issues";
 
 function createMcpServer(token: string): McpServer {
   const server = new McpServer({
@@ -15,6 +18,9 @@ function createMcpServer(token: string): McpServer {
   registerPullsTools(server, token);
   registerReleasesTools(server, token);
   registerLogsTools(server, token);
+  registerRepositoryTools(server, token);
+  registerCommitsTools(server, token);
+  registerIssuesTools(server, token);
 
   return server;
 }

--- a/src/mcp/tools/commits.ts
+++ b/src/mcp/tools/commits.ts
@@ -1,0 +1,113 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { githubApi, parseRepo, validateOrg } from "../../github-api";
+
+export function registerCommitsTools(server: McpServer, token: string): void {
+  server.registerTool(
+    "list_commits",
+    {
+      description: "List commits for a repository. Supports branch/tag and file path filtering.",
+      inputSchema: {
+        repo: z.string().describe("Repository (e.g. 'rust-alc-api')"),
+        sha: z.string().default("main").describe("Branch, tag, or SHA (default: main)"),
+        path: z.string().optional().describe("Filter commits touching this file path"),
+        per_page: z.number().min(1).max(100).default(20).describe("Results per page (default 20)"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ repo, sha, path, per_page }) => {
+      const { owner, repo: name } = parseRepo(repo);
+      validateOrg(owner);
+
+      const params: Record<string, string> = {
+        sha,
+        per_page: String(per_page),
+      };
+      if (path) params.path = path;
+
+      const commits = await githubApi<CommitListItem[]>(
+        token, "GET", `/repos/${owner}/${name}/commits`, undefined, params,
+      );
+
+      const result = commits.map((c) => ({
+        sha: c.sha.slice(0, 7),
+        message: c.commit.message.split("\n")[0],
+        author: c.commit.author.name,
+        date: c.commit.author.date,
+      }));
+
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "get_commit",
+    {
+      description: "Get commit details including changed files and diff patches.",
+      inputSchema: {
+        repo: z.string().describe("Repository (e.g. 'rust-alc-api')"),
+        sha: z.string().describe("Commit SHA (full or short)"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ repo, sha }) => {
+      const { owner, repo: name } = parseRepo(repo);
+      validateOrg(owner);
+
+      const commit = await githubApi<CommitDetail>(
+        token, "GET", `/repos/${owner}/${name}/commits/${sha}`,
+      );
+
+      const MAX_PATCH_LINES = 500;
+      const files = (commit.files ?? []).map((f) => {
+        let patch = f.patch ?? "";
+        const patchLines = patch.split("\n");
+        if (patchLines.length > MAX_PATCH_LINES) {
+          patch = patchLines.slice(0, MAX_PATCH_LINES).join("\n") + `\n... (truncated, ${patchLines.length} total lines)`;
+        }
+        return {
+          filename: f.filename,
+          status: f.status,
+          additions: f.additions,
+          deletions: f.deletions,
+          patch,
+        };
+      });
+
+      const result = {
+        sha: commit.sha.slice(0, 7),
+        message: commit.commit.message,
+        author: commit.commit.author.name,
+        date: commit.commit.author.date,
+        stats: commit.stats,
+        files,
+      };
+
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}
+
+interface CommitListItem {
+  sha: string;
+  commit: {
+    message: string;
+    author: { name: string; date: string };
+  };
+}
+
+interface CommitDetail {
+  sha: string;
+  commit: {
+    message: string;
+    author: { name: string; date: string };
+  };
+  stats: { total: number; additions: number; deletions: number };
+  files?: Array<{
+    filename: string;
+    status: string;
+    additions: number;
+    deletions: number;
+    patch?: string;
+  }>;
+}

--- a/src/mcp/tools/issues.ts
+++ b/src/mcp/tools/issues.ts
@@ -1,0 +1,110 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { githubApi, parseRepo, validateOrg } from "../../github-api";
+
+export function registerIssuesTools(server: McpServer, token: string): void {
+  server.registerTool(
+    "list_issues",
+    {
+      description: "List issues for a repository. Supports state and label filtering.",
+      inputSchema: {
+        repo: z.string().describe("Repository (e.g. 'rust-alc-api')"),
+        state: z.enum(["open", "closed", "all"]).default("open").describe("Issue state filter (default: open)"),
+        labels: z.string().optional().describe("Comma-separated label names (e.g. 'bug,enhancement')"),
+        per_page: z.number().min(1).max(100).default(20).describe("Results per page (default 20)"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ repo, state, labels, per_page }) => {
+      const { owner, repo: name } = parseRepo(repo);
+      validateOrg(owner);
+
+      const params: Record<string, string> = {
+        state,
+        per_page: String(per_page),
+      };
+      if (labels) params.labels = labels;
+
+      const issues = await githubApi<Issue[]>(
+        token, "GET", `/repos/${owner}/${name}/issues`, undefined, params,
+      );
+
+      // Filter out pull requests (GitHub Issues API returns PRs too)
+      const filtered = issues.filter((i) => !i.pull_request);
+
+      const result = filtered.map((i) => ({
+        number: i.number,
+        title: i.title,
+        state: i.state,
+        author: i.user.login,
+        labels: i.labels.map((l) => l.name),
+        created_at: i.created_at,
+        updated_at: i.updated_at,
+        comments: i.comments,
+        url: i.html_url,
+      }));
+
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "get_issue",
+    {
+      description: "Get issue details including body and comments.",
+      inputSchema: {
+        repo: z.string().describe("Repository (e.g. 'rust-alc-api')"),
+        issue_number: z.number().describe("Issue number"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ repo, issue_number }) => {
+      const { owner, repo: name } = parseRepo(repo);
+      validateOrg(owner);
+
+      const [issue, comments] = await Promise.all([
+        githubApi<Issue>(token, "GET", `/repos/${owner}/${name}/issues/${issue_number}`),
+        githubApi<IssueComment[]>(token, "GET", `/repos/${owner}/${name}/issues/${issue_number}/comments`),
+      ]);
+
+      const result = {
+        number: issue.number,
+        title: issue.title,
+        state: issue.state,
+        author: issue.user.login,
+        labels: issue.labels.map((l) => l.name),
+        created_at: issue.created_at,
+        updated_at: issue.updated_at,
+        body: issue.body,
+        url: issue.html_url,
+        comments: comments.map((c) => ({
+          author: c.user.login,
+          created_at: c.created_at,
+          body: c.body,
+        })),
+      };
+
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}
+
+interface Issue {
+  number: number;
+  title: string;
+  state: string;
+  user: { login: string };
+  labels: Array<{ name: string }>;
+  created_at: string;
+  updated_at: string;
+  html_url: string;
+  body: string | null;
+  comments: number;
+  pull_request?: unknown;
+}
+
+interface IssueComment {
+  user: { login: string };
+  created_at: string;
+  body: string;
+}

--- a/src/mcp/tools/repository.ts
+++ b/src/mcp/tools/repository.ts
@@ -1,0 +1,248 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { githubApi, parseRepo, validateOrg } from "../../github-api";
+
+export function registerRepositoryTools(server: McpServer, token: string): void {
+  server.registerTool(
+    "get_file_tree",
+    {
+      description: "Get the file tree of a repository. Use path filter to scope to a subdirectory.",
+      inputSchema: {
+        repo: z.string().describe("Repository (e.g. 'rust-alc-api' or 'ippoan/rust-alc-api')"),
+        ref: z.string().default("main").describe("Branch, tag, or commit SHA (default: main)"),
+        path: z.string().optional().describe("Filter to paths starting with this prefix (e.g. 'src/routes')"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ repo, ref, path }) => {
+      const { owner, repo: name } = parseRepo(repo);
+      validateOrg(owner);
+
+      const data = await githubApi<GitTree>(
+        token, "GET", `/repos/${owner}/${name}/git/trees/${ref}`, undefined,
+        { recursive: "1" },
+      );
+
+      let items = data.tree.map((t) => ({
+        type: t.type === "blob" ? "file" : "dir",
+        path: t.path,
+        size: t.size ?? null,
+      }));
+
+      if (path) {
+        const prefix = path.endsWith("/") ? path : `${path}/`;
+        items = items.filter((i) => i.path.startsWith(prefix) || i.path === path);
+      }
+
+      let header = `${items.length} entries`;
+      if (data.truncated) header += " (truncated — repo too large for full tree)";
+
+      return {
+        content: [{
+          type: "text" as const,
+          text: `${header}\n\n${items.map((i) => `${i.type === "dir" ? "d" : "f"} ${i.path}${i.size != null ? ` (${i.size}B)` : ""}`).join("\n")}`,
+        }],
+      };
+    },
+  );
+
+  server.registerTool(
+    "get_file_content",
+    {
+      description: "Get file content with optional line range. For directories, returns the entry listing.",
+      inputSchema: {
+        repo: z.string().describe("Repository (e.g. 'rust-alc-api')"),
+        path: z.string().describe("File path (e.g. 'src/main.rs')"),
+        ref: z.string().optional().describe("Branch, tag, or commit SHA"),
+        start_line: z.number().min(1).optional().describe("Start line (1-based)"),
+        end_line: z.number().min(1).optional().describe("End line (inclusive)"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ repo, path, ref, start_line, end_line }) => {
+      const { owner, repo: name } = parseRepo(repo);
+      validateOrg(owner);
+
+      const params: Record<string, string> = {};
+      if (ref) params.ref = ref;
+
+      const data = await githubApi<ContentResponse | ContentResponse[]>(
+        token, "GET", `/repos/${owner}/${name}/contents/${path}`, undefined, params,
+      );
+
+      // Directory listing
+      if (Array.isArray(data)) {
+        const entries = data.map((e) => `${e.type === "dir" ? "d" : "f"} ${e.name}${e.size ? ` (${e.size}B)` : ""}`);
+        return {
+          content: [{
+            type: "text" as const,
+            text: `Directory: ${path}\n${entries.length} entries\n\n${entries.join("\n")}`,
+          }],
+        };
+      }
+
+      // File content
+      if (data.type === "symlink" || data.type === "submodule") {
+        return { content: [{ type: "text" as const, text: `${data.type}: ${data.target ?? data.submodule_git_url ?? data.name}` }] };
+      }
+
+      if (!data.content) {
+        return { content: [{ type: "text" as const, text: `File too large (${data.size}B). Use git blob API for files > 1MB.` }] };
+      }
+
+      const decoded = atob(data.content.replace(/\n/g, ""));
+      const lines = decoded.split("\n");
+      const totalLines = lines.length;
+
+      let selected: string[];
+      let header: string;
+
+      if (start_line !== undefined) {
+        const start = Math.max(1, start_line);
+        const end = end_line !== undefined ? Math.min(totalLines, end_line) : totalLines;
+        selected = lines.slice(start - 1, end);
+        header = `${data.name} — Lines ${start}-${Math.min(end, totalLines)} of ${totalLines}`;
+      } else {
+        selected = lines;
+        header = `${data.name} — ${totalLines} lines (${data.size}B)`;
+      }
+
+      const startNum = start_line !== undefined ? Math.max(1, start_line) : 1;
+      const numbered = selected.map((line, i) => `${startNum + i}: ${line}`);
+
+      return { content: [{ type: "text" as const, text: `${header}\n\n${numbered.join("\n")}` }] };
+    },
+  );
+
+  server.registerTool(
+    "search_code",
+    {
+      description: "Search code in a repository (grep-like). Returns matching files with text fragments.",
+      inputSchema: {
+        repo: z.string().describe("Repository (e.g. 'rust-alc-api')"),
+        query: z.string().describe("Search query (e.g. 'handleWebhook', 'TODO')"),
+        path: z.string().optional().describe("Path filter (e.g. 'src/routes')"),
+        extension: z.string().optional().describe("File extension filter (e.g. 'ts', 'rs')"),
+        per_page: z.number().min(1).max(100).default(20).describe("Results per page (default 20)"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ repo, query, path, extension, per_page }) => {
+      const { owner, repo: name } = parseRepo(repo);
+      validateOrg(owner);
+
+      let q = `${query} repo:${owner}/${name}`;
+      if (path) q += ` path:${path}`;
+      if (extension) q += ` extension:${extension}`;
+
+      const data = await githubApi<SearchCodeResponse>(
+        token, "GET", "/search/code", undefined,
+        { q, per_page: String(per_page) },
+        { Accept: "application/vnd.github.text-match+json" },
+      );
+
+      const results = data.items.map((item) => {
+        const fragments = (item.text_matches ?? [])
+          .map((m) => m.fragment)
+          .join("\n---\n");
+        return `## ${item.path}\n${fragments || "(no text preview)"}`;
+      });
+
+      const header = `${data.total_count} total matches, showing ${data.items.length}`;
+      return { content: [{ type: "text" as const, text: `${header}\n\n${results.join("\n\n")}` }] };
+    },
+  );
+
+  server.registerTool(
+    "search_symbols",
+    {
+      description: "Search for symbol definitions (functions, classes, structs, types) in a repository. LSP-like definition finder.",
+      inputSchema: {
+        repo: z.string().describe("Repository (e.g. 'rust-alc-api')"),
+        symbol: z.string().describe("Symbol name to search for"),
+        kind: z.enum(["function", "class", "struct", "interface", "type", "enum", "trait", "mod"]).optional()
+          .describe("Symbol kind — builds language-aware query (e.g. 'fn' for Rust function)"),
+        language: z.string().optional().describe("Language filter (e.g. 'rust', 'typescript')"),
+        per_page: z.number().min(1).max(50).default(10).describe("Results per page (default 10)"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ repo, symbol, kind, language, per_page }) => {
+      const { owner, repo: name } = parseRepo(repo);
+      validateOrg(owner);
+
+      const keyword = kind ? symbolKeyword(kind, language) : "";
+      const quotedSymbol = keyword ? `"${keyword} ${symbol}"` : `"${symbol}"`;
+
+      let q = `${quotedSymbol} repo:${owner}/${name}`;
+      if (language) q += ` language:${language}`;
+
+      const data = await githubApi<SearchCodeResponse>(
+        token, "GET", "/search/code", undefined,
+        { q, per_page: String(per_page) },
+        { Accept: "application/vnd.github.text-match+json" },
+      );
+
+      const results = data.items.map((item) => {
+        const fragments = (item.text_matches ?? [])
+          .map((m) => m.fragment)
+          .join("\n---\n");
+        return `## ${item.path}\n${fragments || "(no text preview)"}`;
+      });
+
+      const header = `${data.total_count} matches for ${kind ?? "symbol"} "${symbol}"`;
+      return { content: [{ type: "text" as const, text: `${header}\n\n${results.join("\n\n")}` }] };
+    },
+  );
+}
+
+function symbolKeyword(kind: string, language?: string): string {
+  const lang = language?.toLowerCase();
+  const keywords: Record<string, Record<string, string>> = {
+    function: { rust: "fn", python: "def", go: "func", _default: "function" },
+    class: { _default: "class" },
+    struct: { _default: "struct" },
+    interface: { go: "type", _default: "interface" },
+    type: { rust: "type", go: "type", _default: "type" },
+    enum: { _default: "enum" },
+    trait: { _default: "trait" },
+    mod: { rust: "mod", python: "import", _default: "module" },
+  };
+  const kindMap = keywords[kind];
+  if (!kindMap) return kind;
+  return (lang && kindMap[lang]) || kindMap._default || kind;
+}
+
+interface GitTree {
+  sha: string;
+  tree: Array<{
+    path: string;
+    type: string;
+    size?: number;
+  }>;
+  truncated: boolean;
+}
+
+interface ContentResponse {
+  name: string;
+  path: string;
+  type: string;
+  size: number;
+  content?: string;
+  encoding?: string;
+  target?: string;
+  submodule_git_url?: string;
+}
+
+interface SearchCodeResponse {
+  total_count: number;
+  items: Array<{
+    name: string;
+    path: string;
+    html_url: string;
+    text_matches?: Array<{
+      fragment: string;
+      matches: Array<{ text: string; indices: number[] }>;
+    }>;
+  }>;
+}

--- a/test/mcp/commits.test.ts
+++ b/test/mcp/commits.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { githubApi, parseRepo, validateOrg } from "../../src/github-api";
+
+describe("Commits tool logic", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("list_commits returns formatted results", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json([
+        {
+          sha: "abc123def456789",
+          commit: {
+            message: "feat: add MCP tools\n\nDetailed description here",
+            author: { name: "yhonda", date: "2026-04-13T10:00:00Z" },
+          },
+        },
+        {
+          sha: "def456abc789012",
+          commit: {
+            message: "fix: webhook handling",
+            author: { name: "yhonda", date: "2026-04-12T09:00:00Z" },
+          },
+        },
+      ]),
+    );
+
+    const { owner, repo } = parseRepo("ci-dashboard");
+    validateOrg(owner);
+    const commits = await githubApi<Array<{
+      sha: string;
+      commit: { message: string; author: { name: string; date: string } };
+    }>>(
+      "token", "GET", `/repos/${owner}/${repo}/commits`,
+      undefined, { sha: "main", per_page: "20" },
+    );
+
+    expect(commits).toHaveLength(2);
+    expect(commits[0]!.sha.slice(0, 7)).toBe("abc123d");
+    expect(commits[0]!.commit.message.split("\n")[0]).toBe("feat: add MCP tools");
+  });
+
+  it("list_commits with path filter", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json([]),
+    );
+
+    const { owner, repo } = parseRepo("ci-dashboard");
+    await githubApi<unknown[]>(
+      "token", "GET", `/repos/${owner}/${repo}/commits`,
+      undefined, { sha: "main", per_page: "10", path: "src/webhook.ts" },
+    );
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("path=src%2Fwebhook.ts");
+  });
+
+  it("get_commit returns files with patch", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        sha: "abc123def456789",
+        commit: {
+          message: "feat: add webhook handler",
+          author: { name: "yhonda", date: "2026-04-13T10:00:00Z" },
+        },
+        stats: { total: 15, additions: 10, deletions: 5 },
+        files: [
+          {
+            filename: "src/webhook.ts",
+            status: "modified",
+            additions: 10,
+            deletions: 5,
+            patch: "@@ -1,5 +1,10 @@\n+import { verify } from './crypto';\n export function handleWebhook() {",
+          },
+        ],
+      }),
+    );
+
+    const { owner, repo } = parseRepo("ci-dashboard");
+    const commit = await githubApi<{
+      sha: string;
+      stats: { total: number };
+      files: Array<{ filename: string; patch?: string }>;
+    }>(
+      "token", "GET", `/repos/${owner}/${repo}/commits/abc123d`,
+    );
+
+    expect(commit.sha.slice(0, 7)).toBe("abc123d");
+    expect(commit.stats.total).toBe(15);
+    expect(commit.files).toHaveLength(1);
+    expect(commit.files[0]!.filename).toBe("src/webhook.ts");
+    expect(commit.files[0]!.patch).toContain("import { verify }");
+  });
+
+  it("get_commit truncates large patches", () => {
+    const MAX_PATCH_LINES = 500;
+    const largePatch = Array.from({ length: 600 }, (_, i) => `+line ${i}`).join("\n");
+    const patchLines = largePatch.split("\n");
+
+    expect(patchLines.length).toBe(600);
+
+    // Simulate truncation logic
+    const truncated = patchLines.slice(0, MAX_PATCH_LINES).join("\n")
+      + `\n... (truncated, ${patchLines.length} total lines)`;
+    expect(truncated).toContain("... (truncated, 600 total lines)");
+    expect(truncated.split("\n").length).toBe(MAX_PATCH_LINES + 1);
+  });
+});

--- a/test/mcp/issues.test.ts
+++ b/test/mcp/issues.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { githubApi, parseRepo, validateOrg } from "../../src/github-api";
+
+describe("Issues tool logic", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("list_issues returns formatted results, filtering out PRs", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json([
+        {
+          number: 10,
+          title: "Bug: webhook fails",
+          state: "open",
+          user: { login: "yhonda" },
+          labels: [{ name: "bug" }],
+          created_at: "2026-04-10T00:00:00Z",
+          updated_at: "2026-04-11T00:00:00Z",
+          html_url: "https://github.com/ippoan/ci-dashboard/issues/10",
+          body: "Details here",
+          comments: 3,
+        },
+        {
+          number: 11,
+          title: "feat: add MCP tools",
+          state: "open",
+          user: { login: "yhonda" },
+          labels: [],
+          created_at: "2026-04-11T00:00:00Z",
+          updated_at: "2026-04-11T00:00:00Z",
+          html_url: "https://github.com/ippoan/ci-dashboard/pull/11",
+          body: null,
+          comments: 0,
+          pull_request: { url: "https://api.github.com/..." },
+        },
+      ]),
+    );
+
+    const { owner, repo } = parseRepo("ci-dashboard");
+    validateOrg(owner);
+    const issues = await githubApi<Array<{
+      number: number;
+      title: string;
+      pull_request?: unknown;
+    }>>(
+      "token", "GET", `/repos/${owner}/${repo}/issues`,
+      undefined, { state: "open", per_page: "20" },
+    );
+
+    // Filter out PRs like the tool does
+    const filtered = issues.filter((i) => !i.pull_request);
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]!.number).toBe(10);
+    expect(filtered[0]!.title).toBe("Bug: webhook fails");
+  });
+
+  it("list_issues with labels filter", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json([]),
+    );
+
+    const { owner, repo } = parseRepo("ci-dashboard");
+    await githubApi<unknown[]>(
+      "token", "GET", `/repos/${owner}/${repo}/issues`,
+      undefined, { state: "open", per_page: "20", labels: "bug,enhancement" },
+    );
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toContain("labels=bug%2Cenhancement");
+  });
+
+  it("get_issue fetches issue + comments in parallel", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    fetchSpy.mockResolvedValueOnce(
+      Response.json({
+        number: 10,
+        title: "Bug: webhook fails",
+        state: "open",
+        user: { login: "yhonda" },
+        labels: [{ name: "bug" }],
+        created_at: "2026-04-10T00:00:00Z",
+        updated_at: "2026-04-11T00:00:00Z",
+        html_url: "https://github.com/ippoan/ci-dashboard/issues/10",
+        body: "The webhook handler crashes when...",
+        comments: 2,
+      }),
+    );
+    fetchSpy.mockResolvedValueOnce(
+      Response.json([
+        {
+          user: { login: "reviewer" },
+          created_at: "2026-04-10T01:00:00Z",
+          body: "Can you add more details?",
+        },
+        {
+          user: { login: "yhonda" },
+          created_at: "2026-04-10T02:00:00Z",
+          body: "Added stack trace above.",
+        },
+      ]),
+    );
+
+    const { owner, repo } = parseRepo("ci-dashboard");
+
+    // Simulate parallel fetch like the tool does
+    const [issue, comments] = await Promise.all([
+      githubApi<{ number: number; title: string; body: string | null }>(
+        "token", "GET", `/repos/${owner}/${repo}/issues/10`,
+      ),
+      githubApi<Array<{ user: { login: string }; body: string }>>(
+        "token", "GET", `/repos/${owner}/${repo}/issues/10/comments`,
+      ),
+    ]);
+
+    expect(issue.number).toBe(10);
+    expect(issue.body).toContain("webhook handler crashes");
+    expect(comments).toHaveLength(2);
+    expect(comments[0]!.user.login).toBe("reviewer");
+    expect(comments[1]!.body).toBe("Added stack trace above.");
+  });
+});

--- a/test/mcp/repository.test.ts
+++ b/test/mcp/repository.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { githubApi, parseRepo, validateOrg } from "../../src/github-api";
+
+describe("Repository tool logic", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("get_file_tree returns file listing", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        sha: "abc123",
+        tree: [
+          { path: "src", type: "tree" },
+          { path: "src/index.ts", type: "blob", size: 1024 },
+          { path: "src/hub.ts", type: "blob", size: 2048 },
+          { path: "README.md", type: "blob", size: 512 },
+        ],
+        truncated: false,
+      }),
+    );
+
+    const { owner, repo } = parseRepo("ci-dashboard");
+    validateOrg(owner);
+    const data = await githubApi<{
+      tree: Array<{ path: string; type: string; size?: number }>;
+      truncated: boolean;
+    }>(
+      "token", "GET", `/repos/${owner}/${repo}/git/trees/main`,
+      undefined, { recursive: "1" },
+    );
+
+    expect(data.tree).toHaveLength(4);
+    expect(data.tree[1]!.path).toBe("src/index.ts");
+    expect(data.truncated).toBe(false);
+  });
+
+  it("get_file_tree with path filter", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        sha: "abc123",
+        tree: [
+          { path: "src", type: "tree" },
+          { path: "src/index.ts", type: "blob", size: 1024 },
+          { path: "src/mcp/server.ts", type: "blob", size: 512 },
+          { path: "test/foo.test.ts", type: "blob", size: 256 },
+        ],
+        truncated: false,
+      }),
+    );
+
+    const { owner, repo } = parseRepo("ci-dashboard");
+    const data = await githubApi<{
+      tree: Array<{ path: string; type: string; size?: number }>;
+    }>(
+      "token", "GET", `/repos/${owner}/${repo}/git/trees/main`,
+      undefined, { recursive: "1" },
+    );
+
+    // Simulate path filter
+    const prefix = "src/";
+    const filtered = data.tree.filter((t) => t.path.startsWith(prefix) || t.path === "src");
+    expect(filtered).toHaveLength(3);
+  });
+
+  it("get_file_content returns decoded content with line numbers", async () => {
+    const content = btoa("line 1\nline 2\nline 3\nline 4\nline 5\n");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        name: "test.ts",
+        path: "src/test.ts",
+        type: "file",
+        size: 30,
+        content,
+        encoding: "base64",
+      }),
+    );
+
+    const { owner, repo } = parseRepo("ci-dashboard");
+    const data = await githubApi<{ content: string; name: string; size: number }>(
+      "token", "GET", `/repos/${owner}/${repo}/contents/src/test.ts`,
+    );
+
+    const decoded = atob(data.content.replace(/\n/g, ""));
+    const lines = decoded.split("\n");
+    expect(lines[0]).toBe("line 1");
+    expect(lines[4]).toBe("line 5");
+
+    // Simulate range: lines 2-4
+    const selected = lines.slice(1, 4);
+    expect(selected).toEqual(["line 2", "line 3", "line 4"]);
+  });
+
+  it("get_file_content handles directory listing", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json([
+        { name: "index.ts", path: "src/index.ts", type: "file", size: 1024 },
+        { name: "hub.ts", path: "src/hub.ts", type: "file", size: 2048 },
+        { name: "mcp", path: "src/mcp", type: "dir" },
+      ]),
+    );
+
+    const { owner, repo } = parseRepo("ci-dashboard");
+    const data = await githubApi<Array<{ name: string; type: string }>>(
+      "token", "GET", `/repos/${owner}/${repo}/contents/src`,
+    );
+
+    expect(Array.isArray(data)).toBe(true);
+    expect(data).toHaveLength(3);
+    expect(data[2]!.type).toBe("dir");
+  });
+
+  it("search_code sends text-match header", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        total_count: 2,
+        items: [
+          {
+            name: "webhook.ts",
+            path: "src/webhook.ts",
+            html_url: "https://github.com/ippoan/ci-dashboard/blob/main/src/webhook.ts",
+            text_matches: [
+              { fragment: "export async function handleWebhook(", matches: [{ text: "handleWebhook", indices: [29, 42] }] },
+            ],
+          },
+        ],
+      }),
+    );
+
+    const { owner, repo } = parseRepo("ci-dashboard");
+    await githubApi<{ total_count: number; items: unknown[] }>(
+      "token", "GET", "/search/code", undefined,
+      { q: `handleWebhook repo:${owner}/${repo}`, per_page: "20" },
+      { Accept: "application/vnd.github.text-match+json" },
+    );
+
+    // Verify text-match header was sent
+    const headers = fetchSpy.mock.calls[0]![1]!.headers as Record<string, string>;
+    expect(headers.Accept).toBe("application/vnd.github.text-match+json");
+  });
+
+  it("search_symbols builds language-aware query", () => {
+    // Test query building logic
+    const symbolKeyword = (kind: string, language?: string): string => {
+      const lang = language?.toLowerCase();
+      const keywords: Record<string, Record<string, string>> = {
+        function: { rust: "fn", python: "def", go: "func", _default: "function" },
+        class: { _default: "class" },
+        struct: { _default: "struct" },
+        trait: { _default: "trait" },
+      };
+      const kindMap = keywords[kind];
+      if (!kindMap) return kind;
+      return (lang && kindMap[lang]) || kindMap._default || kind;
+    };
+
+    expect(symbolKeyword("function", "rust")).toBe("fn");
+    expect(symbolKeyword("function", "python")).toBe("def");
+    expect(symbolKeyword("function", "go")).toBe("func");
+    expect(symbolKeyword("function", "typescript")).toBe("function");
+    expect(symbolKeyword("struct")).toBe("struct");
+    expect(symbolKeyword("trait")).toBe("trait");
+  });
+});


### PR DESCRIPTION
## Summary
- `search_code`: リポジトリ内コード検索 (grep相当、text-match header)
- `get_file_content`: ファイル内容取得 (行範囲指定対応)
- `get_file_tree`: ファイルツリー取得 (パスフィルタ対応)
- `search_symbols`: シンボル定義検索 (LSP風、言語別キーワード対応)
- `list_commits` / `get_commit`: コミット履歴・詳細 (diff patch付き)
- `list_issues` / `get_issue`: Issue一覧・詳細 (コメント付き)

## Changes
- `github-api.ts`: `extraHeaders` パラメータ追加
- `src/mcp/tools/repository.ts`: 4ツール (file tree, content, search, symbols)
- `src/mcp/tools/commits.ts`: 2ツール (list, detail)
- `src/mcp/tools/issues.ts`: 2ツール (list, detail)
- `src/mcp/server.ts`: 新ツール登録
- テスト: 3ファイル追加 (全57テスト合格)

🤖 Generated with [Claude Code](https://claude.com/claude-code)