### PR TITLE
feat(releases): table view per tag, batch close across tags

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { handleDashboard } from "./dashboard";
 import { handleIssuesPage } from "./issues-page";
 import { handleReleasesPage } from "./releases-page";
 import { handleReleaseClose } from "./release-close";
+import { handleReleaseCloseBatch } from "./release-close-batch";
 import { handleRecheck } from "./recheck";
 import { handleTagRelease } from "./tag-release";
 import { handleMcpRequest } from "./mcp/server";
@@ -37,6 +38,7 @@ app.get("/issues", (c) => handleIssuesPage(c.env));
 // See issue #35 + CLAUDE.md `release / close フロー`.
 app.get("/releases", (c) => handleReleasesPage(c.req.raw, c.env));
 app.post("/api/release-close", (c) => handleReleaseClose(c.req.raw, c.env));
+app.post("/api/release-close-batch", (c) => handleReleaseCloseBatch(c.req.raw, c.env));
 
 // WebSocket
 app.get("/ws", (c) => getHub(c.env).fetch(c.req.raw));

--- a/src/release-close-batch.ts
+++ b/src/release-close-batch.ts
@@ -1,0 +1,104 @@
+import { githubApi, parseRepo, validateOrg } from "./github-api";
+
+// POST /api/release-close-batch
+//
+// The `/releases` index page renders one form per repo, but inside that form
+// the operator picks issues across several tags. The form encodes each
+// selection as `pair=<tag>:<issue>`, so this handler groups by tag in order
+// to attribute each "Closed by release <tag>" comment to the right tag, then
+// closes the issues.
+//
+// Single-tag close still lives at POST /api/release-close (used by the
+// detail page) — that handler's payload shape is the older `tag` + `issue[]`
+// form and we keep it for backward compatibility.
+
+const PAIR_RE = /^(.+):(\d+)$/;
+
+export async function handleReleaseCloseBatch(
+  req: Request,
+  env: { GITHUB_TOKEN: string },
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+
+  const form = await req.formData();
+  const repoParam = String(form.get("repo") ?? "").trim();
+  const rawPairs = form.getAll("pair").map((v) => String(v));
+
+  if (!repoParam) {
+    return new Response("Missing repo", { status: 400 });
+  }
+
+  // Parse `tag:issue` pairs; silently drop anything malformed.
+  const grouped = new Map<string, number[]>();
+  for (const raw of rawPairs) {
+    const m = raw.match(PAIR_RE);
+    if (!m) continue;
+    const tag = m[1]!;
+    const n = Number(m[2]);
+    if (!Number.isInteger(n) || n <= 0) continue;
+    const list = grouped.get(tag);
+    if (list) list.push(n);
+    else grouped.set(tag, [n]);
+  }
+
+  // Nothing selected → bounce straight back to /releases without spamming
+  // GitHub. This is the "user submitted an empty form" path.
+  if (grouped.size === 0) {
+    return redirect("/releases");
+  }
+
+  let owner: string, name: string;
+  try {
+    ({ owner, repo: name } = parseRepo(repoParam));
+    validateOrg(owner);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return new Response(`Bad repo: ${msg}`, { status: 400 });
+  }
+
+  // Flatten the grouped map into one operation list so failures per issue
+  // can be tracked back to the right number for the flash query.
+  type Operation = { tag: string; issue: number };
+  const ops: Operation[] = [];
+  for (const [tag, issues] of grouped) {
+    for (const issue of issues) ops.push({ tag, issue });
+  }
+
+  const settled = await Promise.allSettled(
+    ops.map(async ({ tag, issue }) => {
+      await githubApi(
+        env.GITHUB_TOKEN, "POST",
+        `/repos/${owner}/${name}/issues/${issue}/comments`,
+        { body: `Closed by release ${tag}` },
+      );
+      await githubApi(
+        env.GITHUB_TOKEN, "PATCH",
+        `/repos/${owner}/${name}/issues/${issue}`,
+        { state: "closed", state_reason: "completed" },
+      );
+      return issue;
+    }),
+  );
+
+  const closed: number[] = [];
+  const failed: number[] = [];
+  settled.forEach((r, i) => {
+    if (r.status === "fulfilled") closed.push(r.value);
+    else failed.push(ops[i]!.issue);
+  });
+
+  const params = new URLSearchParams({ repo: repoParam });
+  if (closed.length > 0) params.set("closed", closed.join(","));
+  if (failed.length > 0) params.set("failed", failed.join(","));
+  return redirect(`/releases?${params.toString()}`);
+}
+
+function redirect(location: string): Response {
+  // 303 so the browser swaps POST → GET on the redirect target.
+  return new Response(null, {
+    status: 303,
+    headers: { Location: location },
+  });
+}

--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -64,7 +64,21 @@ export async function handleReleasesPage(
 // "Recent releases" landing page (no params)
 // --------------------------------------------------------------------------
 
-interface RepoTags { repo: string; tags: string[] }
+interface RepoView {
+  repo: string;
+  tagBlocks: TagBlock[];
+  olderTags: string[];   // tags beyond the displayed top N
+}
+
+interface TagBlock {
+  tag: string;
+  prevTag: string | null;
+  issues: IssueRow[];    // already-fetched and warning-annotated
+}
+
+// Top tags shown inline per repo (each fans out compare + per-issue fetches).
+// Older tags collapse to a link strip pointing at the detail page.
+const TOP_TAGS_INLINE = 5;
 
 async function handleIndexPage(
   env: { GITHUB_TOKEN: string; CI_HUB: DurableObjectNamespace },
@@ -83,26 +97,103 @@ async function handleIndexPage(
     }
   } catch { /* empty list → page falls back to lookup form only */ }
 
-  // 2. Latest 5 semver tags per repo in parallel. Per-repo failures are
-  //    swallowed: a deleted repo or rate-limited org shouldn't sink the page.
-  const items: RepoTags[] = await Promise.all(repos.map(async (repo) => {
+  // 2. Per-repo data load in parallel; whole-repo failures get a null view
+  //    we drop in the renderer.
+  const views = await Promise.all(repos.map(async (repo) => {
     try {
-      const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
-      const tags = await githubApi<TagListItem[]>(
-        env.GITHUB_TOKEN, "GET", `/repos/${owner}/${name}/tags`, undefined,
-        { per_page: "10" },
-      );
-      return {
-        repo,
-        tags: sortSemverDesc(tags.map((t) => t.name)).slice(0, 5),
-      };
+      return await loadRepoView(env.GITHUB_TOKEN, repo);
     } catch {
-      return { repo, tags: [] };
+      return null;
     }
   }));
 
-  return html(renderIndex(items), 200);
+  return html(
+    renderIndex(views.filter((v): v is RepoView => v !== null)),
+    200,
+  );
+}
+
+async function loadRepoView(token: string, repo: string): Promise<RepoView | null> {
+  const { owner, repo: name } = parseRepo(repo);
+  validateOrg(owner);
+
+  // 1. Recent semver tags. 10 gives us 5 inline + room for the predecessor
+  //    pairing on the oldest of those 5 + a small "older" strip.
+  const allTags = await githubApi<TagListItem[]>(
+    token, "GET", `/repos/${owner}/${name}/tags`, undefined,
+    { per_page: "10" },
+  );
+  const sorted = sortSemverDesc(allTags.map((t) => t.name));
+  const topTags = sorted.slice(0, TOP_TAGS_INLINE);
+  if (topTags.length === 0) {
+    return { repo: `${owner}/${name}`, tagBlocks: [], olderTags: [] };
+  }
+
+  // 2. For each inline tag, compare to its immediate predecessor (next in
+  //    sorted-desc) and harvest issue refs from commit messages. We skip the
+  //    PR-fetch heuristic the detail page uses, to keep the index sub-request
+  //    budget bounded (fans out across N repos).
+  const rawBlocks = await Promise.all(topTags.map(async (tag, i) => {
+    const prevTag = sorted[i + 1] ?? null;
+    if (!prevTag) {
+      return { tag, prevTag: null, refs: [] as number[] };
+    }
+    try {
+      const cmp = await githubApi<CompareResponse>(
+        token, "GET", `/repos/${owner}/${name}/compare/${prevTag}...${tag}`,
+      );
+      const refs = new Set<number>();
+      for (const c of cmp.commits) {
+        for (const n of extractRefIssues(c.commit.message)) refs.add(n);
+      }
+      return { tag, prevTag, refs: [...refs] };
+    } catch {
+      return { tag, prevTag, refs: [] };
+    }
+  }));
+
+  // 3. Deduplicate issue numbers across blocks so the same issue referenced
+  //    by two tags only triggers one GitHub fetch.
+  const uniqueRefs = new Set<number>();
+  for (const b of rawBlocks) for (const n of b.refs) uniqueRefs.add(n);
+
+  const issueByNum = new Map<number, IssueRow | null>();
+  await Promise.all([...uniqueRefs].map(async (n) => {
+    try {
+      const issue = await githubApi<RawIssue>(
+        token, "GET", `/repos/${owner}/${name}/issues/${n}`,
+      );
+      if (issue.pull_request) { issueByNum.set(n, null); return; }
+      const labels = issue.labels.map((l) => l.name);
+      issueByNum.set(n, {
+        number: issue.number,
+        title: issue.title,
+        state: issue.state,
+        labels,
+        assignees: issue.assignees.map((a) => a.login),
+        url: issue.html_url,
+        updated_at: issue.updated_at,
+        warnings: computeWarnings({ state: issue.state, labels }),
+      });
+    } catch {
+      issueByNum.set(n, null);
+    }
+  }));
+
+  const tagBlocks: TagBlock[] = rawBlocks.map((b) => ({
+    tag: b.tag,
+    prevTag: b.prevTag,
+    issues: b.refs
+      .map((n) => issueByNum.get(n) ?? null)
+      .filter((i): i is IssueRow => i !== null)
+      .sort((a, c) => a.number - c.number),
+  }));
+
+  return {
+    repo: `${owner}/${name}`,
+    tagBlocks,
+    olderTags: sorted.slice(TOP_TAGS_INLINE),
+  };
 }
 
 // --------------------------------------------------------------------------
@@ -384,11 +475,16 @@ ${renderLookupForm(repo, tag)}
 </body></html>`;
 }
 
-function renderIndex(items: RepoTags[]): string {
-  const populated = items.filter((i) => i.tags.length > 0);
-  const repoBlocks = populated.length === 0
-    ? `<div class="empty">🤷 No watched repos with releases yet. Look one up below.</div>`
-    : populated.map((i) => renderIndexRepo(i)).join("\n");
+function renderIndex(views: RepoView[]): string {
+  // Show repos with at least one referenced issue in their displayed tag
+  // window; repos that haven't had a Refs-bearing release yet would just
+  // be a noise card.
+  const populated = views.filter((v) =>
+    v.tagBlocks.some((b) => b.issues.length > 0),
+  );
+  const body = populated.length === 0
+    ? `<div class="empty">🤷 No releases with referenced issues in the recent window. Look one up below.</div>`
+    : populated.map(renderIndexRepo).join("\n");
 
   return `<!DOCTYPE html>
 <html lang="en"><head>
@@ -398,22 +494,93 @@ function renderIndex(items: RepoTags[]): string {
 <header>
   ${renderTabs("releases")}
   <h1>🏷️ Releases</h1>
-  <div class="summary">Pick a tag to review the issues it touched.</div>
+  <div class="summary">Tick the issues that this release actually closed; one button per repo closes them all.</div>
 </header>
-${repoBlocks}
+${body}
 <h2 class="lookup-header">Look up another release</h2>
 ${renderLookupForm(null, null)}
 </body></html>`;
 }
 
-function renderIndexRepo(item: RepoTags): string {
-  const tagLinks = item.tags.map((t) =>
-    `<li><a href="/releases?repo=${encodeURIComponent(item.repo)}&tag=${encodeURIComponent(t)}">${escapeHtml(t)}</a></li>`,
-  ).join("");
+function renderIndexRepo(view: RepoView): string {
+  const tagSections = view.tagBlocks
+    .filter((b) => b.issues.length > 0)
+    .map((b) => renderTagBlock(view.repo, b))
+    .join("\n");
+
+  const olderHtml = view.olderTags.length === 0
+    ? ""
+    : `<div class="older-tags">older: ${view.olderTags
+        .map((t) =>
+          `<a href="/releases?repo=${encodeURIComponent(view.repo)}&tag=${encodeURIComponent(t)}">${escapeHtml(t)}</a>`,
+        )
+        .join(" · ")}</div>`;
+
+  // Whole repo card is one form so the operator can tick across tags and
+  // close them in one shot; the POST handler groups by tag for comment
+  // attribution.
   return `<section class="repo-card">
-    <h2><a href="https://github.com/${escapeHtml(item.repo)}/releases" target="_blank" rel="noopener">${escapeHtml(item.repo)}</a></h2>
-    <ul class="tag-list">${tagLinks}</ul>
+    <h2><a href="https://github.com/${escapeHtml(view.repo)}/releases" target="_blank" rel="noopener">${escapeHtml(view.repo)}</a></h2>
+    <form method="POST" action="/api/release-close-batch" class="batch-close-form">
+      <input type="hidden" name="repo" value="${escapeHtml(view.repo)}">
+      ${tagSections}
+      <div class="actions">
+        <button type="submit">✅ Close selected as released</button>
+        <span class="hint">⚠️ rows start unchecked.</span>
+      </div>
+    </form>
+    ${olderHtml}
   </section>`;
+}
+
+function renderTagBlock(repo: string, block: TagBlock): string {
+  const rows = block.issues.map((i) => renderIndexRow(block.tag, i)).join("\n");
+  const since = block.prevTag
+    ? `<span class="since">since <code>${escapeHtml(block.prevTag)}</code></span>`
+    : "";
+  return `<div class="tag-block">
+    <div class="tag-block-header">
+      <strong>${escapeHtml(block.tag)}</strong>
+      ${since}
+      <a class="detail-link"
+         href="/releases?repo=${encodeURIComponent(repo)}&tag=${encodeURIComponent(block.tag)}">
+        → detail
+      </a>
+    </div>
+    <table>
+      <thead><tr>
+        <th class="col-check"></th>
+        <th>#</th>
+        <th>Title</th>
+        <th>State</th>
+        <th>Labels</th>
+      </tr></thead>
+      <tbody>${rows}</tbody>
+    </table>
+  </div>`;
+}
+
+function renderIndexRow(tag: string, r: IssueRow): string {
+  const hasWarn = r.warnings.length > 0;
+  const checked = hasWarn ? "" : " checked";
+  const pair = `${tag}:${r.number}`;
+  const warnIcon = hasWarn
+    ? `<span class="warn" title="${escapeHtml(r.warnings.join(", "))}">⚠️</span>`
+    : "";
+  const labelChips = r.labels.length > 0
+    ? `<div class="labels">${r.labels
+        .map((l) => `<span class="label">${escapeHtml(l)}</span>`).join("")}</div>`
+    : "—";
+  const stateChip =
+    `<span class="state state-${escapeHtml(r.state)}">${escapeHtml(r.state)}</span>`;
+
+  return `<tr>
+    <td class="col-check"><input type="checkbox" name="pair" value="${escapeHtml(pair)}"${checked}></td>
+    <td class="num"><a href="${escapeHtml(r.url)}" target="_blank" rel="noopener">#${r.number}</a></td>
+    <td class="title">${warnIcon}<a href="${escapeHtml(r.url)}" target="_blank" rel="noopener">${escapeHtml(r.title)}</a></td>
+    <td>${stateChip}</td>
+    <td>${labelChips}</td>
+  </tr>`;
 }
 
 // Bare `<form>` extracted so both the index landing page and the
@@ -500,23 +667,44 @@ const STYLES = `
   .flash.err { background: #341a1f; border: 1px solid #f85149; color: #ffa198; }
   .flash a { color: inherit; text-decoration: underline; }
 
-  /* Recent releases landing page */
+  /* Recent releases landing page — repo card with stacked tag blocks */
   .repo-card {
     background: #161b22; border: 1px solid #30363d;
-    border-radius: 8px; padding: 12px 16px; margin-bottom: 12px;
+    border-radius: 8px; padding: 16px; margin-bottom: 16px;
   }
-  .repo-card h2 { font-size: 14px; font-weight: 600; margin-bottom: 8px; }
-  .repo-card h2 a { color: #c9d1d9; text-decoration: none; }
-  .repo-card h2 a:hover { color: #58a6ff; }
-  ul.tag-list { list-style: none; display: flex; flex-wrap: wrap; gap: 8px; }
-  ul.tag-list li a {
-    display: inline-block; padding: 4px 10px;
+  .repo-card > h2 { font-size: 14px; font-weight: 600; margin-bottom: 12px; }
+  .repo-card > h2 a { color: #c9d1d9; text-decoration: none; }
+  .repo-card > h2 a:hover { color: #58a6ff; }
+  .batch-close-form { display: block; }
+  .tag-block { margin-bottom: 14px; }
+  .tag-block-header {
+    display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap;
+    font-size: 13px; margin-bottom: 4px; color: #c9d1d9;
+  }
+  .tag-block-header strong {
+    color: #d2a8ff; font-variant-numeric: tabular-nums; font-weight: 600;
+  }
+  .tag-block-header .since { color: #8b949e; font-size: 12px; }
+  .tag-block-header .since code { background: #0d1117; padding: 1px 4px;
+    border-radius: 4px; color: #d2a8ff; }
+  .tag-block-header .detail-link {
+    margin-left: auto; color: #58a6ff; text-decoration: none; font-size: 12px;
+  }
+  .tag-block-header .detail-link:hover { text-decoration: underline; }
+  .tag-block table {
     background: #0d1117; border: 1px solid #30363d;
-    border-radius: 12px; color: #58a6ff;
-    text-decoration: none; font-size: 13px;
+    border-radius: 6px; overflow: hidden;
+  }
+  .older-tags {
+    margin-top: 8px; font-size: 12px; color: #8b949e;
+    border-top: 1px dashed #30363d; padding-top: 8px;
+  }
+  .older-tags a {
+    color: #58a6ff; text-decoration: none;
+    padding: 1px 6px; border-radius: 4px;
     font-variant-numeric: tabular-nums;
   }
-  ul.tag-list li a:hover { background: #1f6feb22; border-color: #58a6ff; }
+  .older-tags a:hover { background: #1f6feb22; }
   .lookup-header {
     font-size: 12px; font-weight: 600; text-transform: uppercase;
     letter-spacing: 0.5px; color: #8b949e;

--- a/test/release-close-batch.test.ts
+++ b/test/release-close-batch.test.ts
@@ -1,0 +1,185 @@
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import worker from "../src/index";
+import type { Env } from "../src/index";
+
+function testEnv(): Env {
+  return {
+    CI_STATUS: env.CI_STATUS,
+    WEBHOOK_SECRET: "test-secret",
+    GITHUB_TOKEN: "test-token",
+    CI_HUB: {
+      idFromName: () => ({}),
+      get: () => ({ fetch: async () => new Response("OK") }),
+    } as unknown as DurableObjectNamespace,
+  };
+}
+
+interface RecordedCall {
+  url: string;
+  method: string;
+  body: unknown;
+}
+
+function stubCloseFlow(opts: { failIssue?: number } = {}) {
+  const calls: RecordedCall[] = [];
+  const spy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    const method = init?.method ?? (input instanceof Request ? input.method : "GET");
+    let body: unknown = init?.body;
+    if (typeof body === "string") {
+      try { body = JSON.parse(body); } catch { /* keep string */ }
+    }
+    calls.push({ url, method, body });
+
+    if (opts.failIssue && url.includes(`/issues/${opts.failIssue}`)) {
+      return new Response("boom", { status: 500 });
+    }
+    if (url.includes("/comments")) {
+      return Response.json({ id: 1 });
+    }
+    return Response.json({ number: 1, state: "closed", state_reason: "completed", html_url: "" });
+  });
+  return { spy, calls };
+}
+
+function formBody(pairs: Array<[string, string]>): string {
+  const params = new URLSearchParams();
+  for (const [k, v] of pairs) params.append(k, v);
+  return params.toString();
+}
+
+describe("POST /api/release-close-batch", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("groups pairs by tag and posts a tag-attributed comment + PATCH per issue", async () => {
+    const { calls } = stubCloseFlow();
+    const req = new Request("http://localhost/api/release-close-batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formBody([
+        ["repo", "ippoan/ci-dashboard"],
+        ["pair", "v1.2.0:1"],
+        ["pair", "v1.2.0:5"],
+        ["pair", "v1.1.0:3"],
+      ]),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(303);
+    const location = res.headers.get("Location") ?? "";
+    expect(location).toMatch(/^\/releases\?/);
+    expect(location).toContain("repo=ippoan%2Fci-dashboard");
+    // All three closed (numbers in flash, any order — URLSearchParams encodes
+    // commas as %2C, so we decode and compare against a set).
+    const closedMatch = location.match(/closed=([^&]+)/);
+    expect(closedMatch).not.toBeNull();
+    const closedNums = decodeURIComponent(closedMatch![1]!).split(",").sort();
+    expect(closedNums).toEqual(["1", "3", "5"]);
+    expect(location).not.toContain("failed=");
+
+    // 3 issues × (POST comment + PATCH issue) = 6 GitHub calls.
+    expect(calls.length).toBe(6);
+    const comments = calls.filter((c) => c.method === "POST" && c.url.includes("/comments"));
+    const patches = calls.filter((c) => c.method === "PATCH" && /\/issues\/\d+$/.test(c.url));
+    expect(comments.length).toBe(3);
+    expect(patches.length).toBe(3);
+
+    // Tag-attributed comment bodies.
+    const bodies = comments.map((c) => (c.body as { body: string }).body);
+    expect(bodies.filter((b) => b === "Closed by release v1.2.0").length).toBe(2);
+    expect(bodies.filter((b) => b === "Closed by release v1.1.0").length).toBe(1);
+  });
+
+  it("partitions partial failures into closed= and failed=", async () => {
+    const { calls } = stubCloseFlow({ failIssue: 5 });
+    const req = new Request("http://localhost/api/release-close-batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formBody([
+        ["repo", "ippoan/ci-dashboard"],
+        ["pair", "v1.2.0:1"],
+        ["pair", "v1.2.0:5"],
+      ]),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(303);
+    const location = res.headers.get("Location") ?? "";
+    expect(location).toContain("closed=1");
+    expect(location).toContain("failed=5");
+    expect(calls.length).toBeGreaterThan(0);
+  });
+
+  it("redirects without touching GitHub when no pairs are selected", async () => {
+    const { calls } = stubCloseFlow();
+    const req = new Request("http://localhost/api/release-close-batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formBody([["repo", "ippoan/ci-dashboard"]]),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(303);
+    expect(calls.length).toBe(0);
+    expect(res.headers.get("Location")).toBe("/releases");
+  });
+
+  it("ignores malformed pair strings instead of crashing", async () => {
+    const { calls } = stubCloseFlow();
+    const req = new Request("http://localhost/api/release-close-batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formBody([
+        ["repo", "ippoan/ci-dashboard"],
+        ["pair", "no-colon"],
+        ["pair", "v1.2.0:not-a-number"],
+        ["pair", "v1.2.0:-3"],
+        ["pair", "v1.2.0:7"],   // only this one is valid
+      ]),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(303);
+    // 1 issue × 2 ops = 2 calls.
+    expect(calls.length).toBe(2);
+    expect(res.headers.get("Location") ?? "").toContain("closed=7");
+  });
+
+  it("400s on a missing repo or a disallowed org", async () => {
+    {
+      const req = new Request("http://localhost/api/release-close-batch", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: formBody([["pair", "v1.2.0:1"]]),
+      });
+      const ctx = createExecutionContext();
+      const res = await worker.fetch(req, testEnv(), ctx);
+      await waitOnExecutionContext(ctx);
+      expect(res.status).toBe(400);
+    }
+    {
+      const req = new Request("http://localhost/api/release-close-batch", {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: formBody([
+          ["repo", "evil-org/x"],
+          ["pair", "v1.2.0:1"],
+        ]),
+      });
+      const ctx = createExecutionContext();
+      const res = await worker.fetch(req, testEnv(), ctx);
+      await waitOnExecutionContext(ctx);
+      expect(res.status).toBe(400);
+      expect(await res.text()).toContain("Org not allowed");
+    }
+  });
+});

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -112,16 +112,19 @@ describe("GET /releases", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
     // No watched repos → empty hint + lookup form at the bottom.
-    expect(html).toContain("No watched repos");
+    expect(html).toContain("No releases with referenced issues");
     expect(html).toContain('<form method="GET" action="/releases"');
     expect(html).toContain('name="repo"');
     expect(html).toContain('name="tag"');
   });
 
-  it("lists recent releases for every watched repo on /releases (no params)", async () => {
-    // Stub /tags per watched repo so we can verify the merge.
+  it("renders per-repo tables with stacked tag blocks and pair-encoded checkboxes", async () => {
+    // Index data flow per repo: /tags → /compare/prev...current per top-N tag →
+    // /issues/:n for each unique referenced issue. The stub answers each step.
     vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
       const url = typeof req === "string" ? req : (req as Request).url;
+
+      // ci-dashboard: 3 tags, 2 inline blocks (v1.2.0..v1.1.0..v1.0.0)
       if (url.includes("/repos/ippoan/ci-dashboard/tags")) {
         return Response.json([
           { name: "v1.2.0", commit: { sha: "a" } },
@@ -129,13 +132,55 @@ describe("GET /releases", () => {
           { name: "v1.0.0", commit: { sha: "c" } },
         ]);
       }
+      if (url.includes("/repos/ippoan/ci-dashboard/compare/v1.1.0...v1.2.0")) {
+        return Response.json({
+          commits: [{ sha: "x", commit: { message: "feat: do thing\n\nRefs #1" } }],
+        });
+      }
+      if (url.includes("/repos/ippoan/ci-dashboard/compare/v1.0.0...v1.1.0")) {
+        return Response.json({
+          commits: [{ sha: "y", commit: { message: "fix: bug-y\n\nRefs #2" } }],
+        });
+      }
+      if (url.endsWith("/repos/ippoan/ci-dashboard/issues/1")) {
+        return Response.json({
+          number: 1, title: "clean issue", state: "open",
+          labels: [], assignees: [],
+          html_url: "https://github.com/ippoan/ci-dashboard/issues/1",
+          updated_at: "2026-05-01T00:00:00Z",
+        });
+      }
+      if (url.endsWith("/repos/ippoan/ci-dashboard/issues/2")) {
+        return Response.json({
+          number: 2, title: "warning-flagged", state: "open",
+          labels: [{ name: "bug" }], assignees: [],
+          html_url: "https://github.com/ippoan/ci-dashboard/issues/2",
+          updated_at: "2026-05-01T00:00:00Z",
+        });
+      }
+
+      // nuxt-notify: 2 tags, 1 block
       if (url.includes("/repos/ippoan/nuxt-notify/tags")) {
         return Response.json([
           { name: "v0.5.0", commit: { sha: "d" } },
+          { name: "v0.4.0", commit: { sha: "e" } },
         ]);
       }
-      // ohishi-exp tag fetch is allowed to fail (rate limit / 404) — the page
-      // must not crash, that repo just renders no card.
+      if (url.includes("/repos/ippoan/nuxt-notify/compare/v0.4.0...v0.5.0")) {
+        return Response.json({
+          commits: [{ sha: "z", commit: { message: "feat\n\nRefs #100" } }],
+        });
+      }
+      if (url.endsWith("/repos/ippoan/nuxt-notify/issues/100")) {
+        return Response.json({
+          number: 100, title: "feature", state: "open",
+          labels: [], assignees: [],
+          html_url: "https://github.com/ippoan/nuxt-notify/issues/100",
+          updated_at: "2026-05-01T00:00:00Z",
+        });
+      }
+
+      // dead-repo: /tags 403 → loadRepoView throws → repo card omitted.
       return new Response("rate limit", { status: 403 });
     });
 
@@ -152,18 +197,33 @@ describe("GET /releases", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
 
-    // Both populated repos rendered as their own cards.
+    // Both populated repos rendered as cards; dead-repo dropped.
     expect(html).toContain("ippoan/ci-dashboard");
     expect(html).toContain("ippoan/nuxt-notify");
-    // Tags in semver-desc order with detail-page links (% encoded).
-    expect(html).toMatch(/href="\/releases\?repo=ippoan%2Fci-dashboard&tag=v1\.2\.0"/);
-    expect(html).toMatch(/href="\/releases\?repo=ippoan%2Fnuxt-notify&tag=v0\.5\.0"/);
+    expect(html).not.toContain("dead-repo");
+
+    // Tag headers + previous-tag chips.
     expect(html).toContain("v1.2.0");
     expect(html).toContain("v1.1.0");
     expect(html).toContain("v0.5.0");
-    // Repos whose tag fetch failed don't even show up as a card.
-    expect(html).not.toContain("dead-repo");
-    // Lookup form is still appended for arbitrary-tag access.
+
+    // Issue rows show titles inline (no longer just chips).
+    expect(html).toContain("clean issue");
+    expect(html).toContain("warning-flagged");
+    expect(html).toContain("feature");
+
+    // Detail-page link per tag block ("→ detail").
+    expect(html).toMatch(/href="\/releases\?repo=ippoan%2Fci-dashboard&tag=v1\.2\.0"/);
+
+    // Checkbox values are `tag:issue` pairs; clean rows checked, warning OFF.
+    expect(html).toMatch(/name="pair" value="v1\.2\.0:1" checked/);
+    expect(html).toMatch(/name="pair" value="v1\.1\.0:2"(?! checked)/);
+    expect(html).toMatch(/name="pair" value="v0\.5\.0:100" checked/);
+
+    // Batch-close form per repo points at the new endpoint.
+    expect(html).toContain('action="/api/release-close-batch"');
+
+    // Lookup form still present at the bottom for arbitrary-tag access.
     expect(html).toContain('<form method="GET" action="/releases"');
   });
 


### PR DESCRIPTION
## Summary

`/releases` を **tag グルーピング付きテーブル** に作り替え、issue title / state / labels が一目で見えて、その場で複数 tag 横断 close できるようにした。Refs #43。

## Before / After

**Before (PR #42)**: タグ chip 一覧。クリックして別ページ行かないと issue が見えない。
**After**: 各 repo カード内で top 5 tag を inline 展開、各 tag に小テーブル (title / state / labels + checkbox)。1 ボタンで全 tag 横断 close。

```
ippoan/ci-dashboard
┌──────────────────────────────────────┐
│ v0.0.39  since v0.0.38  → detail     │
│ ☑ #41 feat /releases recent  open    │
│ ⚠️ #36 yhonda-ohishi added  open bug │
│                                      │
│ v0.0.38  since v0.0.37  → detail     │
│ ☑ #39 nav tabs              open     │
│                                      │
│ [✅ Close selected as released]      │
│ older: v0.0.34 · v0.0.33 · ...       │
└──────────────────────────────────────┘
```

## What

### New endpoint: `POST /api/release-close-batch`
- form body: `repo`, `pair[]=<tag>:<issue>`
- pair を **tag ごとに group** → 各 tag の comment「`Closed by release <tag>`」を正しい tag 名で付与してから close
- 303 redirect で `/releases?repo=...&closed=...&failed=...`
- 既存 `/api/release-close` (single-tag, detail page から使う) はそのまま残し backward-compat 維持

### `loadRepoView(repo)` per-repo loader
- `/tags?per_page=10` → top 5 semver-desc
- 各 top tag 並列で `/compare/<prev>...<current>` → commit message から `Refs #N` 抽出
- 5 block 横断で issue 番号 dedupe → unique で `/issues/:n` 1 回ずつ
- 各 block に resolve した IssueRow を map back

detail page (`?repo=X&tag=Y`) の PR-fetch heuristic (PR head.ref + body) はスキップ — index 描画の sub-request 予算を抑えるため。

### 失敗時の挙動
- repo 単位失敗 (deleted / 403): カード自体表示しない
- tag block 単位失敗 (compare 500): block を空にして他に影響なし
- issue fetch 失敗: 該当行のみ脱落

### CSS
新 `.tag-block` / `.tag-block-header` / `.older-tags` を repo-card 内に。モバイル幅でも崩れない。

## Tests (13 files / 116 pass)

- `test/releases-page.test.ts` の index 系を再構成
  - 2 watched repo + 1 dead-repo (403) の full data flow stub
  - tag-block 表示、inline title、detail link、`pair="<tag>:<issue>"`、warning OFF default、`/api/release-close-batch` POST 先などを assertion
- `test/release-close-batch.test.ts` 新規
  - 3 pair 横断 2 tag の happy path: 6 GitHub call (2 + 1 comment + 3 PATCH)
  - tag-attributed comment body の verify
  - partial 失敗: closed= + failed= 分割
  - 空 pair: GitHub call ゼロで bounce
  - malformed pair (`no-colon` / `:not-a-number` / `:-3`) は silently drop
  - missing repo / disallowed org: 400

## Verification

```bash
cd /home/yhonda/js/ci-dashboard
npm test
```

13 test files / 116 tests pass.

Refs #43
Refs #35