### PR TITLE
feat(mcp): list_org_issues for cross-org bulk view

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ src/
 | `list_commits` | commits | read | List commits for a repository. |
 | `get_commit` | commits | read | Get commit details including changed files and diff patches. |
 | `list_issues` | issues | read | List issues for a repository. |
+| `list_org_issues` | issues | read | List issues across multiple orgs in one call (search-backed, PRs excluded). |
 | `get_issue` | issues | read | Get issue details including body and comments. |
 | `create_issue` | issues | write | Create a new issue in a repository. |
 | `add_issue_comment` | issues | write | Add a comment to an existing issue or PR. |

--- a/src/mcp/tools/issues.ts
+++ b/src/mcp/tools/issues.ts
@@ -265,6 +265,89 @@ export function registerIssuesTools(server: McpServer, token: string): void {
       return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
     },
   );
+
+  server.registerTool(
+    "list_org_issues",
+    {
+      description:
+        "List issues across multiple orgs in one call (uses GitHub search). " +
+        "Filters by state/labels/assignee. PRs are excluded.",
+      inputSchema: {
+        orgs: z.array(z.string()).min(1)
+          .describe("Organization names (e.g. ['ippoan', 'ohishi-exp'])"),
+        state: z.enum(["open", "closed", "all"]).default("open"),
+        labels: z.array(z.string()).optional()
+          .describe("AND filter by label names"),
+        assignee: z.string().optional()
+          .describe("GitHub username, or '@me' for the current token's user"),
+        query: z.string().optional()
+          .describe("Raw GitHub search syntax appended to q (advanced)"),
+        per_page: z.number().min(1).max(100).default(30),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ orgs, state, labels, assignee, query, per_page }) => {
+      for (const o of orgs) validateOrg(o);
+
+      const parts: string[] = ["is:issue"];
+      if (state !== "all") parts.push(`state:${state}`);
+      for (const o of orgs) parts.push(`org:${o}`);
+      if (labels) for (const l of labels) parts.push(`label:"${l}"`);
+      if (assignee) parts.push(`assignee:${assignee}`);
+      if (query) parts.push(query);
+      const q = parts.join(" ");
+
+      const data = await githubApi<SearchIssuesResponse>(
+        token, "GET", "/search/issues", undefined,
+        { q, per_page: String(per_page) },
+      );
+
+      const items = data.items
+        .filter((i) => !i.pull_request)
+        .map((i) => ({
+          repo: i.repository_url.split("/").slice(-2).join("/"),
+          number: i.number,
+          title: i.title,
+          state: i.state,
+          author: i.user?.login ?? "",
+          labels: i.labels.map((l) => l.name),
+          assignees: (i.assignees ?? []).map((a) => a.login),
+          comments: i.comments,
+          created_at: i.created_at,
+          updated_at: i.updated_at,
+          url: i.html_url,
+        }));
+
+      const result = {
+        total_count: data.total_count,
+        incomplete: data.incomplete_results,
+        items,
+      };
+
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}
+
+interface SearchIssuesResponse {
+  total_count: number;
+  incomplete_results: boolean;
+  items: SearchIssueItem[];
+}
+
+interface SearchIssueItem {
+  number: number;
+  title: string;
+  state: string;
+  user: { login: string } | null;
+  labels: Array<{ name: string }>;
+  assignees?: Array<{ login: string }>;
+  comments: number;
+  created_at: string;
+  updated_at: string;
+  html_url: string;
+  repository_url: string;
+  pull_request?: unknown;
 }
 
 interface Issue {

--- a/test/mcp/tools.test.ts
+++ b/test/mcp/tools.test.ts
@@ -395,6 +395,98 @@ describe("Issues write tool logic", () => {
   });
 });
 
+describe("list_org_issues tool logic", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("builds q with state/orgs/labels/assignee and extracts repo from repository_url", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        total_count: 1,
+        incomplete_results: false,
+        items: [
+          {
+            number: 42,
+            title: "bug: thing broken",
+            state: "open",
+            user: { login: "yhonda" },
+            labels: [{ name: "bug" }],
+            assignees: [{ login: "yhonda" }],
+            comments: 2,
+            created_at: "2026-05-01T00:00:00Z",
+            updated_at: "2026-05-02T00:00:00Z",
+            html_url: "https://github.com/ippoan/foo/issues/42",
+            repository_url: "https://api.github.com/repos/ippoan/foo",
+          },
+        ],
+      }),
+    );
+
+    // Validate each org first (mirrors tool behavior)
+    for (const o of ["ippoan", "ohishi-exp"]) validateOrg(o);
+
+    const parts = [
+      "is:issue", "state:open", "org:ippoan", "org:ohishi-exp",
+      'label:"bug"', "assignee:@me",
+    ];
+    const q = parts.join(" ");
+
+    await githubApi("token", "GET", "/search/issues", undefined,
+      { q, per_page: "30" });
+
+    const calledUrl = fetchSpy.mock.calls[0]![0] as string;
+    // URLSearchParams encodes spaces as '+'
+    expect(decodeURIComponent(calledUrl.replace(/\+/g, " "))).toContain(
+      "q=is:issue state:open org:ippoan org:ohishi-exp",
+    );
+    expect(calledUrl).toContain("per_page=30");
+
+    // Tool's mapping logic
+    const repo = "https://api.github.com/repos/ippoan/foo".split("/").slice(-2).join("/");
+    expect(repo).toBe("ippoan/foo");
+  });
+
+  it("filters out items that look like PRs (defensive even with is:issue)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        total_count: 2,
+        incomplete_results: false,
+        items: [
+          {
+            number: 1, title: "real issue", state: "open",
+            user: { login: "a" }, labels: [], assignees: [],
+            comments: 0, created_at: "2026-05-01T00:00:00Z",
+            updated_at: "2026-05-01T00:00:00Z",
+            html_url: "https://github.com/ippoan/foo/issues/1",
+            repository_url: "https://api.github.com/repos/ippoan/foo",
+          },
+          {
+            number: 2, title: "stray PR", state: "open",
+            user: { login: "b" }, labels: [], assignees: [],
+            comments: 0, created_at: "2026-05-01T00:00:00Z",
+            updated_at: "2026-05-01T00:00:00Z",
+            html_url: "https://github.com/ippoan/foo/pull/2",
+            repository_url: "https://api.github.com/repos/ippoan/foo",
+            pull_request: { url: "https://api.github.com/repos/ippoan/foo/pulls/2" },
+          },
+        ],
+      }),
+    );
+
+    const data = await githubApi<{ items: Array<{ number: number; pull_request?: unknown }> }>(
+      "token", "GET", "/search/issues", undefined, { q: "is:issue", per_page: "30" },
+    );
+    const filtered = data.items.filter((i) => !i.pull_request);
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]!.number).toBe(1);
+  });
+
+  it("rejects disallowed org via validateOrg", () => {
+    expect(() => {
+      for (const o of ["ippoan", "evil-org"]) validateOrg(o);
+    }).toThrow(GitHubApiError);
+  });
+});
+
 describe("MCP server smoke test", () => {
   afterEach(() => { vi.restoreAllMocks(); });
 


### PR DESCRIPTION
## Summary

複数 org にまたがる issue を 1 リクエストで取得する MCP ツール `list_org_issues` を追加。

### 追加ツール
- `list_org_issues` (read) — GitHub search API (`/search/issues`) で `org:A org:B` を組み立てて全 org 横断検索

### 入力
- `orgs: string[]` (必須、各要素を validateOrg で検証)
- `state: open|closed|all` (default open)
- `labels: string[]` (AND フィルタ)
- `assignee: string` (`@me` 可)
- `query: string` (任意の追加 search 構文)
- `per_page: 1-100` (default 30)

### 出力
`{ total_count, incomplete, items: [{ repo, number, title, state, author, labels, assignees, comments, created_at, updated_at, url }] }`

PR は `is:issue` 強制 + `pull_request` フィールド防御フィルタの 2 段で除外。

### テスト
- q 構築 + repo 抽出 (`https://api.github.com/repos/X/Y` → `X/Y`)
- PR 混入時の防御フィルタ
- disallowed org 拒否
- 68 tests pass (既存 65 + 新規 3)

### README
- ツール一覧表に 1 行追加 (issues / read)

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm test` 全 pass (68 tests)
- [ ] PR merge + Workers 反映後、ToolSearch 経由で dogfood (`list_org_issues(orgs: ['ippoan'])` で実応答確認)