### PR TITLE
feat: add GET /issues SSR page for cross-org open issue list

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -234,7 +234,7 @@ export function handleDashboard(): Response {
   </style>
 </head>
 <body>
-  <h1>CI Dashboard</h1>
+  <h1>CI Dashboard <a href="/issues" style="font-size:13px;font-weight:400;margin-left:12px;color:#58a6ff;text-decoration:none;">📋 Open Issues →</a></h1>
   <div class="status-bar">
     WS: <span id="sse-status" class="disconnected">connecting...</span>
     &middot; Last update: <span id="last-update">-</span>

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { handleWebhook } from "./webhook";
 import { handleDashboard } from "./dashboard";
+import { handleIssuesPage } from "./issues-page";
 import { handleRecheck } from "./recheck";
 import { handleTagRelease } from "./tag-release";
 import { handleMcpRequest } from "./mcp/server";
@@ -26,6 +27,9 @@ function getHub(env: Env): DurableObjectStub {
 
 // Dashboard
 app.get("/", () => handleDashboard());
+
+// Open issues (SSR, cross-org)
+app.get("/issues", (c) => handleIssuesPage(c.env));
 
 // WebSocket
 app.get("/ws", (c) => getHub(c.env).fetch(c.req.raw));

--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -1,0 +1,222 @@
+import { fetchOrgIssues, type OrgIssue } from "./mcp/tools/issues";
+
+// Same allowlist as github-api.ts. We do not import ALLOWED_ORGS from there
+// because it isn't exported; if that list grows the two should be kept in sync.
+const ORGS = ["ippoan", "ohishi-exp"];
+
+export async function handleIssuesPage(env: { GITHUB_TOKEN: string }): Promise<Response> {
+  let data;
+  try {
+    data = await fetchOrgIssues(env.GITHUB_TOKEN, {
+      orgs: ORGS,
+      state: "open",
+      per_page: 100,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return new Response(renderError(msg), {
+      status: 502,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  }
+
+  const grouped = new Map<string, OrgIssue[]>();
+  for (const item of data.items) {
+    if (!grouped.has(item.repo)) grouped.set(item.repo, []);
+    grouped.get(item.repo)!.push(item);
+  }
+  // Sort repos alphabetically and issues by `updated_at` desc within each repo
+  // so the page is deterministic even when GitHub's order shifts.
+  const repos = [...grouped.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([repo, items]) => [
+      repo,
+      [...items].sort((a, b) => b.updated_at.localeCompare(a.updated_at)),
+    ] as const);
+
+  return new Response(renderHtml(data.total_count, data.incomplete, repos), {
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+function renderHtml(
+  total: number,
+  incomplete: boolean,
+  repos: ReadonlyArray<readonly [string, OrgIssue[]]>,
+): string {
+  const repoSections = repos
+    .map(([repo, items]) => renderRepoSection(repo, items))
+    .join("\n");
+
+  const incompleteBanner = incomplete
+    ? `<div class="banner">⚠️ Result was truncated by GitHub search. Showing ${total} issues but more may exist.</div>`
+    : "";
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Open Issues — CI Dashboard</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #0d1117;
+      color: #c9d1d9;
+      padding: 24px;
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+    header { margin-bottom: 24px; }
+    header .nav { font-size: 13px; margin-bottom: 8px; }
+    header .nav a { color: #58a6ff; text-decoration: none; }
+    header .nav a:hover { text-decoration: underline; }
+    h1 { font-size: 20px; color: #58a6ff; }
+    .summary { font-size: 13px; color: #8b949e; margin-top: 4px; }
+    .banner {
+      background: #341a1f;
+      border: 1px solid #f85149;
+      color: #ffa198;
+      border-radius: 6px;
+      padding: 10px 14px;
+      font-size: 13px;
+      margin-bottom: 16px;
+    }
+    section.repo {
+      background: #161b22;
+      border: 1px solid #30363d;
+      border-radius: 8px;
+      margin-bottom: 16px;
+      overflow: hidden;
+    }
+    section.repo h2 {
+      font-size: 14px;
+      font-weight: 600;
+      padding: 10px 14px;
+      background: #1f2630;
+      border-bottom: 1px solid #30363d;
+    }
+    section.repo h2 .count {
+      color: #8b949e;
+      font-weight: 400;
+      margin-left: 6px;
+    }
+    section.repo h2 a { color: #c9d1d9; text-decoration: none; }
+    section.repo h2 a:hover { color: #58a6ff; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+    tbody tr { border-top: 1px solid #21262d; }
+    tbody tr:hover { background: #1c2129; }
+    th, td {
+      padding: 8px 14px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: #8b949e;
+      background: #0d1117;
+    }
+    td.num { width: 60px; color: #8b949e; font-variant-numeric: tabular-nums; }
+    td.num a { color: #58a6ff; text-decoration: none; }
+    td.num a:hover { text-decoration: underline; }
+    td.title a { color: #c9d1d9; text-decoration: none; font-weight: 500; }
+    td.title a:hover { color: #58a6ff; text-decoration: underline; }
+    td.author { width: 130px; color: #8b949e; }
+    td.updated {
+      width: 110px;
+      color: #8b949e;
+      font-variant-numeric: tabular-nums;
+      white-space: nowrap;
+    }
+    .labels { margin-top: 4px; }
+    .label {
+      display: inline-block;
+      font-size: 11px;
+      padding: 1px 6px;
+      border-radius: 10px;
+      background: #1f6feb22;
+      color: #79c0ff;
+      margin-right: 4px;
+      margin-bottom: 2px;
+    }
+    .empty {
+      padding: 32px;
+      text-align: center;
+      color: #8b949e;
+      font-size: 14px;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="nav"><a href="/">← CI Dashboard</a></div>
+    <h1>📋 Open Issues</h1>
+    <div class="summary">
+      ${escapeHtml(String(total))} issue${total === 1 ? "" : "s"} across
+      ${escapeHtml(String(repos.length))} repo${repos.length === 1 ? "" : "s"}
+      (orgs: ${ORGS.map((o) => escapeHtml(o)).join(", ")})
+    </div>
+  </header>
+  ${incompleteBanner}
+  ${repos.length === 0
+    ? `<div class="empty">🎉 No open issues. Nice work.</div>`
+    : repoSections}
+</body>
+</html>`;
+}
+
+function renderRepoSection(repo: string, items: OrgIssue[]): string {
+  const rows = items.map((i) => renderRow(i)).join("\n");
+  const repoUrl = `https://github.com/${repo}/issues`;
+  return `<section class="repo">
+  <h2><a href="${escapeHtml(repoUrl)}" target="_blank" rel="noopener">${escapeHtml(repo)}</a><span class="count">(${items.length})</span></h2>
+  <table>
+    <thead><tr><th>#</th><th>Title</th><th>Author</th><th>Updated</th></tr></thead>
+    <tbody>${rows}</tbody>
+  </table>
+</section>`;
+}
+
+function renderRow(i: OrgIssue): string {
+  const labelChips = i.labels.length > 0
+    ? `<div class="labels">${i.labels.map((l) =>
+        `<span class="label">${escapeHtml(l)}</span>`).join("")}</div>`
+    : "";
+  return `<tr>
+    <td class="num"><a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">#${i.number}</a></td>
+    <td class="title"><a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">${escapeHtml(i.title)}</a>${labelChips}</td>
+    <td class="author">@${escapeHtml(i.author)}</td>
+    <td class="updated">${escapeHtml(i.updated_at.slice(0, 10))}</td>
+  </tr>`;
+}
+
+function renderError(msg: string): string {
+  return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><title>Open Issues — Error</title>
+<style>body { font-family: sans-serif; background: #0d1117; color: #c9d1d9; padding: 24px; }
+.err { background: #341a1f; border: 1px solid #f85149; color: #ffa198;
+       padding: 12px 16px; border-radius: 6px; max-width: 720px; }</style>
+</head><body>
+<h1>📋 Open Issues</h1>
+<div class="err">Failed to fetch issues: ${escapeHtml(msg)}</div>
+<p style="margin-top: 12px;"><a href="/" style="color:#58a6ff">← CI Dashboard</a></p>
+</body></html>`;
+}
+
+// Minimal HTML entity escape. Covers attribute and text contexts.
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/src/mcp/tools/issues.ts
+++ b/src/mcp/tools/issues.ts
@@ -287,46 +287,90 @@ export function registerIssuesTools(server: McpServer, token: string): void {
       annotations: { readOnlyHint: true },
     },
     async ({ orgs, state, labels, assignee, query, per_page }) => {
-      for (const o of orgs) validateOrg(o);
-
-      const parts: string[] = ["is:issue"];
-      if (state !== "all") parts.push(`state:${state}`);
-      for (const o of orgs) parts.push(`org:${o}`);
-      if (labels) for (const l of labels) parts.push(`label:"${l}"`);
-      if (assignee) parts.push(`assignee:${assignee}`);
-      if (query) parts.push(query);
-      const q = parts.join(" ");
-
-      const data = await githubApi<SearchIssuesResponse>(
-        token, "GET", "/search/issues", undefined,
-        { q, per_page: String(per_page) },
-      );
-
-      const items = data.items
-        .filter((i) => !i.pull_request)
-        .map((i) => ({
-          repo: i.repository_url.split("/").slice(-2).join("/"),
-          number: i.number,
-          title: i.title,
-          state: i.state,
-          author: i.user?.login ?? "",
-          labels: i.labels.map((l) => l.name),
-          assignees: (i.assignees ?? []).map((a) => a.login),
-          comments: i.comments,
-          created_at: i.created_at,
-          updated_at: i.updated_at,
-          url: i.html_url,
-        }));
-
-      const result = {
-        total_count: data.total_count,
-        incomplete: data.incomplete_results,
-        items,
-      };
-
+      const result = await fetchOrgIssues(token, {
+        orgs, state, labels, assignee, query, per_page,
+      });
       return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
     },
   );
+}
+
+// --------------------------------------------------------------------------
+// Shared: org-wide issue search (used by `list_org_issues` MCP tool and by
+// the SSR `/issues` page in src/issues-page.ts)
+// --------------------------------------------------------------------------
+
+export interface OrgIssue {
+  repo: string;
+  number: number;
+  title: string;
+  state: string;
+  author: string;
+  labels: string[];
+  assignees: string[];
+  comments: number;
+  created_at: string;
+  updated_at: string;
+  url: string;
+}
+
+export interface FetchOrgIssuesParams {
+  orgs: string[];
+  state?: "open" | "closed" | "all";
+  labels?: string[];
+  assignee?: string;
+  query?: string;
+  per_page?: number;
+}
+
+export interface FetchOrgIssuesResult {
+  total_count: number;
+  incomplete: boolean;
+  items: OrgIssue[];
+}
+
+export async function fetchOrgIssues(
+  token: string,
+  params: FetchOrgIssuesParams,
+): Promise<FetchOrgIssuesResult> {
+  const { orgs, state = "open", labels, assignee, query, per_page = 30 } = params;
+
+  for (const o of orgs) validateOrg(o);
+
+  const parts: string[] = ["is:issue"];
+  if (state !== "all") parts.push(`state:${state}`);
+  for (const o of orgs) parts.push(`org:${o}`);
+  if (labels) for (const l of labels) parts.push(`label:"${l}"`);
+  if (assignee) parts.push(`assignee:${assignee}`);
+  if (query) parts.push(query);
+  const q = parts.join(" ");
+
+  const data = await githubApi<SearchIssuesResponse>(
+    token, "GET", "/search/issues", undefined,
+    { q, per_page: String(per_page) },
+  );
+
+  const items = data.items
+    .filter((i) => !i.pull_request)
+    .map((i) => ({
+      repo: i.repository_url.split("/").slice(-2).join("/"),
+      number: i.number,
+      title: i.title,
+      state: i.state,
+      author: i.user?.login ?? "",
+      labels: i.labels.map((l) => l.name),
+      assignees: (i.assignees ?? []).map((a) => a.login),
+      comments: i.comments,
+      created_at: i.created_at,
+      updated_at: i.updated_at,
+      url: i.html_url,
+    }));
+
+  return {
+    total_count: data.total_count,
+    incomplete: data.incomplete_results,
+    items,
+  };
 }
 
 interface SearchIssuesResponse {

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -1,0 +1,185 @@
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import worker from "../src/index";
+import type { Env } from "../src/index";
+import { escapeHtml } from "../src/issues-page";
+
+function testEnv(): Env {
+  return {
+    CI_STATUS: env.CI_STATUS,
+    WEBHOOK_SECRET: "test-secret",
+    GITHUB_TOKEN: "test-token",
+    CI_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
+  };
+}
+
+// Stub a /search/issues response with two issues across two repos and one PR
+// that must be filtered out. Includes a hostile title to verify escaping.
+function stubSearchIssues() {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
+    const url = typeof req === "string" ? req : (req as Request).url;
+    if (!url.includes("/search/issues")) {
+      return new Response("not stubbed: " + url, { status: 500 });
+    }
+    return Response.json({
+      total_count: 3,
+      incomplete_results: false,
+      items: [
+        {
+          number: 7,
+          title: "<script>alert('xss')</script> & ok",
+          state: "open",
+          user: { login: "yhonda-ohishi" },
+          labels: [{ name: "bug" }, { name: "needs-triage" }],
+          assignees: [],
+          comments: 0,
+          created_at: "2026-05-10T00:00:00Z",
+          updated_at: "2026-05-10T03:00:00Z",
+          html_url: "https://github.com/ippoan/rust-alc-api/issues/7",
+          repository_url: "https://api.github.com/repos/ippoan/rust-alc-api",
+        },
+        {
+          number: 3,
+          title: "Add feature X",
+          state: "open",
+          user: { login: "yhonda-ohishi" },
+          labels: [],
+          assignees: [{ login: "yhonda-ohishi" }],
+          comments: 2,
+          created_at: "2026-05-09T00:00:00Z",
+          updated_at: "2026-05-09T05:00:00Z",
+          html_url: "https://github.com/ohishi-exp/daiun-salary/issues/3",
+          repository_url: "https://api.github.com/repos/ohishi-exp/daiun-salary",
+        },
+        {
+          number: 99,
+          title: "This is a PR, must be excluded",
+          state: "open",
+          user: { login: "yhonda-ohishi" },
+          labels: [],
+          assignees: [],
+          comments: 0,
+          created_at: "2026-05-08T00:00:00Z",
+          updated_at: "2026-05-08T00:00:00Z",
+          html_url: "https://github.com/ippoan/rust-alc-api/pull/99",
+          repository_url: "https://api.github.com/repos/ippoan/rust-alc-api",
+          pull_request: { url: "https://api.github.com/..." },
+        },
+      ],
+    });
+  });
+}
+
+describe("GET /issues", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("renders an HTML page with repo-grouped tables", async () => {
+    stubSearchIssues();
+    const req = new Request("http://localhost/issues");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/html; charset=utf-8");
+
+    const html = await res.text();
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html).toContain("Open Issues");
+    // Both repos rendered as separate <section>
+    expect(html).toContain("ippoan/rust-alc-api");
+    expect(html).toContain("ohishi-exp/daiun-salary");
+    // Both <section class="repo"> blocks must be present (= 2)
+    const sectionCount = (html.match(/<section class="repo">/g) ?? []).length;
+    expect(sectionCount).toBe(2);
+    // Issue numbers + dates
+    expect(html).toContain("#7");
+    expect(html).toContain("#3");
+    expect(html).toContain("2026-05-10");
+    // PR is filtered out
+    expect(html).not.toContain("#99");
+    expect(html).not.toContain("must be excluded");
+    // Labels rendered as chips
+    expect(html).toContain(">bug<");
+    expect(html).toContain(">needs-triage<");
+    // Back link to /
+    expect(html).toContain('href="/"');
+  });
+
+  it("escapes HTML in issue titles (XSS guard)", async () => {
+    stubSearchIssues();
+    const req = new Request("http://localhost/issues");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    const html = await res.text();
+    // Raw <script> must not appear in the body
+    expect(html).not.toContain("<script>alert('xss')</script>");
+    // Escaped form must appear
+    expect(html).toContain("&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;");
+    expect(html).toContain("&amp;");
+  });
+
+  it("queries GitHub Search with the expected org filter and state=open", async () => {
+    const spy = stubSearchIssues();
+    const req = new Request("http://localhost/issues");
+    const ctx = createExecutionContext();
+    await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const url = spy.mock.calls[0]![0] as string;
+    expect(url).toContain("/search/issues");
+    // q param contains is:issue, state:open, both orgs
+    const decoded = decodeURIComponent(url);
+    expect(decoded).toContain("is:issue");
+    expect(decoded).toContain("state:open");
+    expect(decoded).toContain("org:ippoan");
+    expect(decoded).toContain("org:ohishi-exp");
+    expect(url).toContain("per_page=100");
+  });
+
+  it("returns a friendly error page when GitHub API fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("rate limited", { status: 403 }),
+    );
+    const req = new Request("http://localhost/issues");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(502);
+    expect(res.headers.get("Content-Type")).toBe("text/html; charset=utf-8");
+    const html = await res.text();
+    expect(html).toContain("Failed to fetch issues");
+    expect(html).toContain("← CI Dashboard");
+  });
+
+  it("renders an empty-state message when no issues match", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({ total_count: 0, incomplete_results: false, items: [] }),
+    );
+    const req = new Request("http://localhost/issues");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("No open issues");
+    expect((html.match(/<section class="repo">/g) ?? []).length).toBe(0);
+  });
+});
+
+describe("escapeHtml()", () => {
+  it("escapes the five HTML special characters", () => {
+    expect(escapeHtml(`<a href="x" & 'b'>`)).toBe(
+      "&lt;a href=&quot;x&quot; &amp; &#39;b&#39;&gt;",
+    );
+  });
+
+  it("is a no-op for plain text", () => {
+    expect(escapeHtml("plain text 123")).toBe("plain text 123");
+  });
+});


### PR DESCRIPTION
## Summary

`mcp__ci-dashboard__list_org_issues` MCP tool は Claude からは叩けるが、ブラウザから見る手段がなかった。新規 `GET /issues` ページを追加して `/check-issue` 出力相当を SSR で表示する。

## Changes

- **src/mcp/tools/issues.ts**: `list_org_issues` ハンドラ内のクエリ生成 + fetch + マッピングロジックを `fetchOrgIssues(token, params)` として export。MCP tool 経由と SSR ページ経由で同一コードパス
- **src/issues-page.ts** (新規): `handleIssuesPage(env)` SSR ハンドラ。ippoan + ohishi-exp org の open issue を取って repo 別に `<section><table>` で描画。エラー時は 502 + 案内 HTML、空時は "No open issues" バナー。`escapeHtml()` で title/label/author/URL を全エスケープ (XSS 対策)
- **src/index.ts**: `app.get("/issues", ...)` 1 行追加
- **src/dashboard.ts**: `<h1>CI Dashboard</h1>` 横に `📋 Open Issues →` リンクを追加 (既存テスト互換)
- **test/issues-page.test.ts** (新規, 7 cases):
  - SSR HTML が repo 別 `<section>` 2 個生成し、PR が除外されることを確認
  - `<script>alert('xss')</script>` 入りタイトルがエスケープされることを確認
  - GitHub Search クエリに `is:issue`, `state:open`, `org:ippoan`, `org:ohishi-exp`, `per_page=100` が含まれることを確認
  - GitHub API 失敗時に 502 + "Failed to fetch issues" を返すことを確認
  - 0 件時に空状態メッセージを返すことを確認
  - `escapeHtml()` 単体テスト

## Verification

```
npm run typecheck   # clean
npm test            # 75 passed (9 files) — 既存 68 + 新規 7
```

merge → CI 自動デプロイ後に <https://ci-dashboard.ippoan.org/issues> をブラウザで開いて表示確認。

## Out of scope (明示)

- フィルタ UI (state / label / assignee)
- close / label 追加等の write 操作
- WebSocket リアルタイム更新
- 認証 (既存 dashboard と同様に非認証 + ALLOWED_ORGS 制限のみ)