### PR TITLE
refactor(dashboard): center body to match /issues and /releases

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -15,6 +15,8 @@ export function handleDashboard(): Response {
       background: #0d1117;
       color: #c9d1d9;
       padding: 24px;
+      max-width: 1200px;
+      margin: 0 auto;
     }
     h1 { font-size: 20px; margin-bottom: 16px; color: #58a6ff; }
     .status-bar {


### PR DESCRIPTION
## 概要

`/` (dashboard) だけ body の `max-width` / `margin: 0 auto` が無く左寄せだったため、`/issues` / `/releases` (両方とも 1200px 中央寄せ) とタブを切り替えると左右に飛んで見えた。dashboard.ts の body に 2 行追加するだけで揃う。

## 変更

```diff
 body {
   font-family: ...;
   background: #0d1117;
   color: #c9d1d9;
   padding: 24px;
+  max-width: 1200px;
+  margin: 0 auto;
 }
```

dashboard 内部の `.layout` は sidebar 220px + main flex:1 で、1200px に余裕で収まるため他の CSS は無変更。

## テスト

全 14 test files / 135 tests pass (local)。

Refs #55