### PR TITLE
docs: branch ↔ issue 紐付け規約と PR テンプレートを追加

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## 概要
+
+<!-- この PR で何を / なぜ変えるかを 1-3 行で -->
+
+## 関連 issue
+
+<!--
+  必ず `Refs #N` 形式で記入する。`Closes` / `Fixes` / `Resolves` は使用禁止
+  (PR auto-merge 時に issue が自動 close されると release 時の close 確認 UI
+  と整合しないため)。release tag 後にダッシュボード経由で目視 close する。
+-->
+
+Refs #
+
+## 変更点
+
+-
+
+## 動作確認
+
+- [ ] `npm test`
+- [ ] `npm run typecheck`
+- [ ] 手動確認 (該当する場合は手順を記載)
+
+## メモ
+
+<!-- レビュー時に注目してほしい点、保留事項など -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# CLAUDE.md
+
+Claude Code 向けの本リポジトリ作業ルール。
+
+## Worktree / branch 命名規則
+
+形式: `<issue-number>-<type>-<short-description>`
+
+- `issue-number`: 必須。先に issue を立ててから worktree / branch を作る
+- `type`: `feat` | `fix` | `refactor` | `infra`
+- `short-description`: 半角小文字英数字とハイフン
+
+例:
+
+- `123-fix-onedrive-token`
+- `145-feat-line-works-webhook`
+- `156-refactor-pdf-generator`
+
+issue 番号を持たない branch (Claude Code が自動採番する `claude/...` 等)
+で実装に入る前に、対応する issue を作成し、上記の形式で rename / 再切り出し
+すること。
+
+## PR description / commit message のキーワード
+
+- 使用禁止: `Closes #N` / `Fixes #N` / `Resolves #N`
+  - PR auto-merge が走った瞬間に issue が自動 close されるため、release 時の
+    close 確認 UI と整合しない
+- 使用推奨: `Refs #N` / `Related to #N` / `Part of #N`
+  - GitHub の Development セクションには紐付くが auto-close されない
+  - release tag 後に [ci-dashboard の close 確認 UI 構想] で目視 close する
+
+PR テンプレートは `.github/pull_request_template.md` で `Refs` を強制する。
+
+## release / close フロー
+
+1. PR は `Refs #N` のみで merge する (auto-close させない)
+2. release tag は workflow_dispatch (`tag-release.yml`) で発行
+3. ci-dashboard 上の release 確認画面で、tag に含まれる commit から
+   `Refs #N` を逆引きし、close 候補として一覧表示
+4. 目視確認後、ci-dashboard MCP server (`close_issue` tool) で close する
+
+## 関連
+
+- 規約: yhonda-ohishi/claude-skills の対応 issue (本 PR 後に作成)
+- 実装: yhonda-ohishi/claude-hooks の PreToolUse hook (本 PR 後に作成)
+- 詳細: [`docs/branch-issue-linking.md`](docs/branch-issue-linking.md)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ wrangler secret put GITHUB_TOKEN
 
 `repo` / `workflow` スコープが必要 (issue 書込・PR マージ・workflow dispatch のため)。
 
+## 開発ルール
+
+- branch / worktree 命名: [`CLAUDE.md`](CLAUDE.md)
+- PR description / commit message のキーワード規約と release 時の close
+  フロー: [`docs/branch-issue-linking.md`](docs/branch-issue-linking.md)
+- PR テンプレート: [`.github/pull_request_template.md`](.github/pull_request_template.md)
+
 ## ツール追加手順
 
 1. `src/mcp/tools/<category>.ts` の `registerXxxTools` 関数内に `server.registerTool(...)` を追加

--- a/docs/branch-issue-linking.md
+++ b/docs/branch-issue-linking.md
@@ -1,0 +1,123 @@
+# branch ↔ issue 紐付け規約
+
+worktree / branch と GitHub issue を機械的に紐付け、PR auto-merge による
+意図しない issue auto-close を防ぐための運用規則。
+
+## 背景
+
+- 既存の `feat-/fix-/refactor-/infra-` 命名規則には issue 番号がなく、
+  branch から対応 issue を機械的に逆引きできない
+- `Closes #N` / `Fixes #N` / `Resolves #N` を使うと PR auto-merge で
+  issue が自動 close される。release tag 発行は workflow_dispatch で
+  非同期に行うため、merge 時 close と release タイミングが噛み合わない
+- ci-dashboard 側で release ごとに「この tag に含まれる close 候補」を
+  目視確認してから close するフローを実現したい
+
+## 規約
+
+### 1. branch 命名
+
+形式: `<issue-number>-<type>-<short-description>`
+
+- `type`: `feat` | `fix` | `refactor` | `infra`
+- `issue-number`: 必須。先に issue を立てる
+- 正規表現: `^[0-9]+-(feat|fix|refactor|infra)-[a-z0-9-]+$`
+
+### 2. 連携キーワード
+
+| キーワード                        | 用途                       | auto-close |
+| --------------------------------- | -------------------------- | ---------- |
+| `Closes` / `Fixes` / `Resolves`   | **禁止**                   | する       |
+| `Refs` / `Related to` / `Part of` | 推奨。Development に紐付く | しない     |
+
+### 3. PR テンプレート
+
+`.github/pull_request_template.md` で `Refs #` を雛形に入れて強制する。
+
+### 4. release / close
+
+1. PR merge: `Refs #N` のみで auto-close させない
+2. tag 発行: `tag-release.yml` (workflow_dispatch)
+3. ci-dashboard の release 確認画面で tag に含まれる commit から
+   `Refs #N` を抽出し close 候補として一覧表示
+4. 目視確認 → `close_issue` MCP tool で明示 close
+
+## 機械的に守らせる仕組み
+
+### ローカル (Claude Code hook)
+
+`yhonda-ohishi/claude-hooks` の PreToolUse hook が `git worktree add` /
+`git checkout -b` / `git switch -c` をフックし、branch 名の正規表現一致と
+issue 番号の実在を検証する (詳細は claude-hooks の対応 issue 参照)。
+
+### サーバサイド (GitHub Actions)
+
+ローカル hook はバイパス可能なため、各プロジェクトに以下のような workflow
+を併設する:
+
+```yaml
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: validate branch name
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          if [[ ! "$BRANCH" =~ ^[0-9]+-(feat|fix|refactor|infra)-[a-z0-9-]+$ ]]; then
+            echo "::error::Branch name '$BRANCH' violates policy"
+            exit 1
+          fi
+```
+
+PR description 側の禁止キーワード検出も同 workflow に追加できる:
+
+```bash
+if grep -Ei '(closes|fixes|resolves)[[:space:]]+#[0-9]+' <<< "$PR_BODY"; then
+  echo "::error::Use 'Refs #N' instead of Closes/Fixes/Resolves"
+  exit 1
+fi
+```
+
+## 既存プロジェクトへの移行手順
+
+1. `.github/pull_request_template.md` を本リポジトリの内容で配置
+2. `CLAUDE.md` (or 既存 CLAUDE.md の更新) に worktree 命名規則を追記
+3. 走行中の branch は無理に rename せず、新規 branch から本規則を適用
+4. CHANGELOG 生成を行っているリポジトリでは `Refs` を拾う設定に変更
+   (例は次節)
+
+## CHANGELOG 生成設定の例
+
+### git-cliff (`cliff.toml`)
+
+```toml
+[git]
+commit_parsers = [
+  { message = "^feat",     group = "Features" },
+  { message = "^fix",      group = "Fixes" },
+  { message = "^refactor", group = "Refactor" },
+  { message = "^infra",    group = "Infra" },
+]
+# body 中の "Refs #N" / "Related to #N" / "Part of #N" を link 化
+link_parsers = [
+  { pattern = "Refs #(\\d+)",       href = "https://github.com/$REPO/issues/$1" },
+  { pattern = "Related to #(\\d+)", href = "https://github.com/$REPO/issues/$1" },
+  { pattern = "Part of #(\\d+)",    href = "https://github.com/$REPO/issues/$1" },
+]
+```
+
+### release-please
+
+`release-please` 自体は `Closes` / `Fixes` を強制しない。`Refs #N` は
+そのまま CHANGELOG に転記されるため、設定変更なしで運用可能。
+release-please による自動 close を抑止したい場合は `release-as` PR の
+body から auto-close キーワードが入らないテンプレートを使う。
+
+## 関連
+
+- 実装: `yhonda-ohishi/claude-hooks` の対応 issue (作業4 で作成)
+- 規約 (本ドキュメントの origin): `yhonda-ohishi/claude-skills` の対応 issue
+  (作業3 で作成)


### PR DESCRIPTION
## 概要

worktree / branch と GitHub issue を機械的に紐付け、PR auto-merge による
意図しない issue auto-close を防ぐための運用規則を、本リポジトリにドッグ
フード適用する。

## 関連 issue

Refs (yhonda-ohishi/claude-skills と yhonda-ohishi/claude-hooks 側の issue は
本 PR merge 後に作成。番号は後追いで本 PR description に追記する)

## 変更点

- `CLAUDE.md`: worktree/branch 命名 (`<issue-number>-<type>-<desc>`) と
  `Refs` キーワード規約を明文化
- `.github/pull_request_template.md`: `Refs #` を雛形に組み込み、
  `Closes`/`Fixes`/`Resolves` を使わない運用を強制
- `docs/branch-issue-linking.md`: 背景・移行手順・CHANGELOG 設定例
  (git-cliff / release-please) を含む詳細仕様
- `README.md`: 上記ドキュメントへのリンクを「開発ルール」節として追加

## 背景

- `Closes #N` 系のキーワードを PR description に書くと auto-merge 時点で
  issue が自動 close される
- 一方、release tag は `tag-release.yml` の workflow_dispatch で別タイミング
  で発行するため、ci-dashboard で release ごとの close 候補を目視確認して
  から close する UI 構想と整合しない
- branch 名に issue 番号が含まれていれば commit ↔ issue の逆引きが機械化
  でき、後段の自動化 (release 時 close 候補抽出、PR description 自動生成)
  の前提が揃う

## 動作確認

- [x] 既存コードへの影響なし (docs のみ)
- [ ] `npm run typecheck` (CI で自動実行)
- [ ] `npm test` (CI で自動実行)

## メモ

- 本 PR merge 後、`yhonda-ohishi/claude-skills` に規約 issue、
  `yhonda-ohishi/claude-hooks` に実装 issue を作成し、本 PR description の
  `Refs` を実番号で更新する予定
- ローカル hook はバイパス可能なため、各プロジェクトへサーバサイド検証
  workflow を併設する (本ドキュメント内に YAML サンプルあり)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8sMFHPBFYVJqqitvEdL5d)_