### PR TITLE
fix(issues-page): drop org: when query has repo:

### DIFF
--- a/src/mcp/tools/issues.ts
+++ b/src/mcp/tools/issues.ts
@@ -324,7 +324,10 @@ export function registerIssuesTools(server: McpServer, token: string): void {
     {
       description:
         "List issues across multiple orgs in one call (uses GitHub search). " +
-        "Filters by state/labels/assignee. PRs are excluded.",
+        "Filters by state/labels/assignee. PRs are excluded. " +
+        "If `query` contains `repo:owner/name`, the `orgs` allowlist is still " +
+        "validated but `org:` is omitted from the search (GitHub silently " +
+        "drops `repo:` when combined with `org:`).",
       inputSchema: {
         orgs: z.array(z.string()).min(1)
           .describe("Organization names (e.g. ['ippoan', 'ohishi-exp'])"),
@@ -390,9 +393,18 @@ export async function fetchOrgIssues(
 
   for (const o of orgs) validateOrg(o);
 
+  // GitHub Search silently drops `repo:` qualifiers when `org:` is also
+  // present in the same query — the result widens to the entire org. When
+  // the caller-supplied `query` already pins specific repos via `repo:`, omit
+  // the `org:` qualifier (the `repo:` already implies the owner). The
+  // `validateOrg` allowlist check above still runs, so this is safe.
+  const queryHasRepoFilter = !!query && /\brepo:/.test(query);
+
   const parts: string[] = ["is:issue"];
   if (state !== "all") parts.push(`state:${state}`);
-  for (const o of orgs) parts.push(`org:${o}`);
+  if (!queryHasRepoFilter) {
+    for (const o of orgs) parts.push(`org:${o}`);
+  }
   if (labels) for (const l of labels) parts.push(`label:"${l}"`);
   if (assignee) parts.push(`assignee:${assignee}`);
   if (query) parts.push(query);

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -166,14 +166,19 @@ describe("GET /issues", () => {
     expect(main!).toContain("org:ohishi-exp");
     expect(main!).not.toContain("repo:yhonda-ohishi/claude-");
 
-    // yhonda-ohishi call: org:yhonda-ohishi + repo: qualifiers (OR) for the
-    // two active claude tooling repos only.
-    const yhonda = decoded.find((d) => d.includes("org:yhonda-ohishi"));
+    // yhonda-ohishi call: repo: qualifiers (OR) for the two active claude
+    // tooling repos only — and CRUCIALLY no `org:yhonda-ohishi`. GitHub Search
+    // silently drops `repo:` when combined with `org:` (it widens the result
+    // to the entire org), so fetchOrgIssues must omit `org:` whenever the
+    // caller-supplied query contains a `repo:` qualifier. Regression guard
+    // for issue #53.
+    const yhonda = decoded.find((d) => d.includes("repo:yhonda-ohishi/claude-skills"));
     expect(yhonda).toBeDefined();
     expect(yhonda!).toContain("is:issue");
     expect(yhonda!).toContain("state:open");
     expect(yhonda!).toContain("repo:yhonda-ohishi/claude-skills");
     expect(yhonda!).toContain("repo:yhonda-ohishi/claude-hooks");
+    expect(yhonda!).not.toContain("org:yhonda-ohishi");
 
     for (const u of urls) expect(u).toContain("per_page=100");
   });


### PR DESCRIPTION
## 概要

GitHub Search の罠で `org:X repo:X/Y` を併用すると `repo:` が黙って drop され、結果が org 全体に広がる。これにより:

- SSR `/issues` ページの yhonda-ohishi 配下に **全 12 個の個人 repo** (nginx / tenko_shijisho / lineworks_bot / authjs-nuxt-test / finger_check / lxc_test / nuxt_module_import_test / python_usb_felica / vue_login_log / win_app …) が混ざって出ていた
- 本来は `YHONDA_REPOS = ["yhonda-ohishi/claude-skills", "yhonda-ohishi/claude-hooks"]` の 2 repo に限定するつもりだった (PR #37 の意図)
- `list_org_issues` MCP tool / check-issue skill も同じバグを踏んでいた

## 実測 (gh api search/issues)

| クエリ | 結果 |
|---|---|
| `is:issue state:open org:yhonda-ohishi repo:.../claude-skills repo:.../claude-hooks` | 18 issues / 12 repos ❌ |
| `is:issue state:open repo:.../claude-skills repo:.../claude-hooks` | 4 issues / 2 repos ✅ |

## 修正

`fetchOrgIssues` (src/mcp/tools/issues.ts) で caller の `query` に `repo:` qualifier が含まれている場合は `org:` を q に追加しない。`validateOrg(o)` の allowlist check は引き続き実行されるので security invariant は維持。呼び出し側 (issues-page.ts / check-issue skill) は無変更で意図通り filter が効くようになる。

`list_org_issues` の description にも hidden contract を明文化。

## テスト

`test/issues-page.test.ts` の 2-call 検証を更新:
- main 呼び出しは `org:ippoan org:ohishi-exp` を含み `repo:` を含まない
- yhonda 呼び出しは `repo:yhonda-ohishi/claude-skills` と `repo:yhonda-ohishi/claude-hooks` を含み **`org:yhonda-ohishi` を含まない** (← 回帰防止 hard assert)

全 14 test files / 135 tests pass。

Refs #53