### PR TITLE
infra: allow yhonda-ohishi org in MCP API

### DIFF
--- a/src/github-api.ts
+++ b/src/github-api.ts
@@ -1,5 +1,5 @@
 const GITHUB_API = "https://api.github.com";
-const ALLOWED_ORGS = ["ippoan", "ohishi-exp"];
+const ALLOWED_ORGS = ["ippoan", "ohishi-exp", "yhonda-ohishi"];
 const DEFAULT_ORG = "ippoan";
 
 export function parseRepo(repo: string): { owner: string; repo: string } {

--- a/test/mcp/tools.test.ts
+++ b/test/mcp/tools.test.ts
@@ -61,6 +61,19 @@ describe("Actions tool logic", () => {
     );
     expect(data.workflow_runs).toHaveLength(0);
   });
+
+  it("supports yhonda-ohishi org", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({ workflow_runs: [] }),
+    );
+
+    const { owner, repo } = parseRepo("yhonda-ohishi/claude-skills");
+    validateOrg(owner);
+    const data = await githubApi<{ workflow_runs: unknown[] }>(
+      "token", "GET", `/repos/${owner}/${repo}/actions/runs`,
+    );
+    expect(data.workflow_runs).toHaveLength(0);
+  });
 });
 
 describe("PR tool logic", () => {


### PR DESCRIPTION
## 概要

`src/github-api.ts` の `ALLOWED_ORGS` に `yhonda-ohishi` を追加。
ci-dashboard の MCP server から `yhonda-ohishi/claude-skills` と
`yhonda-ohishi/claude-hooks` の issue を操作できるようにする。

## 関連 issue

Refs #31, Part of #30

## 変更点

- `src/github-api.ts`: `ALLOWED_ORGS` に `"yhonda-ohishi"` を追加
- `test/mcp/tools.test.ts`: `validateOrg("yhonda-ohishi")` の正の経路テストを追加

## 動作確認

- [x] `npm run typecheck` 通過
- [x] `npm test` 26 件すべて通過 (新規 yhonda-ohishi org テスト含む)
- [ ] deploy 後、`yhonda-ohishi/*` への tool 呼び出しが `403 Org not allowed`
      で拒否されないことを確認

## メモ

- #30 で策定した branch ↔ issue 紐付け規約の最初の実適用ケース。
  branch 名 `31-infra-allow-yhonda-ohishi-org` は新ルール
  `<issue-number>-<type>-<short-description>` 準拠。
- 本 PR merge & deploy 後、`yhonda-ohishi/claude-skills` と
  `yhonda-ohishi/claude-hooks` への issue 作成 (元タスクの作業3〜5) を
  ci-dashboard MCP 経由で実行できるようになる。
- `src/issues-page.ts` の `ORGS` (cross-org 一覧表示用) は本 PR では
  変更しない。一覧表示への追加は別 issue でスコープを切る。

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8sMFHPBFYVJqqitvEdL5d)_