### PR TITLE
feat: dashboard banner for unconfirmed release + /releases DO 統合 + WS 取りこぼし fallback

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -234,11 +234,60 @@ export function handleDashboard(): Response {
     .recheck-btn:disabled { opacity: 0.5; cursor: not-allowed; }
     .recheck-btn.loading { animation: pulse 1.5s infinite; }
     .btn-group { display: flex; gap: 6px; }
+
+    /* Release alert banners — appear after a Tag Release workflow completes
+       when the release range references at least one still-open issue. They
+       sit between the page title and the status bar so the operator sees
+       them as soon as they open the dashboard. */
+    .release-banners { margin-bottom: 16px; }
+    .release-banner {
+      background: #3b2c0e;
+      border: 1px solid #d29922;
+      border-left: 4px solid #d29922;
+      border-radius: 6px;
+      padding: 10px 14px;
+      margin-bottom: 8px;
+      font-size: 13px;
+      color: #e6cf80;
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    .release-banner .repo-tag {
+      font-weight: 600;
+      color: #f5deb3;
+    }
+    .release-banner .repo-tag code {
+      background: #0d1117;
+      padding: 1px 6px;
+      border-radius: 4px;
+      color: #d2a8ff;
+      font-family: monospace;
+    }
+    .release-banner .review-link {
+      color: #58a6ff;
+      text-decoration: none;
+      font-weight: 600;
+      margin-left: auto;
+    }
+    .release-banner .review-link:hover { text-decoration: underline; }
+    .release-banner .issue-chip {
+      background: #0d1117;
+      border: 1px solid #30363d;
+      border-radius: 10px;
+      padding: 1px 8px;
+      font-size: 11px;
+      color: #c9d1d9;
+      text-decoration: none;
+    }
+    .release-banner .issue-chip:hover { color: #58a6ff; border-color: #58a6ff; }
   </style>
 </head>
 <body>
   ${renderTabs("dashboard")}
   <h1>CI Dashboard</h1>
+  <div id="release-banner-list" class="release-banners"></div>
   <div class="status-bar">
     WS: <span id="sse-status" class="disconnected">connecting...</span>
     &middot; Last update: <span id="last-update">-</span>
@@ -258,9 +307,47 @@ export function handleDashboard(): Response {
     const repoList = document.getElementById("repo-list");
     const sseStatus = document.getElementById("sse-status");
     const lastUpdate = document.getElementById("last-update");
+    const bannerList = document.getElementById("release-banner-list");
 
     let lastStatuses = [];
     let activeFilter = null;
+
+    function escapeHtml(s) {
+      return String(s)
+        .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+    }
+
+    function renderBanners(alerts) {
+      if (!Array.isArray(alerts) || alerts.length === 0) {
+        bannerList.innerHTML = "";
+        return;
+      }
+      // Sort newest detectedAt first so the latest release floats to the top.
+      const sorted = [...alerts].sort((a, b) =>
+        (b.detectedAt || "").localeCompare(a.detectedAt || "")
+      );
+      bannerList.innerHTML = sorted.map(a => {
+        const reviewUrl = "/releases?repo=" + encodeURIComponent(a.repo)
+          + "&tag=" + encodeURIComponent(a.tag);
+        const chips = (a.openIssues || []).slice(0, 8).map(i =>
+          '<a class="issue-chip" href="' + escapeHtml(i.url)
+            + '" target="_blank" rel="noopener" title="' + escapeHtml(i.title) + '">'
+            + '#' + i.number + '</a>'
+        ).join("");
+        const more = (a.openIssues || []).length > 8
+          ? ' <span class="issue-chip">+' + ((a.openIssues.length) - 8) + '</span>'
+          : "";
+        const n = (a.openIssues || []).length;
+        return '<div class="release-banner">'
+          + '<span class="repo-tag">\\uD83C\\uDFF7\\uFE0F '
+          + escapeHtml(a.repo) + ' <code>' + escapeHtml(a.tag) + '</code> released</span>'
+          + chips + more
+          + '<a class="review-link" href="' + reviewUrl + '">'
+          + n + ' open related issue' + (n === 1 ? '' : 's') + ' \\u2192 review</a>'
+          + '</div>';
+      }).join("");
+    }
 
     function badgeClass(status, conclusion) {
       if (status === "completed") return conclusion || "success";
@@ -392,6 +479,42 @@ export function handleDashboard(): Response {
       }).join("");
     }
 
+    // Pull both endpoints in parallel. Used on initial connect, periodic
+    // poll (safety net for missed broadcasts), visibilitychange, and WS
+    // reconnect. Skipped while the tab is hidden to avoid wasted requests.
+    async function refreshAll() {
+      if (document.hidden) return;
+      try {
+        const [statuses, alerts] = await Promise.all([
+          fetch("/status").then(r => r.json()),
+          fetch("/release-alerts").then(r => r.json()).catch(() => []),
+        ]);
+        render(statuses);
+        renderBanners(alerts);
+        lastUpdate.textContent = new Date().toLocaleTimeString();
+      } catch {
+        // Ignore — next poll / event will retry
+      }
+    }
+
+    // Periodic safety-net poll. WS broadcasts can be missed during a network
+    // blip / CF Worker WebSocket idle timeout, so we re-fetch every 30s
+    // unconditionally while the tab is visible. Cost: 2 req/30s × visible tab.
+    let pollHandle = null;
+    function startPoll() {
+      if (pollHandle) return;
+      pollHandle = setInterval(refreshAll, 30000);
+    }
+    function stopPoll() {
+      if (pollHandle) { clearInterval(pollHandle); pollHandle = null; }
+    }
+
+    // Tab returned to foreground → catch up immediately. Covers the
+    // "PC slept overnight, dashboard is stale" case.
+    document.addEventListener("visibilitychange", () => {
+      if (!document.hidden) refreshAll();
+    });
+
     function connect() {
       const proto = location.protocol === "https:" ? "wss:" : "ws:";
       const ws = new WebSocket(proto + "//" + location.host + "/ws");
@@ -403,20 +526,35 @@ export function handleDashboard(): Response {
         pingInterval = setInterval(() => {
           if (ws.readyState === WebSocket.OPEN) ws.send("ping");
         }, 30000);
-        // Request initial data
-        fetch("/status").then(r => r.json()).then(data => {
-          render(data);
-          lastUpdate.textContent = new Date().toLocaleTimeString();
-        });
+        // Catch up + start safety-net polling
+        refreshAll();
+        startPoll();
       };
       ws.onmessage = (e) => {
         if (e.data === "pong") return;
-        const data = JSON.parse(e.data);
-        render(data);
-        lastUpdate.textContent = new Date().toLocaleTimeString();
+        try {
+          const msg = JSON.parse(e.data);
+          // Typed envelope (current server format).
+          if (msg && typeof msg === "object" && msg.type === "ci-statuses") {
+            render(msg.data);
+            lastUpdate.textContent = new Date().toLocaleTimeString();
+            return;
+          }
+          if (msg && typeof msg === "object" && msg.type === "release-alerts") {
+            renderBanners(msg.data);
+            lastUpdate.textContent = new Date().toLocaleTimeString();
+            return;
+          }
+          // Legacy fallback: bare CIStatus[] array (older Hub versions).
+          if (Array.isArray(msg)) {
+            render(msg);
+            lastUpdate.textContent = new Date().toLocaleTimeString();
+          }
+        } catch { /* ignore malformed message */ }
       };
       ws.onclose = () => {
         if (pingInterval) clearInterval(pingInterval);
+        stopPoll();
         sseStatus.textContent = "reconnecting...";
         sseStatus.className = "disconnected";
         setTimeout(connect, 3000);

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -1,11 +1,31 @@
 import { DurableObject } from "cloudflare:workers";
 import type { CIStatus, JobStatus } from "./webhook";
 import type { Env } from "./index";
+import {
+  type ReleaseAlert,
+  recomputeAlert,
+  computeReleaseAlert,
+} from "./release-alert";
+
+// WebSocket message envelope. All broadcasts now share `{ type, data }` so
+// the dashboard JS can dispatch by type. Two channels currently:
+//   - "ci-statuses"     → CIStatus[] (workflow run grid)
+//   - "release-alerts"  → ReleaseAlert[] (post-tag-release banner)
+type WsEnvelope =
+  | { type: "ci-statuses"; data: CIStatus[] }
+  | { type: "release-alerts"; data: ReleaseAlert[] };
+
+const ALERT_KEY_PREFIX = "release-alert:";
+const ALERT_TTL_SECONDS = 7 * 86400;
 
 export class CIDashboardHub extends DurableObject<Env> {
   // In-memory cache: run_id → CIStatus
   private cache = new Map<number, CIStatus>();
   private cacheLoaded = false;
+
+  // In-memory cache: "owner/name" → ReleaseAlert
+  private alerts = new Map<string, ReleaseAlert>();
+  private alertsLoaded = false;
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
@@ -27,6 +47,22 @@ export class CIDashboardHub extends DurableObject<Env> {
       }
     }
     this.cacheLoaded = true;
+  }
+
+  private async ensureAlerts(): Promise<void> {
+    if (this.alertsLoaded) return;
+    const list = await this.env.CI_STATUS.list({ prefix: ALERT_KEY_PREFIX });
+    const values = await Promise.all(
+      list.keys.map((key) => this.env.CI_STATUS.get(key.name))
+    );
+    for (const v of values) {
+      if (!v) continue;
+      try {
+        const a = JSON.parse(v) as ReleaseAlert;
+        this.alerts.set(a.repo, a);
+      } catch { /* skip corrupt entry */ }
+    }
+    this.alertsLoaded = true;
   }
 
   private computeStatuses(): CIStatus[] {
@@ -81,6 +117,53 @@ export class CIDashboardHub extends DurableObject<Env> {
       await this.ensureCache();
       const statuses = this.computeStatuses();
       return Response.json(statuses);
+    }
+
+    // All release alerts from in-memory cache (for /release-alerts endpoint).
+    if (url.pathname === "/release-alerts") {
+      await this.ensureAlerts();
+      return Response.json([...this.alerts.values()]);
+    }
+
+    // Compute alert for a tag release that just shipped, store + broadcast.
+    // Called from webhook.ts after a `Tag Release` workflow_run completes.
+    if (url.pathname === "/release-alert-detect") {
+      const { repo, tag } = await request.json<{ repo: string; tag?: string }>();
+      await this.ensureAlerts();
+      try {
+        const alert = await computeReleaseAlert(this.env.GITHUB_TOKEN, repo, tag);
+        this.persistAlert(repo, alert);
+        this.broadcastAlerts();
+      } catch {
+        // Best-effort: a failed compute (e.g. token rate-limit) leaves any
+        // existing alert in place rather than wiping it.
+      }
+      return new Response("OK");
+    }
+
+    // Recompute alert for a repo whose state changed elsewhere (e.g. an
+    // operator just closed issues via /api/release-close{,-batch}). Drops
+    // the alert when no open issues remain.
+    if (url.pathname === "/release-alert-recompute") {
+      const { repo } = await request.json<{ repo: string }>();
+      await this.ensureAlerts();
+      const existing = this.alerts.get(repo);
+      if (!existing) {
+        // Nothing to recompute — but still broadcast an empty alerts list
+        // is unnecessary because nothing changed for the client.
+        return new Response("OK");
+      }
+      try {
+        const fresh = await recomputeAlert(
+          this.env.GITHUB_TOKEN, repo, existing.tag,
+        );
+        this.persistAlert(repo, fresh);
+        this.broadcastAlerts();
+      } catch {
+        // Leave the existing alert in place; the periodic dashboard poll
+        // will eventually pick up the right state.
+      }
+      return new Response("OK");
     }
 
     if (url.pathname === "/update-run") {
@@ -229,9 +312,38 @@ export class CIDashboardHub extends DurableObject<Env> {
     );
   }
 
+  // Persist (or delete, when fresh is null) the alert. Same KV-fire-and-forget
+  // pattern as the run cache. Caller is responsible for calling broadcast
+  // afterward.
+  private persistAlert(repo: string, fresh: ReleaseAlert | null): void {
+    const key = `${ALERT_KEY_PREFIX}${repo}`;
+    if (fresh === null) {
+      this.alerts.delete(repo);
+      this.ctx.waitUntil(this.env.CI_STATUS.delete(key));
+    } else {
+      this.alerts.set(repo, fresh);
+      this.ctx.waitUntil(
+        this.env.CI_STATUS.put(key, JSON.stringify(fresh), {
+          expirationTtl: ALERT_TTL_SECONDS,
+        }),
+      );
+    }
+  }
+
   private broadcastFromCache(): void {
     const statuses = this.computeStatuses();
-    this.broadcast(JSON.stringify(statuses));
+    this.broadcastEnvelope({ type: "ci-statuses", data: statuses });
+  }
+
+  private broadcastAlerts(): void {
+    this.broadcastEnvelope({
+      type: "release-alerts",
+      data: [...this.alerts.values()],
+    });
+  }
+
+  private broadcastEnvelope(envelope: WsEnvelope): void {
+    this.broadcast(JSON.stringify(envelope));
   }
 
   broadcast(data: string): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,8 +37,12 @@ app.get("/issues", (c) => handleIssuesPage(c.env));
 // Release confirmation view (SSR + POST close action)
 // See issue #35 + CLAUDE.md `release / close フロー`.
 app.get("/releases", (c) => handleReleasesPage(c.req.raw, c.env));
-app.post("/api/release-close", (c) => handleReleaseClose(c.req.raw, c.env));
-app.post("/api/release-close-batch", (c) => handleReleaseCloseBatch(c.req.raw, c.env));
+// Pass hub + executionCtx so the close handlers can fire-and-forget a
+// `/release-alert-recompute` to refresh the dashboard banner.
+app.post("/api/release-close",
+  (c) => handleReleaseClose(c.req.raw, c.env, getHub(c.env), c.executionCtx));
+app.post("/api/release-close-batch",
+  (c) => handleReleaseCloseBatch(c.req.raw, c.env, getHub(c.env), c.executionCtx));
 
 // WebSocket
 app.get("/ws", (c) => getHub(c.env).fetch(c.req.raw));
@@ -49,6 +53,19 @@ app.post("/webhook", (c) => handleWebhook(c.req.raw, c.env, getHub(c.env)));
 // Status
 app.get("/status", async (c) => {
   const res = await getHub(c.env).fetch(new Request("http://hub/statuses"));
+  const body = await res.text();
+  return new Response(body, {
+    headers: {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+});
+
+// Release banner alerts (consumed by dashboard JS for the post-tag-release
+// banner). Same proxy pattern as /status — Hub holds the in-memory cache.
+app.get("/release-alerts", async (c) => {
+  const res = await getHub(c.env).fetch(new Request("http://hub/release-alerts"));
   const body = await res.text();
   return new Response(body, {
     headers: {

--- a/src/release-alert.ts
+++ b/src/release-alert.ts
@@ -1,0 +1,187 @@
+// Release alert computation.
+//
+// Shared between `releases-page.ts` (which renders all referenced issues —
+// open + closed — for the operator's confirmation table) and `webhook.ts`
+// (which only cares about *open* issues to decide whether the dashboard
+// banner should appear after a tag release).
+//
+// The two halves below split that pipeline:
+//   - collectIssueNumbersForRange: walks a tag's compare range, harvests
+//     `Refs #N`, PR numbers and branch-prefixed issue numbers into a Set.
+//   - fetchIssuesByNumbers: hydrates those numbers into RawIssue records
+//     (PRs filtered out at the caller).
+//   - computeReleaseAlert: convenience wrapper that picks the latest semver
+//     tag for a repo, runs both steps, and returns ReleaseAlert | null.
+//
+// The split lets the SSR `loadRelease()` reuse the heavy GitHub fan-out
+// without forcing the alert path to recompute warnings / labels / assignees
+// it doesn't show.
+
+import {
+  githubApi,
+  parseRepo,
+  validateOrg,
+  GitHubApiError,
+} from "./github-api";
+import {
+  extractRefIssues,
+  extractPrNumber,
+  extractBranchIssue,
+  sortSemverDesc,
+  previousTag,
+} from "./release-helpers";
+
+export interface ReleaseAlert {
+  repo: string;          // "owner/name"
+  tag: string;
+  prevTag: string | null;
+  openIssues: Array<{ number: number; title: string; url: string }>;
+  detectedAt: string;    // ISO
+}
+
+interface TagListItem { name: string; commit: { sha: string } }
+interface RawCommit { sha: string; commit: { message: string } }
+interface CompareResponse { commits: RawCommit[] }
+interface PrResponse { head: { ref: string }; body: string | null }
+export interface RawIssue {
+  number: number;
+  title: string;
+  state: string;
+  labels: Array<{ name: string }>;
+  assignees: Array<{ login: string }>;
+  html_url: string;
+  updated_at: string;
+  pull_request?: unknown;
+}
+
+// Walk the commits introduced by `tag` (using compare against `prevTag` when
+// available, otherwise a bounded log walk for the first-ever release) and
+// collect every issue number we can attribute to those commits.
+export async function collectIssueNumbersForRange(
+  token: string,
+  owner: string,
+  name: string,
+  tag: string,
+  prevTag: string | null,
+): Promise<{ issueNumbers: Set<number>; commitCount: number }> {
+  const commits = prevTag
+    ? (await githubApi<CompareResponse>(
+        token, "GET", `/repos/${owner}/${name}/compare/${prevTag}...${tag}`,
+      )).commits
+    : await githubApi<RawCommit[]>(
+        token, "GET", `/repos/${owner}/${name}/commits`, undefined,
+        { sha: tag, per_page: "50" },
+      );
+
+  const issueNumbers = new Set<number>();
+  const prNumbers = new Set<number>();
+  for (const c of commits) {
+    const msg = c.commit.message;
+    for (const n of extractRefIssues(msg)) issueNumbers.add(n);
+    const pr = extractPrNumber(msg);
+    if (pr !== null) prNumbers.add(pr);
+  }
+
+  // PR follow-up pass: head.ref (branch name) and body carry refs that the
+  // squash-merge subject line drops.
+  await Promise.all([...prNumbers].map(async (n) => {
+    try {
+      const pr = await githubApi<PrResponse>(
+        token, "GET", `/repos/${owner}/${name}/pulls/${n}`,
+      );
+      const fromBranch = extractBranchIssue(pr.head.ref);
+      if (fromBranch !== null) issueNumbers.add(fromBranch);
+      if (pr.body) {
+        for (const ref of extractRefIssues(pr.body)) issueNumbers.add(ref);
+      }
+    } catch { /* ignore per-PR failure */ }
+  }));
+
+  return { issueNumbers, commitCount: commits.length };
+}
+
+// Hydrate a set of issue numbers into RawIssue records. PRs are NOT filtered
+// here — callers do that with the `pull_request` discriminator so they can
+// decide between dropping vs. logging.
+export async function fetchIssuesByNumbers(
+  token: string,
+  owner: string,
+  name: string,
+  numbers: Iterable<number>,
+): Promise<RawIssue[]> {
+  const results = await Promise.all([...numbers].map(async (n) => {
+    try {
+      return await githubApi<RawIssue>(
+        token, "GET", `/repos/${owner}/${name}/issues/${n}`,
+      );
+    } catch {
+      return null;
+    }
+  }));
+  return results.filter((i): i is RawIssue => i !== null);
+}
+
+// Convenience wrapper: pick the latest semver tag (when not supplied),
+// compute the alert payload, return null when no open issues are referenced
+// (banner suppressed).
+export async function computeReleaseAlert(
+  token: string,
+  repo: string,
+  tagOverride?: string,
+): Promise<ReleaseAlert | null> {
+  const { owner, repo: name } = parseRepo(repo);
+  validateOrg(owner);
+
+  const tags = await githubApi<TagListItem[]>(
+    token, "GET", `/repos/${owner}/${name}/tags`, undefined,
+    { per_page: "30" },
+  );
+  const tagNames = tags.map((t) => t.name);
+  if (tagNames.length === 0) return null;
+
+  const sorted = sortSemverDesc(tagNames);
+  const tag = tagOverride ?? sorted[0]!;
+
+  // If caller passed a tag we don't recognize, surface as 404 — alert
+  // computation is best-effort, not a synchronization layer.
+  if (!tagNames.includes(tag)) {
+    throw new GitHubApiError(
+      404,
+      `Tag "${tag}" not present in ${owner}/${name} (recent ${tagNames.length} tags scanned)`,
+    );
+  }
+
+  const prevTag = previousTag(sorted, tag);
+  const { issueNumbers } = await collectIssueNumbersForRange(
+    token, owner, name, tag, prevTag,
+  );
+
+  if (issueNumbers.size === 0) return null;
+
+  const issues = await fetchIssuesByNumbers(token, owner, name, issueNumbers);
+  const openIssues = issues
+    .filter((i) => !i.pull_request && i.state === "open")
+    .map((i) => ({ number: i.number, title: i.title, url: i.html_url }))
+    .sort((a, b) => a.number - b.number);
+
+  if (openIssues.length === 0) return null;
+
+  return {
+    repo: `${owner}/${name}`,
+    tag,
+    prevTag,
+    openIssues,
+    detectedAt: new Date().toISOString(),
+  };
+}
+
+// Recompute alert against current GitHub state and return null when there
+// are no open referenced issues left (banner should clear). Used by the
+// release-close path so a successful close immediately drops the banner.
+export async function recomputeAlert(
+  token: string,
+  repo: string,
+  tag: string,
+): Promise<ReleaseAlert | null> {
+  return computeReleaseAlert(token, repo, tag);
+}

--- a/src/release-close-batch.ts
+++ b/src/release-close-batch.ts
@@ -17,6 +17,8 @@ const PAIR_RE = /^(.+):(\d+)$/;
 export async function handleReleaseCloseBatch(
   req: Request,
   env: { GITHUB_TOKEN: string },
+  hub?: DurableObjectStub,
+  ctx?: ExecutionContext,
 ): Promise<Response> {
   if (req.method !== "POST") {
     return new Response("Method Not Allowed", { status: 405 });
@@ -88,6 +90,18 @@ export async function handleReleaseCloseBatch(
     if (r.status === "fulfilled") closed.push(r.value);
     else failed.push(ops[i]!.issue);
   });
+
+  // Kick Hub to recompute alert state for this repo when at least one close
+  // succeeded. Same waitUntil pattern as release-close.ts so the redirect
+  // stays snappy and the dashboard banner updates asynchronously.
+  if (hub && closed.length > 0) {
+    const recompute = hub.fetch(new Request("http://hub/release-alert-recompute", {
+      method: "POST",
+      body: JSON.stringify({ repo: repoParam }),
+    }));
+    if (ctx) ctx.waitUntil(recompute);
+    else { void recompute; }
+  }
 
   const params = new URLSearchParams({ repo: repoParam });
   if (closed.length > 0) params.set("closed", closed.join(","));

--- a/src/release-close.ts
+++ b/src/release-close.ts
@@ -14,6 +14,8 @@ import { githubApi, parseRepo, validateOrg } from "./github-api";
 export async function handleReleaseClose(
   req: Request,
   env: { GITHUB_TOKEN: string },
+  hub?: DurableObjectStub,
+  ctx?: ExecutionContext,
 ): Promise<Response> {
   if (req.method !== "POST") {
     return new Response("Method Not Allowed", { status: 405 });
@@ -69,6 +71,18 @@ export async function handleReleaseClose(
     if (r.status === "fulfilled") closed.push(r.value);
     else failed.push(issueNumbers[i]!);
   });
+
+  // Kick the Hub to recompute the banner alert state for this repo when at
+  // least one issue actually closed. waitUntil keeps the user-facing redirect
+  // snappy — the banner update can land asynchronously.
+  if (hub && closed.length > 0) {
+    const recompute = hub.fetch(new Request("http://hub/release-alert-recompute", {
+      method: "POST",
+      body: JSON.stringify({ repo: repoParam }),
+    }));
+    if (ctx) ctx.waitUntil(recompute);
+    else { void recompute; }  // tests / cases without ctx: fire-and-forget
+  }
 
   const params = new URLSearchParams({ repo: repoParam, tag });
   if (closed.length > 0) params.set("closed", closed.join(","));

--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -1,12 +1,14 @@
 import { githubApi, parseRepo, validateOrg, GitHubApiError } from "./github-api";
 import {
   extractRefIssues,
-  extractPrNumber,
-  extractBranchIssue,
   sortSemverDesc,
   previousTag,
   computeWarnings,
 } from "./release-helpers";
+import {
+  collectIssueNumbersForRange,
+  fetchIssuesByNumbers,
+} from "./release-alert";
 import { renderTabs, TAB_STYLES } from "./nav-tabs";
 
 // `/releases` (no params) renders a list of "recent releases" — every watched
@@ -249,58 +251,19 @@ async function loadRelease(
   }
   const prev = previousTag(sortSemverDesc(tagNames), tag);
 
-  // 2. Get the commits introduced by this tag. With a previous tag we use
-  //    GitHub's compare endpoint (it stops at the merge base); without one
-  //    (first release ever) we bound to 50 commits walking back from `tag`.
-  const commits = prev
-    ? (await githubApi<CompareResponse>(
-        token, "GET", `/repos/${owner}/${name}/compare/${prev}...${tag}`,
-      )).commits
-    : await githubApi<RawCommit[]>(
-        token, "GET", `/repos/${owner}/${name}/commits`, undefined,
-        { sha: tag, per_page: "50" },
-      );
+  // 2. Walk the tag's compare range to harvest every issue number we can
+  //    attribute (Refs in commit message, PR body, branch prefix). Shared
+  //    with the dashboard banner path so the two views stay in lockstep.
+  const { issueNumbers, commitCount } = await collectIssueNumbersForRange(
+    token, owner, name, tag, prev,
+  );
 
-  // 3. Harvest issue numbers from commit messages directly, and collect the
-  //    PR numbers so we can do a second pass for branch-name + PR-body refs.
-  const issueNumbers = new Set<number>();
-  const prNumbers = new Set<number>();
-  for (const c of commits) {
-    const msg = c.commit.message;
-    for (const n of extractRefIssues(msg)) issueNumbers.add(n);
-    const pr = extractPrNumber(msg);
-    if (pr !== null) prNumbers.add(pr);
-  }
+  // 3. Hydrate candidates. The /issues/:n endpoint also returns PRs, so we
+  //    filter those out below (PRs carry a `pull_request` discriminator).
+  const issues = await fetchIssuesByNumbers(token, owner, name, issueNumbers);
 
-  // 4. Re-fetch each PR for its head.ref (branch name) and body. We swallow
-  //    per-PR failures so a missing/deleted PR doesn't sink the whole page.
-  await Promise.all([...prNumbers].map(async (n) => {
-    try {
-      const pr = await githubApi<PrResponse>(
-        token, "GET", `/repos/${owner}/${name}/pulls/${n}`,
-      );
-      const fromBranch = extractBranchIssue(pr.head.ref);
-      if (fromBranch !== null) issueNumbers.add(fromBranch);
-      if (pr.body) {
-        for (const ref of extractRefIssues(pr.body)) issueNumbers.add(ref);
-      }
-    } catch { /* ignore per-PR failure */ }
-  }));
-
-  // 5. Fetch each candidate issue. The /issues/:n endpoint also returns PRs,
-  //    so we filter those out (PRs have a `pull_request` discriminator).
-  const issueResults = await Promise.all([...issueNumbers].map(async (n) => {
-    try {
-      return await githubApi<RawIssue>(
-        token, "GET", `/repos/${owner}/${name}/issues/${n}`,
-      );
-    } catch {
-      return null;
-    }
-  }));
-
-  const rows: IssueRow[] = issueResults
-    .filter((i): i is RawIssue => i !== null && !i.pull_request)
+  const rows: IssueRow[] = issues
+    .filter((i) => !i.pull_request)
     .map((i) => {
       const labels = i.labels.map((l) => l.name);
       return {
@@ -320,7 +283,7 @@ async function loadRelease(
     repo: `${owner}/${name}`,
     tag,
     previousTag: prev,
-    commits: commits.length,
+    commits: commitCount,
     rows,
   };
 }
@@ -328,7 +291,6 @@ async function loadRelease(
 interface TagListItem { name: string; commit: { sha: string } }
 interface RawCommit { sha: string; commit: { message: string } }
 interface CompareResponse { commits: RawCommit[] }
-interface PrResponse { head: { ref: string }; body: string | null }
 interface RawIssue {
   number: number;
   title: string;

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -107,6 +107,23 @@ export async function handleWebhook(
         repo: payload.repository.full_name,
       }),
     }));
+
+    // Side channel: a successful `Tag Release` workflow run means a new tag
+    // was just pushed. Trigger alert computation in the Hub so the dashboard
+    // banner can flag any open `Refs #N` issues that the operator forgot to
+    // close. We don't await the response — alert compute fans out to GitHub
+    // and we don't want it blocking webhook delivery.
+    if (
+      payload.action === "completed" &&
+      payload.workflow_run.name === "Tag Release" &&
+      payload.workflow_run.conclusion === "success"
+    ) {
+      await hub.fetch(new Request("http://hub/release-alert-detect", {
+        method: "POST",
+        body: JSON.stringify({ repo: payload.repository.full_name }),
+      }));
+    }
+
     return new Response("OK", { status: 200 });
   }
 

--- a/test/release-alert.test.ts
+++ b/test/release-alert.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { computeReleaseAlert, recomputeAlert } from "../src/release-alert";
+
+// `computeReleaseAlert` fans out to several GitHub endpoints; we stub
+// globalThis.fetch and route by URL. Each test sets up a fixture map so the
+// assertions read like a script of "given these tags / commits / issues,
+// expect this alert payload".
+
+interface Fixture {
+  tags?: Array<{ name: string }>;
+  compare?: Record<string, { commits: Array<{ commit: { message: string } }> }>;
+  pulls?: Record<number, { head: { ref: string }; body: string | null }>;
+  issues?: Record<number, {
+    number: number;
+    title: string;
+    state: string;
+    labels: Array<{ name: string }>;
+    assignees: Array<{ login: string }>;
+    html_url: string;
+    updated_at: string;
+    pull_request?: unknown;
+  }>;
+}
+
+function stubGithub(fx: Fixture) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    const u = new URL(url);
+    const path = u.pathname;
+
+    if (path.endsWith("/tags")) {
+      return Response.json(fx.tags ?? []);
+    }
+    const cmp = path.match(/\/compare\/(.+?)\.\.\.(.+)$/);
+    if (cmp) {
+      const key = `${cmp[1]}...${cmp[2]}`;
+      return Response.json(fx.compare?.[key] ?? { commits: [] });
+    }
+    const prMatch = path.match(/\/pulls\/(\d+)$/);
+    if (prMatch) {
+      const n = Number(prMatch[1]);
+      const pr = fx.pulls?.[n];
+      if (!pr) return new Response("not found", { status: 404 });
+      return Response.json(pr);
+    }
+    const issueMatch = path.match(/\/issues\/(\d+)$/);
+    if (issueMatch) {
+      const n = Number(issueMatch[1]);
+      const issue = fx.issues?.[n];
+      if (!issue) return new Response("not found", { status: 404 });
+      return Response.json(issue);
+    }
+    return new Response("unstubbed: " + path, { status: 500 });
+  });
+}
+
+function openIssue(n: number, title = `issue ${n}`) {
+  return {
+    number: n, title, state: "open",
+    labels: [], assignees: [],
+    html_url: `https://github.com/ippoan/foo/issues/${n}`,
+    updated_at: "2026-05-01T00:00:00Z",
+  };
+}
+function closedIssue(n: number, title = `issue ${n}`) {
+  return { ...openIssue(n, title), state: "closed" };
+}
+
+describe("computeReleaseAlert", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("returns null when the repo has no tags", async () => {
+    stubGithub({ tags: [] });
+    const result = await computeReleaseAlert("token", "ippoan/foo");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the latest tag's commits reference no issues", async () => {
+    stubGithub({
+      tags: [{ name: "v1.1.0" }, { name: "v1.0.0" }],
+      compare: {
+        "v1.0.0...v1.1.0": { commits: [{ commit: { message: "feat: noop" } }] },
+      },
+    });
+    const result = await computeReleaseAlert("token", "ippoan/foo");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when every referenced issue is already closed", async () => {
+    stubGithub({
+      tags: [{ name: "v1.1.0" }, { name: "v1.0.0" }],
+      compare: {
+        "v1.0.0...v1.1.0": {
+          commits: [{ commit: { message: "feat: thing\nRefs #42" } }],
+        },
+      },
+      issues: { 42: closedIssue(42) },
+    });
+    const result = await computeReleaseAlert("token", "ippoan/foo");
+    expect(result).toBeNull();
+  });
+
+  it("returns alert with open issues for the latest tag (no override)", async () => {
+    stubGithub({
+      tags: [{ name: "v1.2.0" }, { name: "v1.1.0" }, { name: "v1.0.0" }],
+      compare: {
+        "v1.1.0...v1.2.0": {
+          commits: [
+            { commit: { message: "feat: x\nRefs #10\nRefs #11" } },
+            { commit: { message: "fix: y\nRefs #12" } },
+          ],
+        },
+      },
+      issues: {
+        10: openIssue(10, "open one"),
+        11: closedIssue(11, "already closed"),
+        12: openIssue(12, "open two"),
+      },
+    });
+    const result = await computeReleaseAlert("token", "ippoan/foo");
+    expect(result).not.toBeNull();
+    expect(result!.repo).toBe("ippoan/foo");
+    expect(result!.tag).toBe("v1.2.0");
+    expect(result!.prevTag).toBe("v1.1.0");
+    expect(result!.openIssues.map((i) => i.number)).toEqual([10, 12]);
+    expect(result!.openIssues[0]!.title).toBe("open one");
+    expect(result!.openIssues[0]!.url).toBe("https://github.com/ippoan/foo/issues/10");
+    // detectedAt is an ISO timestamp produced at compute time
+    expect(() => new Date(result!.detectedAt).toISOString()).not.toThrow();
+  });
+
+  it("respects an explicit tag override (older release)", async () => {
+    stubGithub({
+      tags: [{ name: "v2.0.0" }, { name: "v1.2.0" }, { name: "v1.1.0" }],
+      compare: {
+        "v1.1.0...v1.2.0": {
+          commits: [{ commit: { message: "feat: q\nRefs #99" } }],
+        },
+      },
+      issues: { 99: openIssue(99) },
+    });
+    const result = await computeReleaseAlert("token", "ippoan/foo", "v1.2.0");
+    expect(result?.tag).toBe("v1.2.0");
+    expect(result?.openIssues[0]?.number).toBe(99);
+  });
+
+  it("throws on unknown tag override", async () => {
+    stubGithub({
+      tags: [{ name: "v1.0.0" }],
+    });
+    await expect(
+      computeReleaseAlert("token", "ippoan/foo", "v9.9.9"),
+    ).rejects.toThrow(/Tag .* not present/);
+  });
+
+  it("rejects disallowed orgs", async () => {
+    await expect(
+      computeReleaseAlert("token", "evil-org/foo"),
+    ).rejects.toThrow(/Org not allowed/);
+  });
+
+  it("falls back to commit walk when no previous tag exists (first release)", async () => {
+    // Stub `/commits` (the first-release branch) instead of /compare.
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const u = new URL(url);
+      const path = u.pathname;
+      if (path.endsWith("/tags")) return Response.json([{ name: "v1.0.0" }]);
+      if (path.endsWith("/commits")) {
+        return Response.json([{ commit: { message: "feat: bootstrap\nRefs #1" } }]);
+      }
+      const issueMatch = path.match(/\/issues\/(\d+)$/);
+      if (issueMatch) return Response.json(openIssue(Number(issueMatch[1])));
+      return new Response("unstubbed", { status: 500 });
+    });
+    const result = await computeReleaseAlert("token", "ippoan/foo");
+    expect(result?.openIssues.map((i) => i.number)).toEqual([1]);
+  });
+
+  it("filters out PR records that share issue numbers", async () => {
+    stubGithub({
+      tags: [{ name: "v1.1.0" }, { name: "v1.0.0" }],
+      compare: {
+        "v1.0.0...v1.1.0": {
+          commits: [{ commit: { message: "fix: x\nRefs #50\nRefs #51" } }],
+        },
+      },
+      issues: {
+        50: openIssue(50),
+        // #51 is actually a PR (carries pull_request discriminator) — must be dropped
+        51: { ...openIssue(51), pull_request: { url: "x" } },
+      },
+    });
+    const result = await computeReleaseAlert("token", "ippoan/foo");
+    expect(result?.openIssues.map((i) => i.number)).toEqual([50]);
+  });
+});
+
+describe("recomputeAlert", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("delegates to computeReleaseAlert with explicit tag", async () => {
+    stubGithub({
+      tags: [{ name: "v1.1.0" }, { name: "v1.0.0" }],
+      compare: {
+        "v1.0.0...v1.1.0": {
+          commits: [{ commit: { message: "fix\nRefs #7" } }],
+        },
+      },
+      issues: { 7: openIssue(7) },
+    });
+    const fresh = await recomputeAlert("token", "ippoan/foo", "v1.1.0");
+    expect(fresh?.tag).toBe("v1.1.0");
+    expect(fresh?.openIssues[0]?.number).toBe(7);
+  });
+
+  it("returns null when the previously-tracked issues are now all closed", async () => {
+    stubGithub({
+      tags: [{ name: "v1.1.0" }, { name: "v1.0.0" }],
+      compare: {
+        "v1.0.0...v1.1.0": {
+          commits: [{ commit: { message: "fix\nRefs #7" } }],
+        },
+      },
+      issues: { 7: closedIssue(7) },
+    });
+    const fresh = await recomputeAlert("token", "ippoan/foo", "v1.1.0");
+    expect(fresh).toBeNull();
+  });
+});

--- a/test/status.test.ts
+++ b/test/status.test.ts
@@ -6,11 +6,24 @@ import type { CIStatus } from "../src/webhook";
 
 const WEBHOOK_SECRET = "test-secret";
 
-// Mock Hub that supports /statuses by reading from KV (like the real Hub's ensureCache)
+// Mock Hub that supports /statuses + /release-alerts by reading from KV
+// (like the real Hub's ensureCache + ensureAlerts).
 function mockHub(kv: KVNamespace): DurableObjectStub {
   return {
     fetch: async (req: Request) => {
       const url = new URL(req.url);
+
+      // Banner endpoint: parses release-alert:* keys and returns the cached
+      // payload list. Mirrors Hub.ensureAlerts() shape.
+      if (url.pathname === "/release-alerts") {
+        const list = await kv.list({ prefix: "release-alert:" });
+        const values = await Promise.all(list.keys.map((k) => kv.get(k.name)));
+        const alerts = values
+          .filter((v): v is string => v !== null)
+          .map((v) => JSON.parse(v));
+        return Response.json(alerts);
+      }
+
       if (url.pathname === "/statuses") {
         const list = await kv.list({ prefix: "run:" });
         const values = await Promise.all(
@@ -123,6 +136,45 @@ describe("GET /", () => {
     const html = await res.text();
     expect(html).toContain("CI Dashboard");
     expect(html).toContain("WebSocket");
+    // Banner mount point + supporting JS must be present.
+    expect(html).toContain('id="release-banner-list"');
+    expect(html).toContain("renderBanners");
+    // Polling fallback wiring.
+    expect(html).toContain("refreshAll");
+    expect(html).toContain("visibilitychange");
+  });
+});
+
+describe("GET /release-alerts", () => {
+  it("returns empty list when no alerts cached", async () => {
+    const req = new Request("http://localhost/release-alerts");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/json");
+    const data = await res.json();
+    expect(data).toEqual([]);
+  });
+
+  it("returns cached alerts from KV", async () => {
+    await env.CI_STATUS.put("release-alert:ippoan/foo", JSON.stringify({
+      repo: "ippoan/foo",
+      tag: "v1.2.3",
+      prevTag: "v1.2.2",
+      openIssues: [{ number: 42, title: "still open", url: "https://example.com/42" }],
+      detectedAt: "2026-05-12T10:00:00Z",
+    }));
+
+    const req = new Request("http://localhost/release-alerts");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+    const data: Array<{ repo: string; tag: string; openIssues: unknown[] }> = await res.json();
+    expect(data).toHaveLength(1);
+    expect(data[0]!.repo).toBe("ippoan/foo");
+    expect(data[0]!.tag).toBe("v1.2.3");
+    expect(data[0]!.openIssues).toHaveLength(1);
   });
 });
 

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -1,5 +1,5 @@
 import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import worker from "../src/index";
 import type { Env } from "../src/index";
 import type { CIStatus, JobStatus } from "../src/webhook";
@@ -42,11 +42,32 @@ function makePayload(overrides: Record<string, unknown> = {}) {
   });
 }
 
+// Tracks calls forwarded to the Hub. Tests use this to assert that side
+// effects (e.g. release-alert-detect on a Tag Release completion) actually
+// fire on top of the primary update-run path.
+const hubCalls: Array<{ path: string; body: unknown }> = [];
+
+function resetHubCalls() { hubCalls.length = 0; }
+
 // Mock Hub DO that performs KV operations like the real Hub
 function mockHub(kv: KVNamespace): DurableObjectStub {
   return {
     fetch: async (req: Request) => {
       const url = new URL(req.url);
+      // Record every dispatch for cross-handler assertions. Body is best-effort
+      // — non-JSON requests are kept as raw text.
+      try {
+        const text = await req.clone().text();
+        let parsed: unknown = text;
+        try { parsed = JSON.parse(text); } catch { /* keep raw */ }
+        hubCalls.push({ path: url.pathname, body: parsed });
+      } catch { /* ignore */ }
+
+      if (url.pathname === "/release-alert-detect") {
+        // Side-channel for Tag Release completion. The real Hub fans out to
+        // GitHub; the mock just acks.
+        return new Response("OK");
+      }
 
       if (url.pathname === "/update-run") {
         const payload = await req.json() as {
@@ -133,6 +154,8 @@ function testEnv(): Env {
 }
 
 describe("POST /webhook", () => {
+  beforeEach(() => { resetHubCalls(); });
+
   it("rejects missing signature", async () => {
     const req = new Request("http://localhost/webhook", {
       method: "POST",
@@ -370,5 +393,96 @@ describe("POST /webhook", () => {
     );
     await waitOnExecutionContext(ctx);
     expect(res.status).toBe(200);
+  });
+
+  // Tag Release detection: when the `Tag Release` workflow finishes
+  // successfully we side-channel a /release-alert-detect to the Hub so the
+  // dashboard banner can pick up any open `Refs #N` issues.
+  it("triggers release-alert-detect on a successful Tag Release completion", async () => {
+    const body = makePayload({
+      action: "completed",
+      workflow_run: {
+        id: 77777, name: "Tag Release", head_branch: "main",
+        status: "completed", conclusion: "success",
+        html_url: "https://github.com/ippoan/foo/actions/runs/77777",
+        actor: { login: "yhonda" },
+        updated_at: "2026-05-12T10:00:00Z",
+        run_started_at: "2026-05-12T09:59:00Z",
+      },
+      repository: { full_name: "ippoan/foo" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST",
+        body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "workflow_run" },
+      }),
+      testEnv(),
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(200);
+
+    const detectCalls = hubCalls.filter((c) => c.path === "/release-alert-detect");
+    expect(detectCalls.length).toBe(1);
+    expect(detectCalls[0]!.body).toMatchObject({ repo: "ippoan/foo" });
+  });
+
+  it("does NOT trigger release-alert-detect for non-Tag-Release workflows", async () => {
+    const body = makePayload({
+      action: "completed",
+      workflow_run: {
+        id: 11111, name: "CI", head_branch: "main",
+        status: "completed", conclusion: "success",
+        html_url: "https://github.com/ippoan/foo/actions/runs/11111",
+        actor: { login: "yhonda" },
+        updated_at: "2026-05-12T10:00:00Z",
+        run_started_at: "2026-05-12T09:59:00Z",
+      },
+      repository: { full_name: "ippoan/foo" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST",
+        body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "workflow_run" },
+      }),
+      testEnv(),
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(hubCalls.filter((c) => c.path === "/release-alert-detect")).toHaveLength(0);
+  });
+
+  it("does NOT trigger release-alert-detect for failed Tag Release runs", async () => {
+    const body = makePayload({
+      action: "completed",
+      workflow_run: {
+        id: 22222, name: "Tag Release", head_branch: "main",
+        status: "completed", conclusion: "failure",
+        html_url: "https://github.com/ippoan/foo/actions/runs/22222",
+        actor: { login: "yhonda" },
+        updated_at: "2026-05-12T10:00:00Z",
+        run_started_at: "2026-05-12T09:59:00Z",
+      },
+      repository: { full_name: "ippoan/foo" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST",
+        body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "workflow_run" },
+      }),
+      testEnv(),
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(hubCalls.filter((c) => c.path === "/release-alert-detect")).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## 概要 (Refs #49)

`/releases` を Durable Object 基盤に統合し、`/` (dashboard) に **tag release 後の未 close issue バナー** を追加します。WS push 取りこぼし対策 (既存 dashboard の stale 問題) も同 PR で修正。

## 機能

### 1. Dashboard banner

`Tag Release` workflow_run が成功すると、その release range の commits から `Refs #N` で引かれている **open issue** を抽出し、dashboard ヘッダ直下にバナーを表示:

```
🏷️ ippoan/foo v1.2.3 released  [#10] [#12]  3 open related issues → review
```

リンク先 `/releases?repo=X&tag=Y` で従来通り close 操作。close すると Hub broadcast で他タブ dashboard も **DOM 部分更新** (page reload なし)。

### 2. WS 取りこぼし対策

既存 dashboard の "WS 切断中に webhook が来ても気付けない" 問題を 3 段構えで修正:

- 30s 周期 polling (visible tab のみ)
- `visibilitychange` 即時再取得 (PC スリープ後の stale 解消)
- WS 再接続時の即時再取得 (既存挙動を統一化)

### 3. /releases DO 統合 (server-side のみ)

`/releases` ページ自体に WS 接続は張らず、close 操作が Hub の recompute を kick することで dashboard 側のバナー state を最新化。

## 設計判断

- **トリガー**: 既存配信 `workflow_run` の `Tag Release` 完了を再利用 — webhook 設定変更不要。手動 `gh release create` は範囲外 (後追い PR で `release` event 対応可)
- **Banner dismiss**: open 数 0 で auto-dismiss。手動 dismiss 機構なし
- **WS envelope**: legacy array → typed `{type, data}` に切替。dashboard JS 側で legacy fallback 残置
- **DO migration**: 不要 (新クラス無し、既存 `CIDashboardHub` を拡張)

## 主な変更 file

| File | 役割 |
|---|---|
| `src/release-alert.ts` (新規) | `computeReleaseAlert` / `recomputeAlert` / `collectIssueNumbersForRange` / `fetchIssuesByNumbers` 共通化 |
| `src/hub.ts` | `releaseAlerts` Map + 3 routes + typed envelope |
| `src/webhook.ts` | Tag Release 成功 → `/release-alert-detect` kick |
| `src/release-close{,-batch}.ts` | close 後に Hub recompute kick (`waitUntil`) |
| `src/dashboard.ts` | banner DOM/CSS + dispatcher + polling fallback |
| `src/releases-page.ts` | `loadRelease` 前半を release-alert.ts と共有 refactor |
| `src/index.ts` | `/release-alerts` route + close handlers 配線 |

## テスト

- 全 134 テスト pass / `tsc --noEmit` 通過
- 新規 `test/release-alert.test.ts` 11 ケース
- 新規 webhook テスト 3 ケース (Tag Release 成功・失敗・別 workflow)
- 新規 status テスト 2 ケース (`/release-alerts` + dashboard HTML banner DOM)
