### PR TITLE
feat(issues-page): include yhonda-ohishi/claude-skills + claude-hooks

### DIFF
--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -1,17 +1,35 @@
 import { fetchOrgIssues, type OrgIssue } from "./mcp/tools/issues";
 
-// Same allowlist as github-api.ts. We do not import ALLOWED_ORGS from there
-// because it isn't exported; if that list grows the two should be kept in sync.
+// Orgs fetched in full. Same allowlist as github-api.ts (not imported because
+// ALLOWED_ORGS isn't exported; keep the two in sync if either grows).
 const ORGS = ["ippoan", "ohishi-exp"];
 
+// yhonda-ohishi org has many old personal repos (2023-2024 lineworks_bot /
+// nginx / authjs-nuxt-test etc.) that would create noise. Only surface the
+// active claude-tooling repos by filtering on `repo:` qualifiers.
+const YHONDA_REPOS = ["yhonda-ohishi/claude-skills", "yhonda-ohishi/claude-hooks"];
+
 export async function handleIssuesPage(env: { GITHUB_TOKEN: string }): Promise<Response> {
-  let data;
+  let merged;
   try {
-    data = await fetchOrgIssues(env.GITHUB_TOKEN, {
-      orgs: ORGS,
-      state: "open",
-      per_page: 100,
-    });
+    const [main, yhonda] = await Promise.all([
+      fetchOrgIssues(env.GITHUB_TOKEN, {
+        orgs: ORGS,
+        state: "open",
+        per_page: 100,
+      }),
+      fetchOrgIssues(env.GITHUB_TOKEN, {
+        orgs: ["yhonda-ohishi"],
+        state: "open",
+        per_page: 100,
+        query: YHONDA_REPOS.map((r) => `repo:${r}`).join(" "),
+      }),
+    ]);
+    merged = {
+      total_count: main.total_count + yhonda.total_count,
+      incomplete: main.incomplete || yhonda.incomplete,
+      items: [...main.items, ...yhonda.items],
+    };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return new Response(renderError(msg), {
@@ -21,7 +39,7 @@ export async function handleIssuesPage(env: { GITHUB_TOKEN: string }): Promise<R
   }
 
   const grouped = new Map<string, OrgIssue[]>();
-  for (const item of data.items) {
+  for (const item of merged.items) {
     if (!grouped.has(item.repo)) grouped.set(item.repo, []);
     grouped.get(item.repo)!.push(item);
   }
@@ -34,7 +52,7 @@ export async function handleIssuesPage(env: { GITHUB_TOKEN: string }): Promise<R
       [...items].sort((a, b) => b.updated_at.localeCompare(a.updated_at)),
     ] as const);
 
-  return new Response(renderHtml(data.total_count, data.incomplete, repos), {
+  return new Response(renderHtml(merged.total_count, merged.incomplete, repos), {
     headers: { "Content-Type": "text/html; charset=utf-8" },
   });
 }
@@ -162,7 +180,8 @@ function renderHtml(
     <div class="summary">
       ${escapeHtml(String(total))} issue${total === 1 ? "" : "s"} across
       ${escapeHtml(String(repos.length))} repo${repos.length === 1 ? "" : "s"}
-      (orgs: ${ORGS.map((o) => escapeHtml(o)).join(", ")})
+      (orgs: ${ORGS.map((o) => escapeHtml(o)).join(", ")}
+      + ${YHONDA_REPOS.map((r) => escapeHtml(r)).join(", ")})
     </div>
   </header>
   ${incompleteBanner}

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -13,13 +13,37 @@ function testEnv(): Env {
   };
 }
 
-// Stub a /search/issues response with two issues across two repos and one PR
-// that must be filtered out. Includes a hostile title to verify escaping.
+// Stub /search/issues. The handler fires two queries (main orgs + yhonda repo
+// filter) so we branch on the `q` param to return different items per call.
+// Main response covers two repos and a PR that must be filtered out; yhonda
+// response covers one claude-skills issue. A hostile title verifies escaping.
 function stubSearchIssues() {
   return vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
     const url = typeof req === "string" ? req : (req as Request).url;
     if (!url.includes("/search/issues")) {
       return new Response("not stubbed: " + url, { status: 500 });
+    }
+    const decoded = decodeURIComponent(url);
+    if (decoded.includes("repo:yhonda-ohishi/claude-skills")) {
+      return Response.json({
+        total_count: 1,
+        incomplete_results: false,
+        items: [
+          {
+            number: 1,
+            title: "claude-skills issue",
+            state: "open",
+            user: { login: "yhonda-ohishi" },
+            labels: [],
+            assignees: [],
+            comments: 0,
+            created_at: "2026-05-12T00:00:00Z",
+            updated_at: "2026-05-12T00:00:00Z",
+            html_url: "https://github.com/yhonda-ohishi/claude-skills/issues/1",
+            repository_url: "https://api.github.com/repos/yhonda-ohishi/claude-skills",
+          },
+        ],
+      });
     }
     return Response.json({
       total_count: 3,
@@ -86,12 +110,13 @@ describe("GET /issues", () => {
     const html = await res.text();
     expect(html).toContain("<!DOCTYPE html>");
     expect(html).toContain("Open Issues");
-    // Both repos rendered as separate <section>
+    // All three repos rendered as separate <section>: 2 from main call +
+    // 1 from yhonda-ohishi claude-skills call (merged via Promise.all).
     expect(html).toContain("ippoan/rust-alc-api");
     expect(html).toContain("ohishi-exp/daiun-salary");
-    // Both <section class="repo"> blocks must be present (= 2)
+    expect(html).toContain("yhonda-ohishi/claude-skills");
     const sectionCount = (html.match(/<section class="repo">/g) ?? []).length;
-    expect(sectionCount).toBe(2);
+    expect(sectionCount).toBe(3);
     // Issue numbers + dates
     expect(html).toContain("#7");
     expect(html).toContain("#3");
@@ -121,23 +146,36 @@ describe("GET /issues", () => {
     expect(html).toContain("&amp;");
   });
 
-  it("queries GitHub Search with the expected org filter and state=open", async () => {
+  it("queries GitHub Search twice: main orgs and yhonda-ohishi/claude-* repo filter", async () => {
     const spy = stubSearchIssues();
     const req = new Request("http://localhost/issues");
     const ctx = createExecutionContext();
     await worker.fetch(req, testEnv(), ctx);
     await waitOnExecutionContext(ctx);
 
-    expect(spy).toHaveBeenCalledTimes(1);
-    const url = spy.mock.calls[0]![0] as string;
-    expect(url).toContain("/search/issues");
-    // q param contains is:issue, state:open, both orgs
-    const decoded = decodeURIComponent(url);
-    expect(decoded).toContain("is:issue");
-    expect(decoded).toContain("state:open");
-    expect(decoded).toContain("org:ippoan");
-    expect(decoded).toContain("org:ohishi-exp");
-    expect(url).toContain("per_page=100");
+    expect(spy).toHaveBeenCalledTimes(2);
+    const urls = spy.mock.calls.map((c) => c[0] as string);
+    const decoded = urls.map((u) => decodeURIComponent(u));
+
+    // Main call: ippoan + ohishi-exp orgs without a repo: qualifier.
+    const main = decoded.find((d) => d.includes("org:ippoan"));
+    expect(main).toBeDefined();
+    expect(main!).toContain("is:issue");
+    expect(main!).toContain("state:open");
+    expect(main!).toContain("org:ippoan");
+    expect(main!).toContain("org:ohishi-exp");
+    expect(main!).not.toContain("repo:yhonda-ohishi/claude-");
+
+    // yhonda-ohishi call: org:yhonda-ohishi + repo: qualifiers (OR) for the
+    // two active claude tooling repos only.
+    const yhonda = decoded.find((d) => d.includes("org:yhonda-ohishi"));
+    expect(yhonda).toBeDefined();
+    expect(yhonda!).toContain("is:issue");
+    expect(yhonda!).toContain("state:open");
+    expect(yhonda!).toContain("repo:yhonda-ohishi/claude-skills");
+    expect(yhonda!).toContain("repo:yhonda-ohishi/claude-hooks");
+
+    for (const u of urls) expect(u).toContain("per_page=100");
   });
 
   it("returns a friendly error page when GitHub API fails", async () => {
@@ -157,7 +195,9 @@ describe("GET /issues", () => {
   });
 
   it("renders an empty-state message when no issues match", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    // Use mockImplementation, not mockResolvedValue: handleIssuesPage fires two
+    // fetches in parallel and a single Response instance has a one-shot body.
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
       Response.json({ total_count: 0, incomplete_results: false, items: [] }),
     );
     const req = new Request("http://localhost/issues");


### PR DESCRIPTION
## Summary

`/issues` の cross-org 一覧に `yhonda-ohishi/claude-skills` と `yhonda-ohishi/claude-hooks` を追加。

## Why

- yhonda-ohishi org は MCP allow-list 済み (PR #32) だが、SSR `/issues` のデフォルト orgs (`["ippoan", "ohishi-exp"]`) に入っておらず claude-* repo の issue が見えなかった
- yhonda-ohishi org 全体を入れると 2023-2024 年の作りかけ個人 repo (lineworks_bot / nginx / authjs-nuxt-test 等、open issue 18 件中 14 件) がノイズになる
- 解: claude-skills と claude-hooks の 2 repo だけ `repo:` qualifier で絞った 2 個目の fetch を並列発火 → items / total_count を merge

## What changed

### `src/issues-page.ts`
- `YHONDA_REPOS = ["yhonda-ohishi/claude-skills", "yhonda-ohishi/claude-hooks"]` 追加
- `handleIssuesPage` で `Promise.all` で 2 並列 fetch + merge
- header summary に `+ yhonda-ohishi/claude-skills, yhonda-ohishi/claude-hooks` 表示
- 既存 `fetchOrgIssues` の `query` param をそのまま利用（バックエンド改造なし）

### `test/issues-page.test.ts`
- stub が `q` param 分岐で yhonda 呼び出しに claude-skills #1 を返すように
- section count 期待値: 2 → 3
- 単一 fetch assertion → 2 fetch + qualifier 分離 assertion に置換
- empty-state stub を `mockImplementation` 化 (Response の body は one-shot)

## Verification

- `npm test -- test/issues-page.test.ts` ローカルで 7/7 pass

## Notes

- check-issue skill (`~/.claude/skills/check-issue/SKILL.md`) は別途 plan-mode 前に更新済み (個人 global file なので本 PR には含まれない)
- `src/github-api.ts` の `ALLOWED_ORGS` は PR #32 で yhonda-ohishi 追加済み
- `fetchOrgIssues` (src/mcp/tools/issues.ts) は `query` 引数を以前から受け付けているので、MCP tool 側で同じ手順を踏めばクライアントから同等の絞り込み可能

Refs #36
Refs #32