### PR TITLE
feat(releases): add release confirmation UI MVP

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import { cors } from "hono/cors";
 import { handleWebhook } from "./webhook";
 import { handleDashboard } from "./dashboard";
 import { handleIssuesPage } from "./issues-page";
+import { handleReleasesPage } from "./releases-page";
+import { handleReleaseClose } from "./release-close";
 import { handleRecheck } from "./recheck";
 import { handleTagRelease } from "./tag-release";
 import { handleMcpRequest } from "./mcp/server";
@@ -30,6 +32,11 @@ app.get("/", () => handleDashboard());
 
 // Open issues (SSR, cross-org)
 app.get("/issues", (c) => handleIssuesPage(c.env));
+
+// Release confirmation view (SSR + POST close action)
+// See issue #35 + CLAUDE.md `release / close フロー`.
+app.get("/releases", (c) => handleReleasesPage(c.req.raw, c.env));
+app.post("/api/release-close", (c) => handleReleaseClose(c.req.raw, c.env));
 
 // WebSocket
 app.get("/ws", (c) => getHub(c.env).fetch(c.req.raw));

--- a/src/release-close.ts
+++ b/src/release-close.ts
@@ -1,0 +1,85 @@
+import { githubApi, parseRepo, validateOrg } from "./github-api";
+
+// POST /api/release-close
+// Receives the form submitted from /releases?repo=...&tag=... and closes the
+// selected issues. For each issue we (1) drop a "Closed by release <tag>"
+// comment so the audit trail lives on the issue itself, (2) PATCH the issue
+// to closed/state_reason=completed (mirrors the close_issue MCP tool's
+// payload at src/mcp/tools/issues.ts).
+//
+// Auth: relies on Cloudflare Access in front of ci-dashboard (same trust
+// model as GET /releases). Server-side auth here would just double-gate the
+// same identity.
+
+export async function handleReleaseClose(
+  req: Request,
+  env: { GITHUB_TOKEN: string },
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+
+  const form = await req.formData();
+  const repoParam = String(form.get("repo") ?? "").trim();
+  const tag = String(form.get("tag") ?? "").trim();
+  const issueNumbers = form
+    .getAll("issue")
+    .map((v) => Number(v))
+    .filter((n) => Number.isInteger(n) && n > 0);
+
+  if (!repoParam || !tag) {
+    return new Response("Missing repo or tag", { status: 400 });
+  }
+
+  // No selections: send the user back without spamming GitHub.
+  if (issueNumbers.length === 0) {
+    return redirect(`/releases?repo=${encodeURIComponent(repoParam)}&tag=${encodeURIComponent(tag)}`);
+  }
+
+  let owner: string, name: string;
+  try {
+    ({ owner, repo: name } = parseRepo(repoParam));
+    validateOrg(owner);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return new Response(`Bad repo: ${msg}`, { status: 400 });
+  }
+
+  // Close in parallel; per-issue failures don't sink the whole batch. The
+  // result lists are surfaced as flash params on the redirect target.
+  const settled = await Promise.allSettled(
+    issueNumbers.map(async (n) => {
+      await githubApi(
+        env.GITHUB_TOKEN, "POST",
+        `/repos/${owner}/${name}/issues/${n}/comments`,
+        { body: `Closed by release ${tag}` },
+      );
+      await githubApi(
+        env.GITHUB_TOKEN, "PATCH",
+        `/repos/${owner}/${name}/issues/${n}`,
+        { state: "closed", state_reason: "completed" },
+      );
+      return n;
+    }),
+  );
+
+  const closed: number[] = [];
+  const failed: number[] = [];
+  settled.forEach((r, i) => {
+    if (r.status === "fulfilled") closed.push(r.value);
+    else failed.push(issueNumbers[i]!);
+  });
+
+  const params = new URLSearchParams({ repo: repoParam, tag });
+  if (closed.length > 0) params.set("closed", closed.join(","));
+  if (failed.length > 0) params.set("failed", failed.join(","));
+  return redirect(`/releases?${params.toString()}`);
+}
+
+function redirect(location: string): Response {
+  // 303 See Other so the browser swaps POST → GET on the redirect target.
+  return new Response(null, {
+    status: 303,
+    headers: { Location: location },
+  });
+}

--- a/src/release-helpers.ts
+++ b/src/release-helpers.ts
@@ -1,0 +1,85 @@
+// Pure helpers for the release confirmation view. Kept fetch-free so they can
+// be unit-tested without stubbing GitHub. The SSR page in `releases-page.ts`
+// composes these against githubApi() results.
+
+// `Refs #N` / `Related to #N` / `Part of #N` (case-insensitive). The Refs-style
+// convention is documented in CLAUDE.md as the auto-close-safe replacement for
+// `Closes #N` / `Fixes #N`.
+const REF_PATTERN = /(?:Refs|Related to|Part of)\s+#(\d+)/gi;
+
+export function extractRefIssues(text: string): number[] {
+  if (!text) return [];
+  const out = new Set<number>();
+  for (const m of text.matchAll(REF_PATTERN)) out.add(Number(m[1]));
+  return [...out];
+}
+
+// Squash-merge commits land on main with their PR number trailing the subject,
+// e.g. "feat(x): do thing (#42)". Pull that out so we can re-fetch the PR for
+// its `head.ref` (branch name) and body, which carry additional Refs and the
+// branch-prefixed issue number.
+export function extractPrNumber(commitMessage: string): number | null {
+  if (!commitMessage) return null;
+  const firstLine = commitMessage.split("\n", 1)[0]!;
+  const m = firstLine.match(/\(#(\d+)\)\s*$/);
+  return m ? Number(m[1]) : null;
+}
+
+// Branch convention is `<issue>-<type>-<desc>` (project CLAUDE.md). Pull the
+// leading number off so a release that merged `42-fix-x` is recognized as
+// touching issue #42 even if no Refs trailer exists.
+export function extractBranchIssue(branchName: string): number | null {
+  if (!branchName) return null;
+  const m = branchName.match(/^(\d+)-/);
+  return m ? Number(m[1]) : null;
+}
+
+// Sort semver-shaped tags ("v1.2.3" or "1.2.3") in descending order. Tags that
+// don't match the shape fall to the bottom in alphabetical order — they may be
+// release candidates or hand-rolled labels and we don't want them shadowing a
+// real previous release when we pick "the tag before this one".
+export function sortSemverDesc(tags: readonly string[]): string[] {
+  return [...tags].sort(compareTagsDesc);
+}
+
+const SEMVER_RE = /^v?(\d+)\.(\d+)\.(\d+)/;
+
+function compareTagsDesc(a: string, b: string): number {
+  const ma = a.match(SEMVER_RE);
+  const mb = b.match(SEMVER_RE);
+  if (!ma && !mb) return a.localeCompare(b);
+  if (!ma) return 1;
+  if (!mb) return -1;
+  for (let i = 1; i <= 3; i++) {
+    const d = Number(mb[i]) - Number(ma[i]);
+    if (d !== 0) return d;
+  }
+  return 0;
+}
+
+// Given tags already sorted descending, return the tag immediately *older*
+// than `current`. Returns null when `current` is the oldest (or absent).
+export function previousTag(tagsDescending: readonly string[], current: string): string | null {
+  const idx = tagsDescending.indexOf(current);
+  if (idx < 0 || idx === tagsDescending.length - 1) return null;
+  return tagsDescending[idx + 1] ?? null;
+}
+
+// Warning flags drive whether a candidate row's checkbox defaults to OFF.
+// The list is intentionally narrow for the MVP — comment-after-merge and
+// reaction-based heuristics need extra API calls and can come later.
+export interface IssueLike {
+  state: string;
+  labels: ReadonlyArray<string>;
+}
+
+const WARN_LABELS = new Set(["bug", "regression"]);
+
+export function computeWarnings(issue: IssueLike): string[] {
+  const out: string[] = [];
+  if (issue.state === "closed") out.push("already closed");
+  for (const l of issue.labels) {
+    if (WARN_LABELS.has(l.toLowerCase())) out.push(`${l} label`);
+  }
+  return out;
+}

--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -1,0 +1,418 @@
+import { githubApi, parseRepo, validateOrg, GitHubApiError } from "./github-api";
+import {
+  extractRefIssues,
+  extractPrNumber,
+  extractBranchIssue,
+  sortSemverDesc,
+  previousTag,
+  computeWarnings,
+} from "./release-helpers";
+
+// `/releases?repo=owner/name&tag=vX.Y.Z` renders the release confirmation
+// view: every issue touched by commits in this tag's range, with a checkbox
+// per row so the operator can close them in one POST after eyeballing the
+// list. See issue #35 and CLAUDE.md (Refs convention, manual-close flow).
+//
+// We do NOT persist anything yet — the page recomputes from GitHub each load.
+// Persistence + dashboard "unconfirmed release" badge are deferred to a later
+// PR (issue #35 calls those out as recommended but not required for MVP).
+
+export async function handleReleasesPage(
+  req: Request,
+  env: { GITHUB_TOKEN: string },
+): Promise<Response> {
+  const url = new URL(req.url);
+  const repoParam = url.searchParams.get("repo");
+  const tag = url.searchParams.get("tag");
+
+  // Flash params populated by POST /api/release-close redirect.
+  const closedFlash = numericList(url.searchParams.get("closed"));
+  const failedFlash = numericList(url.searchParams.get("failed"));
+
+  if (!repoParam || !tag) {
+    return html(renderForm(repoParam, tag), 200);
+  }
+
+  let result: ReleasePayload;
+  try {
+    result = await loadRelease(env.GITHUB_TOKEN, repoParam, tag);
+  } catch (err) {
+    if (err instanceof GitHubApiError && err.status === 404) {
+      return html(renderError(`Not found: ${err.message}`), 404);
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    return html(renderError(msg), 502);
+  }
+
+  return html(renderHtml(result, closedFlash, failedFlash), 200);
+}
+
+// --------------------------------------------------------------------------
+// Data loader
+// --------------------------------------------------------------------------
+
+interface ReleasePayload {
+  repo: string;        // "owner/name"
+  tag: string;
+  previousTag: string | null;
+  commits: number;     // count, for the summary line
+  rows: IssueRow[];
+}
+
+interface IssueRow {
+  number: number;
+  title: string;
+  state: string;
+  labels: string[];
+  assignees: string[];
+  url: string;
+  updated_at: string;
+  warnings: string[];
+}
+
+async function loadRelease(
+  token: string,
+  repoParam: string,
+  tag: string,
+): Promise<ReleasePayload> {
+  const { owner, repo: name } = parseRepo(repoParam);
+  validateOrg(owner);
+
+  // 1. Pull recent tags so we can pick the immediate predecessor for the
+  //    compare endpoint. 30 is plenty given typical release cadence; for
+  //    older tags the operator can pass the URL anyway and we fall back to a
+  //    bounded commit list below.
+  const tags = await githubApi<TagListItem[]>(
+    token, "GET", `/repos/${owner}/${name}/tags`, undefined,
+    { per_page: "30" },
+  );
+  const tagNames = tags.map((t) => t.name);
+  if (!tagNames.includes(tag)) {
+    throw new GitHubApiError(
+      404,
+      `Tag "${tag}" not present in ${owner}/${name} (recent ${tagNames.length} tags scanned)`,
+    );
+  }
+  const prev = previousTag(sortSemverDesc(tagNames), tag);
+
+  // 2. Get the commits introduced by this tag. With a previous tag we use
+  //    GitHub's compare endpoint (it stops at the merge base); without one
+  //    (first release ever) we bound to 50 commits walking back from `tag`.
+  const commits = prev
+    ? (await githubApi<CompareResponse>(
+        token, "GET", `/repos/${owner}/${name}/compare/${prev}...${tag}`,
+      )).commits
+    : await githubApi<RawCommit[]>(
+        token, "GET", `/repos/${owner}/${name}/commits`, undefined,
+        { sha: tag, per_page: "50" },
+      );
+
+  // 3. Harvest issue numbers from commit messages directly, and collect the
+  //    PR numbers so we can do a second pass for branch-name + PR-body refs.
+  const issueNumbers = new Set<number>();
+  const prNumbers = new Set<number>();
+  for (const c of commits) {
+    const msg = c.commit.message;
+    for (const n of extractRefIssues(msg)) issueNumbers.add(n);
+    const pr = extractPrNumber(msg);
+    if (pr !== null) prNumbers.add(pr);
+  }
+
+  // 4. Re-fetch each PR for its head.ref (branch name) and body. We swallow
+  //    per-PR failures so a missing/deleted PR doesn't sink the whole page.
+  await Promise.all([...prNumbers].map(async (n) => {
+    try {
+      const pr = await githubApi<PrResponse>(
+        token, "GET", `/repos/${owner}/${name}/pulls/${n}`,
+      );
+      const fromBranch = extractBranchIssue(pr.head.ref);
+      if (fromBranch !== null) issueNumbers.add(fromBranch);
+      if (pr.body) {
+        for (const ref of extractRefIssues(pr.body)) issueNumbers.add(ref);
+      }
+    } catch { /* ignore per-PR failure */ }
+  }));
+
+  // 5. Fetch each candidate issue. The /issues/:n endpoint also returns PRs,
+  //    so we filter those out (PRs have a `pull_request` discriminator).
+  const issueResults = await Promise.all([...issueNumbers].map(async (n) => {
+    try {
+      return await githubApi<RawIssue>(
+        token, "GET", `/repos/${owner}/${name}/issues/${n}`,
+      );
+    } catch {
+      return null;
+    }
+  }));
+
+  const rows: IssueRow[] = issueResults
+    .filter((i): i is RawIssue => i !== null && !i.pull_request)
+    .map((i) => {
+      const labels = i.labels.map((l) => l.name);
+      return {
+        number: i.number,
+        title: i.title,
+        state: i.state,
+        labels,
+        assignees: i.assignees.map((a) => a.login),
+        url: i.html_url,
+        updated_at: i.updated_at,
+        warnings: computeWarnings({ state: i.state, labels }),
+      };
+    })
+    .sort((a, b) => a.number - b.number);
+
+  return {
+    repo: `${owner}/${name}`,
+    tag,
+    previousTag: prev,
+    commits: commits.length,
+    rows,
+  };
+}
+
+interface TagListItem { name: string; commit: { sha: string } }
+interface RawCommit { sha: string; commit: { message: string } }
+interface CompareResponse { commits: RawCommit[] }
+interface PrResponse { head: { ref: string }; body: string | null }
+interface RawIssue {
+  number: number;
+  title: string;
+  state: string;
+  labels: Array<{ name: string }>;
+  assignees: Array<{ login: string }>;
+  html_url: string;
+  updated_at: string;
+  pull_request?: unknown;
+}
+
+function numericList(s: string | null): number[] {
+  if (!s) return [];
+  return s.split(",").map((p) => Number(p.trim())).filter(Number.isInteger);
+}
+
+// --------------------------------------------------------------------------
+// HTML
+// --------------------------------------------------------------------------
+
+function html(body: string, status: number): Response {
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+function renderHtml(
+  data: ReleasePayload,
+  closedFlash: number[],
+  failedFlash: number[],
+): string {
+  const candidateRows = data.rows
+    .filter((r) => !closedFlash.includes(r.number))
+    .map((r) => renderRow(r))
+    .join("\n");
+
+  const flash = renderFlash(closedFlash, failedFlash, data.repo);
+
+  const summary =
+    `${escapeHtml(data.repo)} · <code>${escapeHtml(data.tag)}</code>` +
+    (data.previousTag
+      ? ` (since <code>${escapeHtml(data.previousTag)}</code>, ${data.commits} commits)`
+      : ` (first release; last ${data.commits} commits scanned)`);
+
+  const empty = data.rows.length === 0
+    ? `<div class="empty">🎉 No referenced issues for this release.</div>`
+    : "";
+
+  const formInner = data.rows.length === 0 ? "" : `
+    <form method="POST" action="/api/release-close" class="close-form">
+      <input type="hidden" name="repo" value="${escapeHtml(data.repo)}">
+      <input type="hidden" name="tag" value="${escapeHtml(data.tag)}">
+      <table>
+        <thead><tr>
+          <th class="col-check"></th>
+          <th>#</th>
+          <th>Title</th>
+          <th>State</th>
+          <th>Labels</th>
+          <th>Assignees</th>
+        </tr></thead>
+        <tbody>${candidateRows}</tbody>
+      </table>
+      <div class="actions">
+        <button type="submit">✅ Close selected as released</button>
+        <span class="hint">Rows with ⚠️ are unchecked by default. Untick to skip.</span>
+      </div>
+    </form>`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Release ${escapeHtml(data.tag)} — ${escapeHtml(data.repo)}</title>
+  <style>${STYLES}</style>
+</head>
+<body>
+  <header>
+    <div class="nav"><a href="/">← CI Dashboard</a> · <a href="/issues">📋 Open Issues</a></div>
+    <h1>🏷️ Release confirmation</h1>
+    <div class="summary">${summary}</div>
+  </header>
+  ${flash}
+  ${empty}
+  ${formInner}
+</body>
+</html>`;
+}
+
+function renderRow(r: IssueRow): string {
+  const hasWarn = r.warnings.length > 0;
+  const checked = hasWarn ? "" : " checked";
+  const warnIcon = hasWarn
+    ? `<span class="warn" title="${escapeHtml(r.warnings.join(", "))}">⚠️</span>`
+    : "";
+  const labelChips = r.labels.length > 0
+    ? `<div class="labels">${r.labels
+        .map((l) => `<span class="label">${escapeHtml(l)}</span>`).join("")}</div>`
+    : "";
+  const assignees = r.assignees.length > 0
+    ? r.assignees.map((a) => `@${escapeHtml(a)}`).join(", ")
+    : "—";
+  const stateChip =
+    `<span class="state state-${escapeHtml(r.state)}">${escapeHtml(r.state)}</span>`;
+
+  return `<tr>
+    <td class="col-check"><input type="checkbox" name="issue" value="${r.number}"${checked}></td>
+    <td class="num"><a href="${escapeHtml(r.url)}" target="_blank" rel="noopener">#${r.number}</a></td>
+    <td class="title">${warnIcon}<a href="${escapeHtml(r.url)}" target="_blank" rel="noopener">${escapeHtml(r.title)}</a></td>
+    <td>${stateChip}</td>
+    <td>${labelChips || "—"}</td>
+    <td class="assignees">${assignees}</td>
+  </tr>`;
+}
+
+function renderFlash(
+  closed: number[],
+  failed: number[],
+  repo: string,
+): string {
+  if (closed.length === 0 && failed.length === 0) return "";
+  const closedList = closed.length > 0
+    ? `<div class="flash ok">✅ Closed: ${closed
+        .map((n) => `<a href="https://github.com/${escapeHtml(repo)}/issues/${n}" target="_blank" rel="noopener">#${n}</a>`)
+        .join(" ")}</div>`
+    : "";
+  const failedList = failed.length > 0
+    ? `<div class="flash err">❌ Failed to close: ${failed
+        .map((n) => `<a href="https://github.com/${escapeHtml(repo)}/issues/${n}" target="_blank" rel="noopener">#${n}</a>`)
+        .join(" ")} (try again)</div>`
+    : "";
+  return closedList + failedList;
+}
+
+function renderForm(repo: string | null, tag: string | null): string {
+  return `<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Release confirmation</title><style>${STYLES}</style>
+</head><body>
+<header>
+  <div class="nav"><a href="/">← CI Dashboard</a> · <a href="/issues">📋 Open Issues</a></div>
+  <h1>🏷️ Release confirmation</h1>
+  <div class="summary">Enter a release tag to review the issues it touched.</div>
+</header>
+<form method="GET" action="/releases" class="lookup">
+  <label>repo (<code>owner/name</code>)
+    <input name="repo" required placeholder="ippoan/ci-dashboard"
+      value="${escapeHtml(repo ?? "")}">
+  </label>
+  <label>tag
+    <input name="tag" required placeholder="v1.2.3"
+      value="${escapeHtml(tag ?? "")}">
+  </label>
+  <button type="submit">Look up</button>
+</form>
+</body></html>`;
+}
+
+function renderError(msg: string): string {
+  return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><title>Release confirmation — Error</title>
+<style>${STYLES}</style></head><body>
+<header><div class="nav"><a href="/">← CI Dashboard</a></div>
+<h1>🏷️ Release confirmation</h1></header>
+<div class="flash err">${escapeHtml(msg)}</div>
+</body></html>`;
+}
+
+// Style block kept inline so the page is self-contained, mirroring
+// issues-page.ts. Mobile is the operations target (CLAUDE.md notes the
+// Android-first context) so we keep widths fluid and avoid fixed pixel cols.
+const STYLES = `
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    background: #0d1117; color: #c9d1d9; padding: 24px;
+    max-width: 1200px; margin: 0 auto;
+  }
+  header { margin-bottom: 16px; }
+  header .nav { font-size: 13px; margin-bottom: 8px; }
+  header .nav a { color: #58a6ff; text-decoration: none; }
+  header .nav a:hover { text-decoration: underline; }
+  h1 { font-size: 20px; color: #58a6ff; }
+  .summary { font-size: 13px; color: #8b949e; margin-top: 4px; }
+  .summary code { background: #161b22; padding: 1px 6px; border-radius: 4px; color: #d2a8ff; }
+  .lookup {
+    display: flex; flex-wrap: wrap; gap: 12px; align-items: end;
+    background: #161b22; border: 1px solid #30363d;
+    padding: 16px; border-radius: 8px; margin-top: 12px;
+  }
+  .lookup label { display: flex; flex-direction: column; gap: 4px; font-size: 12px; color: #8b949e; }
+  .lookup input { background: #0d1117; color: #c9d1d9; border: 1px solid #30363d;
+    border-radius: 6px; padding: 6px 10px; font-size: 14px; min-width: 220px; }
+  button { background: #238636; color: white; border: 0; border-radius: 6px;
+    padding: 8px 14px; font-size: 13px; font-weight: 600; cursor: pointer; }
+  button:hover { background: #2ea043; }
+  .close-form { background: #161b22; border: 1px solid #30363d;
+    border-radius: 8px; overflow: hidden; margin-top: 8px; }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  tbody tr { border-top: 1px solid #21262d; }
+  tbody tr:hover { background: #1c2129; }
+  th, td { padding: 8px 12px; text-align: left; vertical-align: top; }
+  th { font-size: 11px; font-weight: 600; text-transform: uppercase;
+       letter-spacing: 0.5px; color: #8b949e; background: #0d1117; }
+  td.col-check, th.col-check { width: 36px; }
+  td.num { width: 60px; color: #8b949e; font-variant-numeric: tabular-nums; }
+  td.num a { color: #58a6ff; text-decoration: none; }
+  td.title a { color: #c9d1d9; text-decoration: none; font-weight: 500; }
+  td.title a:hover { color: #58a6ff; text-decoration: underline; }
+  td.assignees { color: #8b949e; }
+  .warn { margin-right: 4px; }
+  .labels .label { display: inline-block; font-size: 11px; padding: 1px 6px;
+    border-radius: 10px; background: #1f6feb22; color: #79c0ff;
+    margin-right: 4px; margin-bottom: 2px; }
+  .state { display: inline-block; font-size: 11px; padding: 1px 8px;
+    border-radius: 10px; font-weight: 600; }
+  .state-open { background: #238636; color: white; }
+  .state-closed { background: #8957e5; color: white; }
+  .actions { padding: 12px 14px; border-top: 1px solid #21262d;
+    display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+  .actions .hint { color: #8b949e; font-size: 12px; }
+  .empty { padding: 32px; text-align: center; color: #8b949e; font-size: 14px; }
+  .flash { padding: 10px 14px; border-radius: 6px; font-size: 13px;
+    margin-bottom: 12px; }
+  .flash.ok  { background: #1f3d28; border: 1px solid #238636; color: #a3e3b0; }
+  .flash.err { background: #341a1f; border: 1px solid #f85149; color: #ffa198; }
+  .flash a { color: inherit; text-decoration: underline; }
+`;
+
+// Minimal HTML escape, exported for tests.
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/test/release-close.test.ts
+++ b/test/release-close.test.ts
@@ -1,0 +1,167 @@
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import worker from "../src/index";
+import type { Env } from "../src/index";
+
+function testEnv(): Env {
+  return {
+    CI_STATUS: env.CI_STATUS,
+    WEBHOOK_SECRET: "test-secret",
+    GITHUB_TOKEN: "test-token",
+    CI_HUB: {
+      idFromName: () => ({}),
+      get: () => ({ fetch: async () => new Response("OK") }),
+    } as unknown as DurableObjectNamespace,
+  };
+}
+
+interface RecordedCall {
+  url: string;
+  method: string;
+  body: unknown;
+}
+
+function stubCloseFlow(opts: { failIssue?: number } = {}) {
+  const calls: RecordedCall[] = [];
+  const spy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    const method = init?.method ?? (input instanceof Request ? input.method : "GET");
+    let body: unknown = init?.body;
+    if (typeof body === "string") {
+      try { body = JSON.parse(body); } catch { /* keep string */ }
+    }
+    calls.push({ url, method, body });
+
+    // Per-issue failure injection: any GitHub API touching the failing issue
+    // returns 500 so the issue ends up in the `failed` flash list.
+    if (opts.failIssue && url.includes(`/issues/${opts.failIssue}`)) {
+      return new Response("boom", { status: 500 });
+    }
+    if (url.includes("/comments")) {
+      return Response.json({ id: 1 });
+    }
+    return Response.json({ number: 1, state: "closed", state_reason: "completed", html_url: "" });
+  });
+  return { spy, calls };
+}
+
+function formBody(pairs: Array<[string, string]>): string {
+  const params = new URLSearchParams();
+  for (const [k, v] of pairs) params.append(k, v);
+  return params.toString();
+}
+
+describe("POST /api/release-close", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("closes selected issues and redirects with the closed flash", async () => {
+    const { calls } = stubCloseFlow();
+    const req = new Request("http://localhost/api/release-close", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formBody([
+        ["repo", "ippoan/ci-dashboard"],
+        ["tag", "v1.2.0"],
+        ["issue", "12"],
+        ["issue", "34"],
+      ]),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(303);
+    const location = res.headers.get("Location") ?? "";
+    expect(location).toMatch(/^\/releases\?/);
+    expect(location).toContain("repo=ippoan%2Fci-dashboard");
+    expect(location).toContain("tag=v1.2.0");
+    expect(location).toMatch(/closed=12(?:%2C|,)34/);
+    expect(location).not.toContain("failed=");
+
+    // 2 issues × (POST comment + PATCH issue) = 4 GitHub calls.
+    expect(calls.length).toBe(4);
+    const postComments = calls.filter((c) => c.method === "POST" && c.url.includes("/comments"));
+    const patchIssues = calls.filter((c) => c.method === "PATCH" && /\/issues\/\d+$/.test(c.url));
+    expect(postComments.length).toBe(2);
+    expect(patchIssues.length).toBe(2);
+
+    // Comment body carries the release tag.
+    expect((postComments[0]!.body as { body: string }).body).toBe("Closed by release v1.2.0");
+    // PATCH payload uses state_reason=completed.
+    expect(patchIssues[0]!.body).toMatchObject({ state: "closed", state_reason: "completed" });
+  });
+
+  it("partitions partial failures into closed= + failed= flash params", async () => {
+    const { calls } = stubCloseFlow({ failIssue: 34 });
+    const req = new Request("http://localhost/api/release-close", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formBody([
+        ["repo", "ippoan/ci-dashboard"],
+        ["tag", "v1.2.0"],
+        ["issue", "12"],
+        ["issue", "34"],
+      ]),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(303);
+    const location = res.headers.get("Location") ?? "";
+    expect(location).toContain("closed=12");
+    expect(location).toContain("failed=34");
+    // Some GitHub API traffic still happened, but the failed issue short-circuits its PATCH.
+    expect(calls.length).toBeGreaterThan(0);
+  });
+
+  it("redirects without touching GitHub when no issues are selected", async () => {
+    const { calls } = stubCloseFlow();
+    const req = new Request("http://localhost/api/release-close", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formBody([
+        ["repo", "ippoan/ci-dashboard"],
+        ["tag", "v1.2.0"],
+      ]),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(303);
+    expect(calls.length).toBe(0);
+    expect(res.headers.get("Location")).toContain("/releases?repo=");
+  });
+
+  it("400s when repo or tag is missing", async () => {
+    const req = new Request("http://localhost/api/release-close", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formBody([["issue", "12"]]),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("400s on a disallowed org", async () => {
+    const req = new Request("http://localhost/api/release-close", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formBody([
+        ["repo", "evil-org/x"],
+        ["tag", "v1"],
+        ["issue", "1"],
+      ]),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(400);
+    expect(await res.text()).toContain("Org not allowed");
+  });
+});

--- a/test/release-helpers.test.ts
+++ b/test/release-helpers.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractRefIssues,
+  extractPrNumber,
+  extractBranchIssue,
+  sortSemverDesc,
+  previousTag,
+  computeWarnings,
+} from "../src/release-helpers";
+
+describe("extractRefIssues", () => {
+  it("picks Refs / Related to / Part of (case-insensitive)", () => {
+    const msg = "Refs #12\nRelated to #34\nPart of #56\nrefs #78";
+    expect(extractRefIssues(msg).sort()).toEqual([12, 34, 56, 78]);
+  });
+
+  it("dedupes repeated numbers", () => {
+    expect(extractRefIssues("Refs #1 and Refs #1 again")).toEqual([1]);
+  });
+
+  it("ignores Closes / Fixes / Resolves (those would auto-close)", () => {
+    // CLAUDE.md forbids these keywords; the regex must not match them so the
+    // release confirmation flow stays the source of truth.
+    expect(extractRefIssues("Closes #5\nFixes #6\nResolves #7")).toEqual([]);
+  });
+
+  it("returns [] for empty / undefined-shaped input", () => {
+    expect(extractRefIssues("")).toEqual([]);
+    expect(extractRefIssues("no references here")).toEqual([]);
+  });
+});
+
+describe("extractPrNumber", () => {
+  it("pulls trailing (#NN) off a squash-merge subject", () => {
+    expect(extractPrNumber("feat(x): do thing (#42)")).toBe(42);
+  });
+
+  it("uses only the first line of multi-line messages", () => {
+    expect(extractPrNumber("subject (#9)\n\nbody mentions (#999)")).toBe(9);
+  });
+
+  it("returns null when no trailing (#N)", () => {
+    expect(extractPrNumber("plain subject")).toBeNull();
+    expect(extractPrNumber("see #42 inline")).toBeNull();
+  });
+});
+
+describe("extractBranchIssue", () => {
+  it("extracts the leading number from `<n>-<type>-<desc>`", () => {
+    expect(extractBranchIssue("35-feat-release-ui")).toBe(35);
+    expect(extractBranchIssue("123-fix-onedrive-token")).toBe(123);
+  });
+
+  it("returns null for branches without the prefix", () => {
+    expect(extractBranchIssue("feat/no-issue-number")).toBeNull();
+    expect(extractBranchIssue("main")).toBeNull();
+    expect(extractBranchIssue("")).toBeNull();
+  });
+});
+
+describe("sortSemverDesc", () => {
+  it("sorts proper semver tags in descending order", () => {
+    expect(sortSemverDesc(["v1.0.0", "v1.2.3", "v1.2.10", "v0.9.9"]))
+      .toEqual(["v1.2.10", "v1.2.3", "v1.0.0", "v0.9.9"]);
+  });
+
+  it("treats versions without the v prefix as semver too", () => {
+    expect(sortSemverDesc(["1.2.0", "v1.10.0"])).toEqual(["v1.10.0", "1.2.0"]);
+  });
+
+  it("pushes non-semver tags to the bottom", () => {
+    const out = sortSemverDesc(["v1.0.0", "release-candidate", "v0.9.0"]);
+    expect(out[0]).toBe("v1.0.0");
+    expect(out[1]).toBe("v0.9.0");
+    expect(out[2]).toBe("release-candidate");
+  });
+});
+
+describe("previousTag", () => {
+  it("returns the tag immediately older than `current`", () => {
+    expect(previousTag(["v1.2.0", "v1.1.0", "v1.0.0"], "v1.1.0")).toBe("v1.0.0");
+  });
+
+  it("returns null for the oldest tag (no predecessor)", () => {
+    expect(previousTag(["v1.2.0", "v1.1.0", "v1.0.0"], "v1.0.0")).toBeNull();
+  });
+
+  it("returns null when the tag is not in the list", () => {
+    expect(previousTag(["v1.2.0", "v1.0.0"], "v1.1.0")).toBeNull();
+  });
+});
+
+describe("computeWarnings", () => {
+  it("flags closed state", () => {
+    expect(computeWarnings({ state: "closed", labels: [] }))
+      .toContain("already closed");
+  });
+
+  it("flags bug / regression labels (case-insensitive)", () => {
+    expect(computeWarnings({ state: "open", labels: ["bug"] }))
+      .toContain("bug label");
+    expect(computeWarnings({ state: "open", labels: ["Regression"] }))
+      .toContain("Regression label");
+  });
+
+  it("returns [] for a clean open issue", () => {
+    expect(computeWarnings({ state: "open", labels: ["enhancement"] }))
+      .toEqual([]);
+  });
+
+  it("stacks warnings", () => {
+    const w = computeWarnings({ state: "closed", labels: ["bug", "regression"] });
+    expect(w.length).toBe(3);
+  });
+});

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -1,0 +1,216 @@
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import worker from "../src/index";
+import type { Env } from "../src/index";
+
+function testEnv(): Env {
+  return {
+    CI_STATUS: env.CI_STATUS,
+    WEBHOOK_SECRET: "test-secret",
+    GITHUB_TOKEN: "test-token",
+    CI_HUB: {
+      idFromName: () => ({}),
+      get: () => ({ fetch: async () => new Response("OK") }),
+    } as unknown as DurableObjectNamespace,
+  };
+}
+
+// URL-aware stub: branches on the GitHub API path so each step of the data
+// loader (tags → compare → pulls/:n → issues/:n) gets a tailored response.
+//
+// Test fixture covers:
+//   - 2 commits between v1.1.0..v1.2.0
+//     * commit A:  "feat(x): foo (#11)"   PR #11  branch `42-feat-foo`  body "Refs #99"
+//     * commit B:  "fix(y): bar\n\nRefs #50"   no trailing PR
+//   - resulting candidate issues: 42 (from branch), 50 (from Refs in B),
+//                                 99 (from PR body)
+//   - issue 42: open, no labels                    → no warnings, ON
+//   - issue 50: closed                              → "already closed" warn, OFF
+//   - issue 99: open, label "bug"                   → "bug label" warn, OFF
+function stubGithubApi(opts: { tagExists?: boolean; failPr?: boolean } = {}) {
+  const tagExists = opts.tagExists ?? true;
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
+    const url = typeof req === "string" ? req : (req as Request).url;
+
+    if (url.includes("/tags?")) {
+      return Response.json(tagExists ? [
+        { name: "v1.2.0", commit: { sha: "aaaaaaa" } },
+        { name: "v1.1.0", commit: { sha: "bbbbbbb" } },
+        { name: "v1.0.0", commit: { sha: "ccccccc" } },
+      ] : [
+        { name: "v9.9.9", commit: { sha: "zzzzzzz" } },
+      ]);
+    }
+
+    if (url.includes("/compare/v1.1.0...v1.2.0")) {
+      return Response.json({
+        commits: [
+          { sha: "aaa", commit: { message: "feat(x): foo (#11)" } },
+          { sha: "bbb", commit: { message: "fix(y): bar\n\nRefs #50" } },
+        ],
+      });
+    }
+
+    if (url.endsWith("/pulls/11")) {
+      if (opts.failPr) return new Response("boom", { status: 500 });
+      return Response.json({
+        head: { ref: "42-feat-foo" },
+        body: "summary\n\nRefs #99",
+      });
+    }
+
+    if (url.endsWith("/issues/42")) {
+      return Response.json({
+        number: 42, title: "open clean", state: "open",
+        labels: [], assignees: [],
+        html_url: "https://github.com/ippoan/ci-dashboard/issues/42",
+        updated_at: "2026-05-10T00:00:00Z",
+      });
+    }
+    if (url.endsWith("/issues/50")) {
+      return Response.json({
+        number: 50, title: "already done", state: "closed",
+        labels: [], assignees: [],
+        html_url: "https://github.com/ippoan/ci-dashboard/issues/50",
+        updated_at: "2026-05-09T00:00:00Z",
+      });
+    }
+    if (url.endsWith("/issues/99")) {
+      return Response.json({
+        number: 99, title: "<script>alert(1)</script> & bug",
+        state: "open",
+        labels: [{ name: "bug" }], assignees: [{ login: "yhonda-ohishi" }],
+        html_url: "https://github.com/ippoan/ci-dashboard/issues/99",
+        updated_at: "2026-05-11T00:00:00Z",
+      });
+    }
+
+    return new Response("not stubbed: " + url, { status: 500 });
+  });
+}
+
+describe("GET /releases", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("renders the lookup form when repo+tag are missing", async () => {
+    const req = new Request("http://localhost/releases");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Enter a release tag");
+    expect(html).toContain('<form method="GET" action="/releases"');
+    expect(html).toContain('name="repo"');
+    expect(html).toContain('name="tag"');
+  });
+
+  it("renders release candidates with merged ref sources", async () => {
+    stubGithubApi();
+    const req = new Request("http://localhost/releases?repo=ippoan/ci-dashboard&tag=v1.2.0");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // Summary line shows current + previous tag.
+    expect(html).toContain("ippoan/ci-dashboard");
+    expect(html).toContain("v1.2.0");
+    expect(html).toContain("v1.1.0");
+    expect(html).toContain("2 commits");
+
+    // All three issues end up in the table (branch / commit Refs / PR body Refs).
+    expect(html).toContain("#42");
+    expect(html).toContain("#50");
+    expect(html).toContain("#99");
+
+    // Title-level XSS is escaped.
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;");
+
+    // Form points at POST endpoint.
+    expect(html).toContain('action="/api/release-close"');
+  });
+
+  it("warning rows are NOT checked by default; clean rows ARE", async () => {
+    stubGithubApi();
+    const req = new Request("http://localhost/releases?repo=ippoan/ci-dashboard&tag=v1.2.0");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+    const html = await res.text();
+
+    // #42 has no warnings → checkbox starts checked.
+    expect(html).toMatch(/name="issue" value="42" checked/);
+    // #50 is closed, #99 has bug label → both start unchecked.
+    expect(html).toMatch(/name="issue" value="50"(?! checked)/);
+    expect(html).toMatch(/name="issue" value="99"(?! checked)/);
+
+    // Warning icon + tooltip present for warning rows.
+    expect(html).toContain("⚠️");
+    expect(html).toContain("already closed");
+    expect(html).toContain("bug label");
+  });
+
+  it("returns 404 when the tag is not in the recent list", async () => {
+    stubGithubApi({ tagExists: false });
+    const req = new Request("http://localhost/releases?repo=ippoan/ci-dashboard&tag=v1.2.0");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(404);
+    const html = await res.text();
+    expect(html).toContain("Not found");
+    expect(html).toContain("v1.2.0");
+  });
+
+  it("survives a 500 on a single PR fetch (no whole-page crash)", async () => {
+    stubGithubApi({ failPr: true });
+    const req = new Request("http://localhost/releases?repo=ippoan/ci-dashboard&tag=v1.2.0");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // #50 still pulled from commit B's Refs trailer — branch / body refs (#42, #99) are lost.
+    expect(html).toContain("#50");
+    expect(html).not.toContain("#42");
+    expect(html).not.toContain("#99");
+  });
+
+  it("hides rows already in the flash `closed` list and shows ok flash", async () => {
+    stubGithubApi();
+    const req = new Request(
+      "http://localhost/releases?repo=ippoan/ci-dashboard&tag=v1.2.0&closed=42,50",
+    );
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    const html = await res.text();
+    // Closed flash visible.
+    expect(html).toContain("Closed:");
+    // 42 and 50 should not appear as checkbox rows (still appear in flash links).
+    expect(html).not.toMatch(/name="issue" value="42"/);
+    expect(html).not.toMatch(/name="issue" value="50"/);
+    // 99 still in the candidate table.
+    expect(html).toMatch(/name="issue" value="99"/);
+  });
+
+  it("rejects an org outside the allow-list with 502", async () => {
+    // No fetch stub: validateOrg throws before any fetch. The page catches it
+    // as a generic upstream error and renders 502.
+    const req = new Request("http://localhost/releases?repo=evil-org/whatever&tag=v1");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(502);
+    const html = await res.text();
+    expect(html).toContain("evil-org");
+  });
+});


### PR DESCRIPTION
## Summary

Refs #35 の MVP: `Refs #N` で merge した issue を release tag 単位で一覧表示し、目視確認 + 一括 close できる SSR UI を追加。

## Endpoints

- `GET  /releases?repo=<owner>/<name>&tag=<tag>`  
  query 未指定なら lookup form、指定があれば候補一覧 + checkbox。
- `POST /api/release-close`  
  選択 issue に「Closed by release <tag>」コメント追加 → state=closed (state_reason=completed) → `/releases?...&closed=...&failed=...` に 303 redirect。

## 候補抽出ロジック

| ソース | 抽出方法 |
|---|---|
| commit message | `(?:Refs\|Related to\|Part of)\s+#(\d+)` (i, g) |
| squash-merge subject | `\(#(\d+)\)$` で PR 番号 → `/pulls/:n` を fetch |
| PR body | 同じ Refs regex |
| PR branch.ref | `^(\d+)-` |

`pull_request` discriminator で PR は除外。

## 警告フラグ (MVP)

- `state == "closed"` → 「already closed」
- `bug` / `regression` label → 「<label> label」  

警告ありの行は checkbox **OFF default**。

## 再利用 (既存資産)

- `src/github-api.ts` の `validateOrg` / `parseRepo` / `GitHubApiError` を直接呼ぶ
- `ALLOWED_ORGS = ["ippoan", "ohishi-exp", "yhonda-ohishi"]` を SSOT として尊重
- `src/issues-page.ts` の dark theme スタイルパターンを踏襲

## Phase 2 として残したもの (本 PR スコープ外)

- release レコードの DurableObject/KV 永続化
- release webhook (`release: published`) で自動記録
- dashboard top の「未確認 release」バッジ
- comment-after-merge / reaction `-1` の警告計算
- 100 件超のページング

## Verification

```bash
cd /home/yhonda/js/ci-dashboard
npm test
```

12 test files / 109 tests pass:

- `test/release-helpers.test.ts` 13 case (regex / sorting / warning フラグ)
- `test/releases-page.test.ts`   7 case (form / 候補 render / warning checkbox / 404 / per-PR 失敗 tolerance / flash / disallowed org)
- `test/release-close.test.ts`   5 case (POST happy / partial failure / no-selection / 400 / disallowed org)
- 既存 test 13 file は無変更で全 pass

## Auth

CLAUDE.md / セッション内合意のとおり CF Access 依存 (server 側追加認証なし)。CF Access で gate された identity と SSR 操作の identity が一致するため。

Refs #35