### PR TITLE
feat(releases): collapse already-closed issues into <details>

### DIFF
--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -535,10 +535,37 @@ function renderIndexRepo(view: RepoView): string {
 }
 
 function renderTagBlock(repo: string, block: TagBlock): string {
-  const rows = block.issues.map((i) => renderIndexRow(block.tag, i)).join("\n");
+  // Split by state: already-closed issues are noise in the at-a-glance view,
+  // so they collapse into a native <details> below the active rows. The form
+  // wrapping the whole repo card still picks up checkboxes inside <details>
+  // when the operator expands it.
+  const visible = block.issues.filter((i) => i.state !== "closed");
+  const hidden = block.issues.filter((i) => i.state === "closed");
+
   const since = block.prevTag
     ? `<span class="since">since <code>${escapeHtml(block.prevTag)}</code></span>`
     : "";
+
+  const visibleTable = visible.length === 0 ? "" : `
+    <table>
+      <thead><tr>
+        <th class="col-check"></th>
+        <th>#</th>
+        <th>Title</th>
+        <th>State</th>
+        <th>Labels</th>
+      </tr></thead>
+      <tbody>${visible.map((i) => renderIndexRow(block.tag, i)).join("\n")}</tbody>
+    </table>`;
+
+  const hiddenDetails = hidden.length === 0 ? "" : `
+    <details class="closed-details">
+      <summary>${hidden.length} closed issue${hidden.length === 1 ? "" : "s"}</summary>
+      <table>
+        <tbody>${hidden.map((i) => renderIndexRow(block.tag, i)).join("\n")}</tbody>
+      </table>
+    </details>`;
+
   return `<div class="tag-block">
     <div class="tag-block-header">
       <strong>${escapeHtml(block.tag)}</strong>
@@ -548,16 +575,8 @@ function renderTagBlock(repo: string, block: TagBlock): string {
         → detail
       </a>
     </div>
-    <table>
-      <thead><tr>
-        <th class="col-check"></th>
-        <th>#</th>
-        <th>Title</th>
-        <th>State</th>
-        <th>Labels</th>
-      </tr></thead>
-      <tbody>${rows}</tbody>
-    </table>
+    ${visibleTable}
+    ${hiddenDetails}
   </div>`;
 }
 
@@ -706,6 +725,31 @@ const STYLES = `
     font-variant-numeric: tabular-nums;
   }
   .older-tags a:hover { background: #1f6feb22; }
+  details.closed-details {
+    margin-top: 8px;
+    background: #0d1117;
+    border: 1px dashed #30363d;
+    border-radius: 6px;
+  }
+  details.closed-details > summary {
+    padding: 6px 12px;
+    font-size: 12px; color: #8b949e;
+    cursor: pointer; user-select: none;
+    list-style: none;
+  }
+  details.closed-details > summary::before {
+    content: "▶";
+    display: inline-block;
+    margin-right: 6px;
+    transition: transform 0.1s;
+    font-size: 10px;
+  }
+  details.closed-details[open] > summary::before { transform: rotate(90deg); }
+  details.closed-details > summary:hover { color: #c9d1d9; }
+  details.closed-details[open] > summary {
+    color: #c9d1d9; border-bottom: 1px solid #30363d;
+  }
+  details.closed-details table { background: transparent; border: 0; }
   .lookup-header {
     font-size: 12px; font-weight: 600; text-transform: uppercase;
     letter-spacing: 0.5px; color: #8b949e;

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -243,6 +243,68 @@ describe("GET /releases", () => {
     expect(html).toContain('<form method="GET" action="/releases"');
   });
 
+  it("collapses already-closed issues into a <details> section on the index", async () => {
+    // Same minimal index-flow stub as above, but issue #2 is already closed.
+    // It must NOT be in the main <table> rows; it should live inside a
+    // <details> wrapper labeled "1 closed issue".
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
+      const url = typeof req === "string" ? req : (req as Request).url;
+      if (url.includes("/repos/ippoan/ci-dashboard/tags")) {
+        return Response.json([
+          { name: "v1.2.0", commit: { sha: "a" } },
+          { name: "v1.1.0", commit: { sha: "b" } },
+        ]);
+      }
+      if (url.includes("/repos/ippoan/ci-dashboard/compare/v1.1.0...v1.2.0")) {
+        return Response.json({
+          commits: [
+            { sha: "x", commit: { message: "feat\n\nRefs #1" } },
+            { sha: "y", commit: { message: "fix\n\nRefs #2" } },
+          ],
+        });
+      }
+      if (url.endsWith("/repos/ippoan/ci-dashboard/issues/1")) {
+        return Response.json({
+          number: 1, title: "still open", state: "open",
+          labels: [], assignees: [],
+          html_url: "https://github.com/ippoan/ci-dashboard/issues/1",
+          updated_at: "2026-05-01T00:00:00Z",
+        });
+      }
+      if (url.endsWith("/repos/ippoan/ci-dashboard/issues/2")) {
+        return Response.json({
+          number: 2, title: "already-done bug", state: "closed",
+          labels: [{ name: "bug" }], assignees: [],
+          html_url: "https://github.com/ippoan/ci-dashboard/issues/2",
+          updated_at: "2026-05-01T00:00:00Z",
+        });
+      }
+      return new Response("not stubbed", { status: 500 });
+    });
+
+    const e = testEnv({ watched: ["ippoan/ci-dashboard"] });
+    const req = new Request("http://localhost/releases");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, e, ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    // The closed issue is still on the page (so it can be expanded)…
+    expect(html).toContain("already-done bug");
+    expect(html).toContain("#2");
+    // …but wrapped in a <details> with the right summary copy.
+    expect(html).toContain('<details class="closed-details">');
+    expect(html).toContain("<summary>1 closed issue</summary>");
+    // Open issue stays in the main candidate table outside the <details>;
+    // closed issue's checkbox row is below the <details> boundary.
+    const [beforeDetails, afterDetails] = html.split('<details class="closed-details">');
+    expect(beforeDetails).toMatch(/name="pair" value="v1\.2\.0:1"/);
+    expect(beforeDetails).not.toMatch(/name="pair" value="v1\.2\.0:2"/);
+    expect(afterDetails).toMatch(/name="pair" value="v1\.2\.0:2"/);
+  });
+
   it("renders the flash banner on `?repo=X&closed=N` (post-batch-close redirect)", async () => {
     // This is the exact URL shape /api/release-close-batch redirects to.
     // The previous routing fell through to renderForm and hid the banner.


### PR DESCRIPTION
## Summary

`/releases` の各 tag block で **state=closed の issue を `<details>` 配下に折りたたみ表示**。デフォルトで非表示、summary クリックで展開。Refs #47。

## Before / After

Before: closed issue も「⚠️ already closed」警告付きで一覧に並ぶ → 確認したい open / warning 行が埋もれる
After: closed は `▶ N closed issue(s)` summary 配下、必要時だけ展開

```
ippoan/nuxt-pwa-carins
v1.0.15  since v1.0.14                    → detail

(open / warning 行が主役)

▶ 1 closed issue   ← native <details>、展開すると closed 行が出る

[✅ Close selected as released]
```

## What

- `renderTagBlock` で `block.issues` を state で split:
  - `state !== "closed"` → 既存メインテーブル
  - `state === "closed"` → 同じ row フォーマットで `<details class="closed-details">` 配下
- summary copy: `${count} closed issue${count === 1 ? "" : "s"}`
- 全 open: details なし / 全 closed: メインテーブルなし、details のみ / 混在: 両方
- 既存の repo-card 全体を包む `<form>` に依然内包されるので、展開時にチェック → batch close で「Closed by release」コメント付きで再 close も可能
- native HTML だから JS なし。dark theme に合わせ summary に rotating ▶ caret + 破線 border

## Tests

- 新規「collapses already-closed issues into a <details> section」: 1 open + 1 closed の minimal stub、`<details class="closed-details">` の存在と「1 closed issue」 summary を verify。closed checkbox が details 境界の **後** にあることまで assert。
- 既存 index test は全 stub が `state: "open"` なので影響なし。

13 files / **118 tests pass**.

## Verification

```bash
cd /home/yhonda/js/ci-dashboard
npm test
```

Manual (post-deploy):
- `/releases` を開いて closed が「▶ N closed issue」に畳まれてること
- summary クリックで開閉できること

Refs #47
Refs #35