### PR TITLE
feat(mcp): add issue write tools (#25) + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,97 @@
+# ci-dashboard
+
+GitHub CI 監視 + リポジトリ操作のための MCP (Model Context Protocol) サーバー。
+Cloudflare Workers にデプロイされ、Claude などの MCP クライアントから GitHub Actions ワークフローや issue / PR を操作できる。
+
+## アーキテクチャ
+
+```
+src/
+├── mcp/
+│   ├── server.ts        # MCP server エントリ。registerXxxTools をまとめて呼ぶ
+│   └── tools/           # 機能別ツール定義
+│       ├── actions.ts   # GitHub Actions ワークフロー操作
+│       ├── commits.ts   # コミット情報
+│       ├── issues.ts    # issue 読取 + 書込
+│       ├── logs.ts      # ジョブログ取得・検索
+│       ├── pulls.ts     # PR 読取 + マージ
+│       ├── releases.ts  # タグ・リリース
+│       └── repository.ts # ファイルツリー・コード検索
+└── github-api.ts        # 共通 HTTP ラッパー (validateOrg / githubApi / githubApiRaw)
+```
+
+各ツールは `server.registerTool(name, schema, handler)` で登録される。新ツール追加時は対応する `src/mcp/tools/*.ts` の `registerXxxTools` 関数内に追記するだけで `server.ts` の変更は不要。
+
+## 提供ツール一覧
+
+| name | category | type | 説明 |
+|------|----------|------|------|
+| `list_workflow_runs` | actions | read | List recent workflow runs for a repository. |
+| `get_workflow_run` | actions | read | Get details of a specific workflow run. |
+| `list_workflow_run_jobs` | actions | read | List jobs for a workflow run. |
+| `rerun_workflow_run` | actions | write | Re-run all jobs in a workflow run. |
+| `rerun_failed_jobs` | actions | write | Re-run only failed jobs in a workflow run. |
+| `cancel_workflow_run` | actions | write | Cancel an in-progress workflow run. |
+| `list_commits` | commits | read | List commits for a repository. |
+| `get_commit` | commits | read | Get commit details including changed files and diff patches. |
+| `list_issues` | issues | read | List issues for a repository. |
+| `get_issue` | issues | read | Get issue details including body and comments. |
+| `create_issue` | issues | write | Create a new issue in a repository. |
+| `add_issue_comment` | issues | write | Add a comment to an existing issue or PR. |
+| `add_labels` | issues | write | Add labels to an issue or PR. |
+| `remove_label` | issues | write | Remove a single label from an issue or PR. |
+| `close_issue` | issues | write | Close an issue with optional `state_reason`. |
+| `reopen_issue` | issues | write | Reopen a closed issue. |
+| `get_job_logs` | logs | read | Get logs for a workflow job (tail or line range). |
+| `grep_job_logs` | logs | read | Search job logs with regex pattern. |
+| `list_pull_requests` | pulls | read | List pull requests for a repository. |
+| `get_pull_request` | pulls | read | Get PR details including CI check status. |
+| `merge_pull_request` | pulls | write | Merge a pull request using squash merge. |
+| `list_tags` | releases | read | List tags for a repository. |
+| `get_latest_release` | releases | read | Get the latest release for a repository. |
+| `create_tag_release` | releases | write | Dispatch `tag-release.yml` workflow. |
+| `get_file_tree` | repository | read | Get the file tree of a repository. |
+| `get_file_content` | repository | read | Get file content with optional line range. |
+| `search_code` | repository | read | grep-like code search. |
+| `search_symbols` | repository | read | LSP-like symbol definition finder. |
+
+`type=write` のツールは MCP 上で `destructiveHint: true` が付与される。
+
+## 認可
+
+- 操作対象は `ALLOWED_ORGS = ["ippoan", "ohishi-exp"]` 配下のリポジトリのみ (`src/github-api.ts`)
+- それ以外の owner を指定すると `GitHubApiError(403, "Org not allowed: ...")` で拒否
+- リポジトリ指定は `"owner/name"` または `"name"` (後者は `ippoan/` を補完)
+
+## ローカル開発
+
+```bash
+npm install
+npm run dev          # wrangler dev でローカル起動
+npm test             # vitest 実行
+npm run test:coverage
+npm run typecheck    # tsc --noEmit
+```
+
+## デプロイ
+
+```bash
+npm run deploy       # wrangler deploy
+```
+
+GitHub PAT は wrangler secret に登録:
+
+```bash
+wrangler secret put GITHUB_TOKEN
+```
+
+`repo` / `workflow` スコープが必要 (issue 書込・PR マージ・workflow dispatch のため)。
+
+## ツール追加手順
+
+1. `src/mcp/tools/<category>.ts` の `registerXxxTools` 関数内に `server.registerTool(...)` を追加
+2. `parseRepo(repo)` → `validateOrg(owner)` を冒頭で呼ぶ
+3. `githubApi<T>(token, method, path, body?, params?)` で GitHub REST を叩く
+4. 戻り値は `{ content: [{ type: "text" as const, text: JSON.stringify(...) }] }` 形式
+5. `test/mcp/tools.test.ts` に成功 / エラーパスのテストを追加
+6. **この README のツール一覧表にも追記する**

--- a/src/mcp/tools/issues.ts
+++ b/src/mcp/tools/issues.ts
@@ -87,6 +87,184 @@ export function registerIssuesTools(server: McpServer, token: string): void {
       return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
     },
   );
+
+  server.registerTool(
+    "create_issue",
+    {
+      description: "Create a new issue in a repository.",
+      inputSchema: {
+        repo: z.string().describe("Repository (e.g. 'rust-alc-api')"),
+        title: z.string().describe("Issue title"),
+        body: z.string().optional().describe("Issue body (markdown)"),
+        labels: z.array(z.string()).optional().describe("Label names to attach"),
+        assignees: z.array(z.string()).optional().describe("GitHub usernames to assign"),
+      },
+      annotations: { destructiveHint: true },
+    },
+    async ({ repo, title, body, labels, assignees }) => {
+      const { owner, repo: name } = parseRepo(repo);
+      validateOrg(owner);
+
+      const payload: Record<string, unknown> = { title };
+      if (body) payload.body = body;
+      if (labels) payload.labels = labels;
+      if (assignees) payload.assignees = assignees;
+
+      const created = await githubApi<Issue>(
+        token, "POST", `/repos/${owner}/${name}/issues`, payload,
+      );
+
+      const result = {
+        number: created.number,
+        title: created.title,
+        state: created.state,
+        url: created.html_url,
+      };
+
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "add_issue_comment",
+    {
+      description: "Add a comment to an existing issue or pull request.",
+      inputSchema: {
+        repo: z.string().describe("Repository (e.g. 'rust-alc-api')"),
+        issue_number: z.number().describe("Issue or PR number"),
+        body: z.string().describe("Comment body (markdown)"),
+      },
+      annotations: { destructiveHint: true },
+    },
+    async ({ repo, issue_number, body }) => {
+      const { owner, repo: name } = parseRepo(repo);
+      validateOrg(owner);
+
+      const created = await githubApi<{ id: number; html_url: string; created_at: string }>(
+        token, "POST", `/repos/${owner}/${name}/issues/${issue_number}/comments`, { body },
+      );
+
+      const result = {
+        id: created.id,
+        url: created.html_url,
+        created_at: created.created_at,
+      };
+
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "add_labels",
+    {
+      description: "Add labels to an issue or pull request. Returns the current label list.",
+      inputSchema: {
+        repo: z.string().describe("Repository (e.g. 'rust-alc-api')"),
+        issue_number: z.number().describe("Issue or PR number"),
+        labels: z.array(z.string()).min(1).describe("Label names to add"),
+      },
+      annotations: { destructiveHint: true },
+    },
+    async ({ repo, issue_number, labels }) => {
+      const { owner, repo: name } = parseRepo(repo);
+      validateOrg(owner);
+
+      const updated = await githubApi<Array<{ name: string }>>(
+        token, "POST", `/repos/${owner}/${name}/issues/${issue_number}/labels`, { labels },
+      );
+
+      const result = updated.map((l) => l.name);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "remove_label",
+    {
+      description: "Remove a single label from an issue or pull request. Returns the remaining label list.",
+      inputSchema: {
+        repo: z.string().describe("Repository (e.g. 'rust-alc-api')"),
+        issue_number: z.number().describe("Issue or PR number"),
+        label: z.string().describe("Label name to remove"),
+      },
+      annotations: { destructiveHint: true },
+    },
+    async ({ repo, issue_number, label }) => {
+      const { owner, repo: name } = parseRepo(repo);
+      validateOrg(owner);
+
+      const remaining = await githubApi<Array<{ name: string }>>(
+        token, "DELETE",
+        `/repos/${owner}/${name}/issues/${issue_number}/labels/${encodeURIComponent(label)}`,
+      );
+
+      const result = remaining.map((l) => l.name);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "close_issue",
+    {
+      description: "Close an issue. Optionally set state_reason to 'completed' or 'not_planned'.",
+      inputSchema: {
+        repo: z.string().describe("Repository (e.g. 'rust-alc-api')"),
+        issue_number: z.number().describe("Issue number"),
+        state_reason: z.enum(["completed", "not_planned"]).optional()
+          .describe("Reason for closing (default: completed)"),
+      },
+      annotations: { destructiveHint: true },
+    },
+    async ({ repo, issue_number, state_reason }) => {
+      const { owner, repo: name } = parseRepo(repo);
+      validateOrg(owner);
+
+      const payload: Record<string, unknown> = { state: "closed" };
+      payload.state_reason = state_reason ?? "completed";
+
+      const updated = await githubApi<Issue & { state_reason?: string | null }>(
+        token, "PATCH", `/repos/${owner}/${name}/issues/${issue_number}`, payload,
+      );
+
+      const result = {
+        number: updated.number,
+        state: updated.state,
+        state_reason: updated.state_reason ?? null,
+        url: updated.html_url,
+      };
+
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "reopen_issue",
+    {
+      description: "Reopen a closed issue.",
+      inputSchema: {
+        repo: z.string().describe("Repository (e.g. 'rust-alc-api')"),
+        issue_number: z.number().describe("Issue number"),
+      },
+      annotations: { destructiveHint: true },
+    },
+    async ({ repo, issue_number }) => {
+      const { owner, repo: name } = parseRepo(repo);
+      validateOrg(owner);
+
+      const updated = await githubApi<Issue>(
+        token, "PATCH", `/repos/${owner}/${name}/issues/${issue_number}`,
+        { state: "open" },
+      );
+
+      const result = {
+        number: updated.number,
+        state: updated.state,
+        url: updated.html_url,
+      };
+
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
 }
 
 interface Issue {

--- a/test/mcp/tools.test.ts
+++ b/test/mcp/tools.test.ts
@@ -254,6 +254,147 @@ describe("Log tool logic", () => {
   });
 });
 
+describe("Issues write tool logic", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("create_issue posts title/body/labels and returns minimal shape", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        number: 99,
+        title: "test",
+        state: "open",
+        html_url: "https://github.com/ippoan/ci-dashboard/issues/99",
+      }, { status: 201 }),
+    );
+
+    const { owner, repo } = parseRepo("ci-dashboard");
+    validateOrg(owner);
+    const created = await githubApi<{ number: number; html_url: string }>(
+      "token", "POST", `/repos/${owner}/${repo}/issues`,
+      { title: "test", body: "hello", labels: ["enhancement"] },
+    );
+
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string);
+    expect(body.title).toBe("test");
+    expect(body.body).toBe("hello");
+    expect(body.labels).toEqual(["enhancement"]);
+    expect(created.number).toBe(99);
+  });
+
+  it("create_issue propagates 422 validation error", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({ message: "Validation Failed" }, { status: 422 }),
+    );
+
+    await expect(
+      githubApi("token", "POST", "/repos/ippoan/ci-dashboard/issues",
+        { title: "x", labels: ["nonexistent-label"] }),
+    ).rejects.toThrow(GitHubApiError);
+  });
+
+  it("add_issue_comment posts body and returns id/url/created_at", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        id: 12345,
+        html_url: "https://github.com/ippoan/ci-dashboard/issues/99#issuecomment-12345",
+        created_at: "2026-05-02T01:00:00Z",
+      }, { status: 201 }),
+    );
+
+    const { owner, repo } = parseRepo("ci-dashboard");
+    const result = await githubApi<{ id: number; html_url: string; created_at: string }>(
+      "token", "POST", `/repos/${owner}/${repo}/issues/99/comments`,
+      { body: "thanks!" },
+    );
+
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string);
+    expect(body.body).toBe("thanks!");
+    expect(result.id).toBe(12345);
+    expect(result.created_at).toBe("2026-05-02T01:00:00Z");
+  });
+
+  it("add_labels posts labels and normalizes the response to string[]", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json([
+        { name: "bug" },
+        { name: "enhancement" },
+      ]),
+    );
+
+    const { owner, repo } = parseRepo("ci-dashboard");
+    const updated = await githubApi<Array<{ name: string }>>(
+      "token", "POST", `/repos/${owner}/${repo}/issues/99/labels`,
+      { labels: ["enhancement"] },
+    );
+
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string);
+    expect(body.labels).toEqual(["enhancement"]);
+    expect(updated.map((l) => l.name)).toEqual(["bug", "enhancement"]);
+  });
+
+  it("remove_label DELETEs and url-encodes the label name", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json([{ name: "bug" }]),
+    );
+
+    const { owner, repo } = parseRepo("ci-dashboard");
+    const labelToRemove = "needs review";
+    await githubApi<Array<{ name: string }>>(
+      "token", "DELETE",
+      `/repos/${owner}/${repo}/issues/99/labels/${encodeURIComponent(labelToRemove)}`,
+    );
+
+    const calledUrl = fetchSpy.mock.calls[0]![0] as string;
+    expect(calledUrl).toContain("needs%20review");
+    expect(fetchSpy.mock.calls[0]![1]!.method).toBe("DELETE");
+  });
+
+  it("remove_label propagates 404 when label is not attached", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({ message: "Label does not exist" }, { status: 404 }),
+    );
+
+    await expect(
+      githubApi("token", "DELETE", "/repos/ippoan/ci-dashboard/issues/99/labels/missing"),
+    ).rejects.toThrow(GitHubApiError);
+  });
+
+  it("close_issue PATCHes state=closed with state_reason", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        number: 99, state: "closed", state_reason: "completed",
+        html_url: "https://github.com/ippoan/ci-dashboard/issues/99",
+      }),
+    );
+
+    const { owner, repo } = parseRepo("ci-dashboard");
+    await githubApi("token", "PATCH", `/repos/${owner}/${repo}/issues/99`,
+      { state: "closed", state_reason: "completed" });
+
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string);
+    expect(body.state).toBe("closed");
+    expect(body.state_reason).toBe("completed");
+    expect(fetchSpy.mock.calls[0]![1]!.method).toBe("PATCH");
+  });
+
+  it("reopen_issue PATCHes state=open without state_reason", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        number: 99, state: "open",
+        html_url: "https://github.com/ippoan/ci-dashboard/issues/99",
+      }),
+    );
+
+    const { owner, repo } = parseRepo("ci-dashboard");
+    await githubApi("token", "PATCH", `/repos/${owner}/${repo}/issues/99`,
+      { state: "open" });
+
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string);
+    expect(body.state).toBe("open");
+    expect(body.state_reason).toBeUndefined();
+  });
+});
+
 describe("MCP server smoke test", () => {
   afterEach(() => { vi.restoreAllMocks(); });
 


### PR DESCRIPTION
## Summary

ci-dashboard MCP server に issue 書込み 6 ツールを追加し、README を新規作成。

### 追加ツール
- create_issue / add_issue_comment / add_labels / remove_label / close_issue / reopen_issue

全て既存の `parseRepo` -> `validateOrg` -> `githubApi` パターンを踏襲、`destructiveHint: true`。

### テスト
- 成功パス: body 内容と method を assert
- エラーパス: create_issue 422 / remove_label 404 が GitHubApiError で伝播
- 65 tests pass (既存 57 + 新規 8)

### README
- アーキテクチャ図
- 全 28 ツールのカタログ (read/write 分類)
- ALLOWED_ORGS 認可説明
- ローカル開発 / deploy / wrangler secret 手順

Closes #25

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm test` 全 pass (65 tests)
- [ ] PR merge 後 dogfood: ci-dashboard 自身に create_issue で動作確認