### PR TITLE
feat(nav): shared tab strip across dashboard / issues / releases

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,3 +1,5 @@
+import { renderTabs, TAB_STYLES } from "./nav-tabs";
+
 export function handleDashboard(): Response {
   const html = `<!DOCTYPE html>
 <html lang="en">
@@ -7,6 +9,7 @@ export function handleDashboard(): Response {
   <title>CI Dashboard</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
+    ${TAB_STYLES}
     body {
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace;
       background: #0d1117;
@@ -234,7 +237,8 @@ export function handleDashboard(): Response {
   </style>
 </head>
 <body>
-  <h1>CI Dashboard <a href="/issues" style="font-size:13px;font-weight:400;margin-left:12px;color:#58a6ff;text-decoration:none;">📋 Open Issues →</a></h1>
+  ${renderTabs("dashboard")}
+  <h1>CI Dashboard</h1>
   <div class="status-bar">
     WS: <span id="sse-status" class="disconnected">connecting...</span>
     &middot; Last update: <span id="last-update">-</span>

--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -1,4 +1,5 @@
 import { fetchOrgIssues, type OrgIssue } from "./mcp/tools/issues";
+import { renderTabs, TAB_STYLES } from "./nav-tabs";
 
 // Orgs fetched in full. Same allowlist as github-api.ts (not imported because
 // ALLOWED_ORGS isn't exported; keep the two in sync if either grows).
@@ -87,9 +88,7 @@ function renderHtml(
       margin: 0 auto;
     }
     header { margin-bottom: 24px; }
-    header .nav { font-size: 13px; margin-bottom: 8px; }
-    header .nav a { color: #58a6ff; text-decoration: none; }
-    header .nav a:hover { text-decoration: underline; }
+    ${TAB_STYLES}
     h1 { font-size: 20px; color: #58a6ff; }
     .summary { font-size: 13px; color: #8b949e; margin-top: 4px; }
     .banner {
@@ -175,7 +174,7 @@ function renderHtml(
 </head>
 <body>
   <header>
-    <div class="nav"><a href="/">← CI Dashboard</a></div>
+    ${renderTabs("issues")}
     <h1>📋 Open Issues</h1>
     <div class="summary">
       ${escapeHtml(String(total))} issue${total === 1 ? "" : "s"} across

--- a/src/nav-tabs.ts
+++ b/src/nav-tabs.ts
@@ -1,0 +1,59 @@
+// Shared top-of-page tab navigation used by every SSR page (`/`, `/issues`,
+// `/releases`). One tab per page; the active tab is highlighted via the
+// `tab-active` modifier so the operator always knows which page they are on.
+//
+// Each SSR page inlines this HTML + CSS into its own `<style>` block to keep
+// pages self-contained (no external stylesheet to fetch) and avoid the
+// CSS-classname coupling problem if pages grow apart later.
+
+export type TabKey = "dashboard" | "issues" | "releases";
+
+interface TabDef {
+  key: TabKey;
+  href: string;
+  label: string;
+}
+
+const TABS: ReadonlyArray<TabDef> = [
+  { key: "dashboard", href: "/",         label: "📊 Dashboard" },
+  { key: "issues",    href: "/issues",   label: "📋 Open Issues" },
+  { key: "releases",  href: "/releases", label: "🏷️ Releases" },
+];
+
+export function renderTabs(active: TabKey): string {
+  const items = TABS.map((t) => {
+    const cls = t.key === active ? "tab tab-active" : "tab";
+    return `<a href="${t.href}" class="${cls}">${t.label}</a>`;
+  }).join("");
+  return `<nav class="tabs">${items}</nav>`;
+}
+
+// Inline this into each page's `<style>` block.
+//
+// Layout: flex strip with a 1px bottom border; each tab paints a 2px coloured
+// underline only when active, sitting on top of the strip border via a -1px
+// negative margin so the active tab "owns" that pixel column.
+export const TAB_STYLES = `
+  .tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0;
+    margin-bottom: 16px;
+    border-bottom: 1px solid #30363d;
+  }
+  .tab {
+    padding: 8px 14px;
+    font-size: 13px;
+    color: #8b949e;
+    text-decoration: none;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+    white-space: nowrap;
+  }
+  .tab:hover { color: #c9d1d9; }
+  .tab-active {
+    color: #58a6ff;
+    border-bottom-color: #58a6ff;
+    font-weight: 600;
+  }
+`;

--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -7,6 +7,7 @@ import {
   previousTag,
   computeWarnings,
 } from "./release-helpers";
+import { renderTabs, TAB_STYLES } from "./nav-tabs";
 
 // `/releases?repo=owner/name&tag=vX.Y.Z` renders the release confirmation
 // view: every issue touched by commits in this tag's range, with a checkbox
@@ -255,7 +256,7 @@ function renderHtml(
 </head>
 <body>
   <header>
-    <div class="nav"><a href="/">← CI Dashboard</a> · <a href="/issues">📋 Open Issues</a></div>
+    ${renderTabs("releases")}
     <h1>🏷️ Release confirmation</h1>
     <div class="summary">${summary}</div>
   </header>
@@ -340,7 +341,7 @@ function renderError(msg: string): string {
   return `<!DOCTYPE html>
 <html lang="en"><head><meta charset="UTF-8"><title>Release confirmation — Error</title>
 <style>${STYLES}</style></head><body>
-<header><div class="nav"><a href="/">← CI Dashboard</a></div>
+<header>${renderTabs("releases")}
 <h1>🏷️ Release confirmation</h1></header>
 <div class="flash err">${escapeHtml(msg)}</div>
 </body></html>`;
@@ -357,9 +358,7 @@ const STYLES = `
     max-width: 1200px; margin: 0 auto;
   }
   header { margin-bottom: 16px; }
-  header .nav { font-size: 13px; margin-bottom: 8px; }
-  header .nav a { color: #58a6ff; text-decoration: none; }
-  header .nav a:hover { text-decoration: underline; }
+  ${TAB_STYLES}
   h1 { font-size: 20px; color: #58a6ff; }
   .summary { font-size: 13px; color: #8b949e; margin-top: 4px; }
   .summary code { background: #161b22; padding: 1px 6px; border-radius: 4px; color: #d2a8ff; }


### PR DESCRIPTION
## Summary

3 つの SSR page (`/`, `/issues`, `/releases`) の top に共通の **タブナビゲーション**を追加。Refs #38 で release UI を作ったが dashboard top にリンクがなく、operator が辿れなかった。

## What

- 新規 `src/nav-tabs.ts` が `renderTabs(active)` HTML と `TAB_STYLES` CSS を export
- 各ページが import して自分のテンプレートに inline
- アクティブタブは `tab-active` クラスで強調 (青下線 + #58a6ff color)

## 変更点

| file | 内容 |
|---|---|
| `src/nav-tabs.ts` | 新規 — `renderTabs("dashboard" \| "issues" \| "releases")` + `TAB_STYLES` |
| `src/dashboard.ts` | `<h1>CI Dashboard <a href="/issues">…</a></h1>` → `<nav class="tabs">` + 純粋な h1 |
| `src/issues-page.ts` | `<div class="nav">← CI Dashboard</div>` を tab strip に |
| `src/releases-page.ts` | renderHtml / renderForm / renderError の 3 ヶ所のナビを tab strip に |

## 結果

各ページのヘッダーが:

```
[📊 Dashboard] [📋 Open Issues] [🏷️ Releases]
─────────────                  
(現在ページが青下線)
```

`/` を開けば Dashboard が active、`/releases` を開けば Releases が active、というふうに。

## Verification

- `npm test` → 12 files / 109 tests pass (既存 assertion は `href="/"` 等を見ているだけなので影響なし)
- 手元 `git diff --stat`: `+71 -10` (純粋なリファクタ)

Refs #39
Refs #35