### PR TITLE
fix(banner): release-alert trigger を CI(tag) 完了に修正

### DIFF
--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -108,19 +108,26 @@ export async function handleWebhook(
       }),
     }));
 
-    // Side channel: a successful `Tag Release` workflow run means a new tag
-    // was just pushed. Trigger alert computation in the Hub so the dashboard
+    // Side channel: detect "deploy completed for a new tag" so the dashboard
     // banner can flag any open `Refs #N` issues that the operator forgot to
-    // close. We don't await the response — alert compute fans out to GitHub
-    // and we don't want it blocking webhook delivery.
+    // close. We listen for the **CI** workflow finishing on a tag head_branch
+    // (e.g. v0.0.43), not the `Tag Release` workflow itself — Tag Release
+    // only pushes the tag, the CI run for that tag is what does
+    // `wrangler deploy`. Detecting on Tag Release would deliver the
+    // /release-alert-detect ping to the **previous** version's Hub before the
+    // new code with the alert routes is live (see issue #51).
     if (
       payload.action === "completed" &&
-      payload.workflow_run.name === "Tag Release" &&
+      payload.workflow_run.name === "CI" &&
+      /^v\d/.test(payload.workflow_run.head_branch) &&
       payload.workflow_run.conclusion === "success"
     ) {
       await hub.fetch(new Request("http://hub/release-alert-detect", {
         method: "POST",
-        body: JSON.stringify({ repo: payload.repository.full_name }),
+        body: JSON.stringify({
+          repo: payload.repository.full_name,
+          tag: payload.workflow_run.head_branch,  // explicit tag from head_branch
+        }),
       }));
     }
 

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -395,14 +395,16 @@ describe("POST /webhook", () => {
     expect(res.status).toBe(200);
   });
 
-  // Tag Release detection: when the `Tag Release` workflow finishes
-  // successfully we side-channel a /release-alert-detect to the Hub so the
-  // dashboard banner can pick up any open `Refs #N` issues.
-  it("triggers release-alert-detect on a successful Tag Release completion", async () => {
+  // Release alert detection: we listen for the **CI** workflow finishing on a
+  // tag head_branch (e.g. v0.0.43). That run is the one that does
+  // `wrangler deploy`, so by the time it completes the new code is live and
+  // the /release-alert-detect ping reaches a Hub that knows the route. See
+  // issue #51 for why detecting on Tag Release directly was wrong.
+  it("triggers release-alert-detect on a successful CI run for a tag", async () => {
     const body = makePayload({
       action: "completed",
       workflow_run: {
-        id: 77777, name: "Tag Release", head_branch: "main",
+        id: 77777, name: "CI", head_branch: "v0.0.43",
         status: "completed", conclusion: "success",
         html_url: "https://github.com/ippoan/foo/actions/runs/77777",
         actor: { login: "yhonda" },
@@ -427,10 +429,14 @@ describe("POST /webhook", () => {
 
     const detectCalls = hubCalls.filter((c) => c.path === "/release-alert-detect");
     expect(detectCalls.length).toBe(1);
-    expect(detectCalls[0]!.body).toMatchObject({ repo: "ippoan/foo" });
+    // We pass the tag explicitly from head_branch so the Hub doesn't need to
+    // re-resolve "latest" (avoids races with rapid back-to-back releases).
+    expect(detectCalls[0]!.body).toMatchObject({
+      repo: "ippoan/foo", tag: "v0.0.43",
+    });
   });
 
-  it("does NOT trigger release-alert-detect for non-Tag-Release workflows", async () => {
+  it("does NOT trigger release-alert-detect for CI on a branch (non-tag)", async () => {
     const body = makePayload({
       action: "completed",
       workflow_run: {
@@ -458,13 +464,43 @@ describe("POST /webhook", () => {
     expect(hubCalls.filter((c) => c.path === "/release-alert-detect")).toHaveLength(0);
   });
 
-  it("does NOT trigger release-alert-detect for failed Tag Release runs", async () => {
+  it("does NOT trigger release-alert-detect for failed CI on a tag", async () => {
     const body = makePayload({
       action: "completed",
       workflow_run: {
-        id: 22222, name: "Tag Release", head_branch: "main",
+        id: 22222, name: "CI", head_branch: "v0.0.43",
         status: "completed", conclusion: "failure",
         html_url: "https://github.com/ippoan/foo/actions/runs/22222",
+        actor: { login: "yhonda" },
+        updated_at: "2026-05-12T10:00:00Z",
+        run_started_at: "2026-05-12T09:59:00Z",
+      },
+      repository: { full_name: "ippoan/foo" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST",
+        body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "workflow_run" },
+      }),
+      testEnv(),
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(hubCalls.filter((c) => c.path === "/release-alert-detect")).toHaveLength(0);
+  });
+
+  // Regression guard for issue #51: Tag Release directly must NOT fire — the
+  // Hub it would reach is still on the previous version's deploy.
+  it("does NOT trigger release-alert-detect on a Tag Release workflow completion", async () => {
+    const body = makePayload({
+      action: "completed",
+      workflow_run: {
+        id: 33333, name: "Tag Release", head_branch: "main",
+        status: "completed", conclusion: "success",
+        html_url: "https://github.com/ippoan/foo/actions/runs/33333",
         actor: { login: "yhonda" },
         updated_at: "2026-05-12T10:00:00Z",
         run_started_at: "2026-05-12T09:59:00Z",


### PR DESCRIPTION
## 概要 (Refs #51 / Refs #50)

#50 で導入した dashboard banner が production の tag release 後も表示されない症状の修正。

## 原因

`Tag Release` workflow は **タグを push するだけ** で、本番 deploy はその後の `CI` workflow (tag-triggered) が実行する。webhook handler が `Tag Release` 完了で `/release-alert-detect` を投げると、production はまだ旧バージョンのため該当ルートが無く 404 で破棄されていた。

| 時点 | workflow | 状態 |
|---|---|---|
| ① | `Tag Release` 完了 | タグ push 直後、production はまだ旧バージョン |
| ② | `CI` (v0.0.43) 完了 | デプロイ完了、新バージョン稼働 |

## 修正

検出条件を「`Tag Release` 完了」から「`CI` on tag (`head_branch` が `v\d` で始まる) 完了 success」に変更。これは ② のタイミングに対応する。tag は `head_branch` から明示的に渡すことで Hub 側で latest 解決する race を回避。

```ts
if (
  payload.action === "completed" &&
  payload.workflow_run.name === "CI" &&
  /^v\d/.test(payload.workflow_run.head_branch) &&
  payload.workflow_run.conclusion === "success"
) {
  await hub.fetch("/release-alert-detect", { repo, tag: head_branch });
}
```

## テスト

webhook テスト 4 ケース:
- CI on tag (v0.0.43) success → release-alert-detect 発火 (tag 渡しも検証)
- CI on branch (main) success → 発火しない
- CI on tag failure → 発火しない
- Tag Release success → 発火しない (#51 regression guard)

全 135 テスト pass / `tsc --noEmit` 通過。

## E2E 反映タイミング

この PR を merge → 自動 patch release v0.0.44 → CI(v0.0.44) 完了時に **この修正後のコード** が本番に乗る。次回以降の patch release から banner が出る。
