### PR TITLE
feat(releases): synthetic block for direct-push-OK repos

### DIFF
--- a/src/direct-push-allowlist.ts
+++ b/src/direct-push-allowlist.ts
@@ -1,0 +1,104 @@
+// Fetches the direct-push-OK allowlist from `yhonda-ohishi/claude-skills`
+// so this repo and the `/wt-direct-push` skill share one source of truth.
+//
+// SoT file: `yhonda-ohishi/claude-skills/wt-direct-push/config/direct-push-ok.txt`
+//   - one `owner/name` per line
+//   - `#` comments, blank lines OK
+//
+// The fetch is cached in KV with a TTL so the release page renders without
+// 1 extra GitHub round-trip every load. Failure paths fall back to an empty
+// set so the rest of the page still renders — direct-push UI just silently
+// won't appear until the fetch recovers.
+
+import { githubApi, GitHubApiError } from "./github-api";
+
+export const ALLOWLIST_REPO = "yhonda-ohishi/claude-skills";
+export const ALLOWLIST_PATH = "wt-direct-push/config/direct-push-ok.txt";
+const KV_KEY = "direct-push-allowlist:v1";
+const TTL_SECONDS = 600; // 10 minutes
+
+interface ContentsResponse {
+  content: string;
+  encoding: "base64" | string;
+}
+
+interface CachedAllowlist {
+  fetchedAt: number;
+  repos: string[];
+}
+
+// Returns the parsed allowlist as a Set so callers do O(1) membership checks.
+// `kv` is optional so unit tests can exercise the pure-fetch path without
+// stubbing a KV namespace; production passes `env.CI_STATUS`.
+export async function loadDirectPushAllowlist(
+  token: string,
+  kv?: KVNamespace,
+): Promise<Set<string>> {
+  if (kv) {
+    const cached = await kv.get<CachedAllowlist>(KV_KEY, "json");
+    if (cached && Array.isArray(cached.repos)) {
+      return new Set(cached.repos);
+    }
+  }
+
+  const repos = await fetchAllowlistFromGitHub(token);
+
+  if (kv && repos.length > 0) {
+    // Only cache non-empty results so a transient fetch failure doesn't poison
+    // the cache for 10 minutes.
+    await kv.put(
+      KV_KEY,
+      JSON.stringify({ fetchedAt: Date.now(), repos } satisfies CachedAllowlist),
+      { expirationTtl: TTL_SECONDS },
+    );
+  }
+
+  return new Set(repos);
+}
+
+async function fetchAllowlistFromGitHub(token: string): Promise<string[]> {
+  try {
+    const res = await githubApi<ContentsResponse>(
+      token,
+      "GET",
+      `/repos/${ALLOWLIST_REPO}/contents/${ALLOWLIST_PATH}`,
+    );
+    if (res.encoding !== "base64" || typeof res.content !== "string") {
+      return [];
+    }
+    return parseAllowlist(atobUtf8(res.content));
+  } catch (err) {
+    if (err instanceof GitHubApiError) {
+      // 404 = file moved / not yet pushed; treat as empty list (no direct-push
+      // repos configured). Other errors fall back too, but a 5xx would be
+      // worth surfacing in logs.
+      return [];
+    }
+    throw err;
+  }
+}
+
+// Exported for unit tests; converts the txt file body into a flat list of
+// `owner/name` entries with whitespace and comments trimmed. Lines that don't
+// look like `owner/name` are skipped silently so the SSR page never breaks on
+// stray text.
+export function parseAllowlist(body: string): string[] {
+  const out: string[] = [];
+  for (const rawLine of body.split(/\r?\n/)) {
+    const line = rawLine.replace(/#.*$/, "").trim();
+    if (!line) continue;
+    if (!/^[\w.-]+\/[\w.-]+$/.test(line)) continue;
+    out.push(line);
+  }
+  return out;
+}
+
+// GitHub returns base64 with newlines every 60 chars; standard atob copes,
+// but content with non-ASCII chars needs a UTF-8 decode pass. The allowlist
+// is ASCII today so plain atob() suffices, but we wrap it for safety.
+function atobUtf8(b64: string): string {
+  const bin = atob(b64.replace(/\n/g, ""));
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new TextDecoder("utf-8").decode(bytes);
+}

--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -9,6 +9,7 @@ import {
   collectIssueNumbersForRange,
   fetchIssuesByNumbers,
 } from "./release-alert";
+import { loadDirectPushAllowlist } from "./direct-push-allowlist";
 import { renderTabs, TAB_STYLES } from "./nav-tabs";
 
 // `/releases` (no params) renders a list of "recent releases" — every watched
@@ -27,7 +28,11 @@ import { renderTabs, TAB_STYLES } from "./nav-tabs";
 
 export async function handleReleasesPage(
   req: Request,
-  env: { GITHUB_TOKEN: string; CI_HUB: DurableObjectNamespace },
+  env: {
+    GITHUB_TOKEN: string;
+    CI_HUB: DurableObjectNamespace;
+    CI_STATUS?: KVNamespace;
+  },
 ): Promise<Response> {
   const url = new URL(req.url);
   const repoParam = url.searchParams.get("repo");
@@ -73,6 +78,11 @@ interface TagBlock {
   tag: string;
   prevTag: string | null;
   issues: IssueRow[];    // already-fetched and warning-annotated
+  // `synthetic` blocks are constructed from default-branch commits when a
+  // direct-push-OK repo has no semver tags (#57). They drop the "→ detail"
+  // link because there's no compare-range view to point at, and they hide
+  // already-closed issues entirely instead of nesting them in <details>.
+  synthetic?: boolean;
 }
 
 // Top tags shown inline per repo (each fans out compare + per-issue fetches).
@@ -80,30 +90,46 @@ interface TagBlock {
 const TOP_TAGS_INLINE = 5;
 
 async function handleIndexPage(
-  env: { GITHUB_TOKEN: string; CI_HUB: DurableObjectNamespace },
+  env: {
+    GITHUB_TOKEN: string;
+    CI_HUB: DurableObjectNamespace;
+    CI_STATUS?: KVNamespace;
+  },
   closedFlash: number[],
   failedFlash: number[],
   flashRepo: string | null,
 ): Promise<Response> {
-  // 1. Watched repos come from the Hub's status cache — every repo that has
-  //    ever fired a CI run lives there, which is the same source the
-  //    dashboard sidebar uses.
-  let repos: string[] = [];
+  // 1. Watched repos come from two sources:
+  //   (a) Hub status cache — every repo that has ever fired a CI run.
+  //   (b) Direct-push-OK allowlist — repos that never auto-merge a PR and
+  //       therefore won't show up in (a) until they happen to push a tag.
+  //       Fetched from `yhonda-ohishi/claude-skills` (same SoT as
+  //       `/wt-direct-push`); see direct-push-allowlist.ts.
+  const watched = new Set<string>();
   try {
     const hubId = env.CI_HUB.idFromName("singleton");
     const hub = env.CI_HUB.get(hubId);
     const res = await hub.fetch(new Request("http://hub/statuses"));
     if (res.ok) {
       const statuses = await res.json<Array<{ repo: string }>>();
-      repos = [...new Set(statuses.map((s) => s.repo))].sort();
+      for (const s of statuses) watched.add(s.repo);
     }
-  } catch { /* empty list → page falls back to lookup form only */ }
+  } catch { /* empty list → falls through; allowlist may still add repos */ }
+
+  let allowlist = new Set<string>();
+  try {
+    allowlist = await loadDirectPushAllowlist(env.GITHUB_TOKEN, env.CI_STATUS);
+    for (const r of allowlist) watched.add(r);
+  } catch { /* graceful: allowlist stays empty, existing tag-flow unaffected */ }
+
+  const repos = [...watched].sort();
 
   // 2. Per-repo data load in parallel; whole-repo failures get a null view
-  //    we drop in the renderer.
+  //    we drop in the renderer. Allowlisted repos take the synthetic path
+  //    inside loadRepoView when they have no semver tags.
   const views = await Promise.all(repos.map(async (repo) => {
     try {
-      return await loadRepoView(env.GITHUB_TOKEN, repo);
+      return await loadRepoView(env.GITHUB_TOKEN, repo, allowlist.has(repo));
     } catch {
       return null;
     }
@@ -120,7 +146,11 @@ async function handleIndexPage(
   );
 }
 
-async function loadRepoView(token: string, repo: string): Promise<RepoView | null> {
+async function loadRepoView(
+  token: string,
+  repo: string,
+  isDirectPush: boolean,
+): Promise<RepoView | null> {
   const { owner, repo: name } = parseRepo(repo);
   validateOrg(owner);
 
@@ -133,6 +163,19 @@ async function loadRepoView(token: string, repo: string): Promise<RepoView | nul
   const sorted = sortSemverDesc(allTags.map((t) => t.name));
   const topTags = sorted.slice(0, TOP_TAGS_INLINE);
   if (topTags.length === 0) {
+    // Direct-push-OK repos that never tag still need a way to surface their
+    // open Refs. Fall back to a synthetic block built from the default
+    // branch's recent commits (#57). Non-allowlisted tag-less repos return
+    // empty as before so we don't accidentally treat an auto-merge repo as a
+    // direct-push one mid-release.
+    if (isDirectPush) {
+      const block = await loadSyntheticBlock(token, owner, name);
+      return {
+        repo: `${owner}/${name}`,
+        tagBlocks: block ? [block] : [],
+        olderTags: [],
+      };
+    }
     return { repo: `${owner}/${name}`, tagBlocks: [], olderTags: [] };
   }
 
@@ -200,6 +243,87 @@ async function loadRepoView(token: string, repo: string): Promise<RepoView | nul
     repo: `${owner}/${name}`,
     tagBlocks,
     olderTags: sorted.slice(TOP_TAGS_INLINE),
+  };
+}
+
+// Build a synthetic block for tag-less direct-push-OK repos (#57).
+//
+// We scan the most recent SYNTHETIC_COMMIT_WINDOW commits on the default
+// branch for `Refs #N`, hydrate the referenced issues, and keep only the ones
+// still `open`. Closed issues drop out entirely (no <details>): the alternative
+// view's case for collapsing them is "they got auto-closed by `Closes #N` in a
+// PR merge", which can't happen on direct-push-OK repos by construction.
+//
+// The "tag" identity is `<branch>@<sha7>` so the post-close comment
+// ("Closed by release main@e8e90a4") stays traceable even though the synthetic
+// block has no compare range. The detail page (`?repo=X&tag=Y`) is *not*
+// supported for these tags — `renderTagBlock` skips the link.
+const SYNTHETIC_COMMIT_WINDOW = 100;
+
+interface RepoMeta { default_branch: string }
+
+async function loadSyntheticBlock(
+  token: string,
+  owner: string,
+  name: string,
+): Promise<TagBlock | null> {
+  let defaultBranch: string;
+  try {
+    const meta = await githubApi<RepoMeta>(token, "GET", `/repos/${owner}/${name}`);
+    defaultBranch = meta.default_branch;
+  } catch {
+    return null;
+  }
+  if (!defaultBranch) return null;
+
+  let commits: RawCommit[] = [];
+  try {
+    commits = await githubApi<RawCommit[]>(
+      token, "GET", `/repos/${owner}/${name}/commits`, undefined,
+      { sha: defaultBranch, per_page: String(SYNTHETIC_COMMIT_WINDOW) },
+    );
+  } catch {
+    return null;
+  }
+  if (commits.length === 0) return null;
+
+  const refs = new Set<number>();
+  for (const c of commits) {
+    for (const n of extractRefIssues(c.commit.message)) refs.add(n);
+  }
+  if (refs.size === 0) {
+    // No referenced issues in the recent window — nothing to confirm. Skipping
+    // the block (vs. returning an empty one) keeps the repo off the landing
+    // page entirely, matching the tag path's behavior.
+    return null;
+  }
+
+  const issues = await fetchIssuesByNumbers(token, owner, name, refs);
+  const openRows: IssueRow[] = issues
+    .filter((i) => !i.pull_request && i.state === "open")
+    .map((i) => {
+      const labels = i.labels.map((l) => l.name);
+      return {
+        number: i.number,
+        title: i.title,
+        state: i.state,
+        labels,
+        assignees: i.assignees.map((a) => a.login),
+        url: i.html_url,
+        updated_at: i.updated_at,
+        warnings: computeWarnings({ state: i.state, labels }),
+      };
+    })
+    .sort((a, b) => a.number - b.number);
+
+  if (openRows.length === 0) return null;
+
+  const headSha7 = commits[0]!.sha.slice(0, 7);
+  return {
+    tag: `${defaultBranch}@${headSha7}`,
+    prevTag: null,
+    issues: openRows,
+    synthetic: true,
   };
 }
 
@@ -501,12 +625,26 @@ function renderTagBlock(repo: string, block: TagBlock): string {
   // so they collapse into a native <details> below the active rows. The form
   // wrapping the whole repo card still picks up checkboxes inside <details>
   // when the operator expands it.
+  //
+  // Synthetic (direct-push) blocks have already filtered to open-only when
+  // they were built (#57), so `hidden` ends up empty there and the <details>
+  // collapses out naturally.
   const visible = block.issues.filter((i) => i.state !== "closed");
   const hidden = block.issues.filter((i) => i.state === "closed");
 
   const since = block.prevTag
     ? `<span class="since">since <code>${escapeHtml(block.prevTag)}</code></span>`
     : "";
+
+  // Direct-push blocks have no compare range, so the detail page (`?tag=X`)
+  // would 404. Show a passive "direct push" marker instead so the operator
+  // knows why the link is missing.
+  const detailOrMarker = block.synthetic
+    ? `<span class="direct-marker" title="direct-push branch — no tag range">direct push</span>`
+    : `<a class="detail-link"
+         href="/releases?repo=${encodeURIComponent(repo)}&tag=${encodeURIComponent(block.tag)}">
+        → detail
+      </a>`;
 
   const visibleTable = visible.length === 0 ? "" : `
     <table>
@@ -532,10 +670,7 @@ function renderTagBlock(repo: string, block: TagBlock): string {
     <div class="tag-block-header">
       <strong>${escapeHtml(block.tag)}</strong>
       ${since}
-      <a class="detail-link"
-         href="/releases?repo=${encodeURIComponent(repo)}&tag=${encodeURIComponent(block.tag)}">
-        → detail
-      </a>
+      ${detailOrMarker}
     </div>
     ${visibleTable}
     ${hiddenDetails}
@@ -673,6 +808,11 @@ const STYLES = `
     margin-left: auto; color: #58a6ff; text-decoration: none; font-size: 12px;
   }
   .tag-block-header .detail-link:hover { text-decoration: underline; }
+  .tag-block-header .direct-marker {
+    margin-left: auto; font-size: 11px; color: #8b949e;
+    background: #21262d; border: 1px solid #30363d;
+    padding: 1px 8px; border-radius: 10px;
+  }
   .tag-block table {
     background: #0d1117; border: 1px solid #30363d;
     border-radius: 6px; overflow: hidden;

--- a/test/direct-push-allowlist.test.ts
+++ b/test/direct-push-allowlist.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  parseAllowlist,
+  loadDirectPushAllowlist,
+  ALLOWLIST_REPO,
+  ALLOWLIST_PATH,
+} from "../src/direct-push-allowlist";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("parseAllowlist", () => {
+  it("strips comments + blank lines and keeps owner/name lines", () => {
+    const body =
+      "# header\n" +
+      "ippoan/ci-workflows\n" +
+      "\n" +
+      "# section\n" +
+      "yhonda-ohishi/claude-hooks\n" +
+      "yhonda-ohishi/claude-skills  # inline comment\n";
+    expect(parseAllowlist(body)).toEqual([
+      "ippoan/ci-workflows",
+      "yhonda-ohishi/claude-hooks",
+      "yhonda-ohishi/claude-skills",
+    ]);
+  });
+
+  it("rejects lines that don't look like owner/name", () => {
+    // Defensive: a typo or stray prose shouldn't poison the set with a bogus
+    // entry that later compares true to some repo string.
+    const body = "ippoan/good\nbroken line\nhttps://example.com\nfoo/bar/baz\n";
+    expect(parseAllowlist(body)).toEqual(["ippoan/good"]);
+  });
+
+  it("returns [] on empty input", () => {
+    expect(parseAllowlist("")).toEqual([]);
+    expect(parseAllowlist("# just comments\n")).toEqual([]);
+  });
+});
+
+// Minimal in-memory stand-in for `KVNamespace.get<json>()` / `put()`. We only
+// exercise the two methods the loader touches; the rest stay `undefined` so
+// any accidental usage throws loudly.
+function memoryKv(initial: Record<string, string> = {}): KVNamespace {
+  const store = new Map(Object.entries(initial));
+  return {
+    get: async (key: string, type?: "text" | "json") => {
+      const v = store.get(key);
+      if (v === undefined) return null;
+      return type === "json" ? JSON.parse(v) : v;
+    },
+    put: async (key: string, value: string) => {
+      store.set(key, value);
+    },
+  } as unknown as KVNamespace;
+}
+
+function stubContentsResponse(repos: string[]): void {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
+    const url = typeof req === "string" ? req : (req as Request).url;
+    if (url.includes(`/repos/${ALLOWLIST_REPO}/contents/${ALLOWLIST_PATH}`)) {
+      const body = repos.join("\n") + "\n";
+      const content = btoa(body);
+      return Response.json({ content, encoding: "base64" });
+    }
+    throw new Error(`unstubbed fetch: ${url}`);
+  });
+}
+
+describe("loadDirectPushAllowlist", () => {
+  it("returns the parsed Set on a fresh fetch and writes it to KV", async () => {
+    stubContentsResponse([
+      "ippoan/ci-workflows",
+      "yhonda-ohishi/claude-hooks",
+    ]);
+    const kv = memoryKv();
+    const set = await loadDirectPushAllowlist("token", kv);
+    expect([...set].sort()).toEqual([
+      "ippoan/ci-workflows",
+      "yhonda-ohishi/claude-hooks",
+    ]);
+    // Cached for subsequent reads — the KV value carries the parsed list so
+    // the SSR page can return it without re-decoding base64.
+    const cached = await kv.get("direct-push-allowlist:v1", "json");
+    expect(cached).toMatchObject({ repos: ["ippoan/ci-workflows", "yhonda-ohishi/claude-hooks"] });
+  });
+
+  it("returns the cached value without calling GitHub on a warm KV", async () => {
+    const kv = memoryKv({
+      "direct-push-allowlist:v1": JSON.stringify({
+        fetchedAt: Date.now(),
+        repos: ["cached/repo"],
+      }),
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      throw new Error("should not be called");
+    });
+    const set = await loadDirectPushAllowlist("token", kv);
+    expect([...set]).toEqual(["cached/repo"]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty Set when the allowlist file is missing (404)", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response("Not Found", { status: 404 }),
+    );
+    const kv = memoryKv();
+    const set = await loadDirectPushAllowlist("token", kv);
+    expect(set.size).toBe(0);
+    // Empty fetches must NOT poison the cache; the next load gets a real
+    // chance against GitHub.
+    const cached = await kv.get("direct-push-allowlist:v1");
+    expect(cached).toBeNull();
+  });
+
+  it("works without a KV namespace (pure fetch fallback)", async () => {
+    stubContentsResponse(["a/b"]);
+    const set = await loadDirectPushAllowlist("token");
+    expect([...set]).toEqual(["a/b"]);
+  });
+});

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -433,4 +433,142 @@ describe("GET /releases", () => {
     const html = await res.text();
     expect(html).toContain("evil-org");
   });
+
+  // #57: synthetic block for tag-less direct-push-OK repos. The allowlist
+  // comes from `yhonda-ohishi/claude-skills`; only repos appearing in it get
+  // the fallback path so auto-merge PR repos in a brief tag-less window stay
+  // off the page (which is what the user explicitly called out).
+  it("renders a synthetic block from default-branch commits for an allowlisted tag-less repo", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
+      const url = typeof req === "string" ? req : (req as Request).url;
+
+      // SoT allowlist fetched from claude-skills repo.
+      if (url.includes("/repos/yhonda-ohishi/claude-skills/contents/wt-direct-push/config/direct-push-ok.txt")) {
+        const body = "yhonda-ohishi/claude-hooks\n";
+        return Response.json({ content: btoa(body), encoding: "base64" });
+      }
+
+      // Target repo: no tags published → triggers the synthetic path.
+      if (url.includes("/repos/yhonda-ohishi/claude-hooks/tags")) {
+        return Response.json([]);
+      }
+
+      // /repos/{o}/{n} for default_branch lookup.
+      if (url.match(/\/repos\/yhonda-ohishi\/claude-hooks(\?|$)/)) {
+        return Response.json({ default_branch: "master" });
+      }
+
+      // Most recent default-branch commits — only one carries a Refs trailer,
+      // the other is noise we expect the loader to skip cleanly.
+      if (url.includes("/repos/yhonda-ohishi/claude-hooks/commits")) {
+        return Response.json([
+          { sha: "deadbeefcafe1234", commit: { message: "feat: hook\n\nRefs #2" } },
+          { sha: "1111222233334444", commit: { message: "chore: tidy" } },
+        ]);
+      }
+
+      // The Refs target — open + clean → checkbox defaults ON.
+      if (url.endsWith("/repos/yhonda-ohishi/claude-hooks/issues/2")) {
+        return Response.json({
+          number: 2, title: "worktree-naming-guard hook", state: "open",
+          labels: [], assignees: [],
+          html_url: "https://github.com/yhonda-ohishi/claude-hooks/issues/2",
+          updated_at: "2026-05-12T00:00:00Z",
+        });
+      }
+
+      return new Response(`not stubbed: ${url}`, { status: 500 });
+    });
+
+    const req = new Request("http://localhost/releases");
+    const ctx = createExecutionContext();
+    // No `watched` — the repo only appears via the allowlist, proving the
+    // Hub-cache ∪ allowlist union path actually picks it up.
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    // Synthetic tag identity: <branch>@<sha7> from the HEAD commit.
+    expect(html).toContain("master@deadbee");
+    // The "direct push" marker replaces the "→ detail" link.
+    expect(html).toContain("direct push");
+    expect(html).not.toMatch(/→ detail[\s\S]*master@deadbee/);
+    // The candidate row + form pair encoding works the same as the tag path.
+    expect(html).toContain(`name="pair" value="master@deadbee:2"`);
+    expect(html).toContain("worktree-naming-guard hook");
+  });
+
+  it("omits a synthetic block when the recent commit window has no Refs", async () => {
+    // Direct-push-OK repo, but the recent commits don't reference any issue —
+    // we drop the whole RepoView so the landing page doesn't grow a noisy
+    // empty card.
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
+      const url = typeof req === "string" ? req : (req as Request).url;
+
+      if (url.includes("/contents/wt-direct-push/config/direct-push-ok.txt")) {
+        return Response.json({
+          content: btoa("yhonda-ohishi/claude-hooks\n"),
+          encoding: "base64",
+        });
+      }
+      if (url.includes("/repos/yhonda-ohishi/claude-hooks/tags")) {
+        return Response.json([]);
+      }
+      if (url.match(/\/repos\/yhonda-ohishi\/claude-hooks(\?|$)/)) {
+        return Response.json({ default_branch: "master" });
+      }
+      if (url.includes("/repos/yhonda-ohishi/claude-hooks/commits")) {
+        return Response.json([
+          { sha: "aaa", commit: { message: "no refs here" } },
+        ]);
+      }
+      return new Response(`not stubbed: ${url}`, { status: 500 });
+    });
+
+    const req = new Request("http://localhost/releases");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // Repo dropped → empty-state hint shown, no synthetic block markup.
+    expect(html).toContain("No releases with referenced issues");
+    expect(html).not.toContain("yhonda-ohishi/claude-hooks");
+  });
+
+  it("does not turn an unallowlisted tag-less repo into a synthetic block", async () => {
+    // Guard against the auto-merge regression the user called out: a PR repo
+    // briefly without tags must NOT show its main-branch commits here.
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
+      const url = typeof req === "string" ? req : (req as Request).url;
+
+      // Allowlist is empty.
+      if (url.includes("/contents/wt-direct-push/config/direct-push-ok.txt")) {
+        return Response.json({ content: btoa(""), encoding: "base64" });
+      }
+      if (url.includes("/repos/ippoan/some-pr-repo/tags")) {
+        return Response.json([]);
+      }
+      // /repos/{o}/{n} should NOT be hit for the non-allowlisted path; fail
+      // loudly if it is so we notice the regression in CI.
+      if (url.match(/\/repos\/ippoan\/some-pr-repo(\?|$)/)) {
+        throw new Error("unexpected fetch: synthetic path leaked");
+      }
+      return new Response(`not stubbed: ${url}`, { status: 500 });
+    });
+
+    const e = testEnv({ watched: ["ippoan/some-pr-repo"] });
+    const req = new Request("http://localhost/releases");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, e, ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("No releases with referenced issues");
+    expect(html).not.toContain("direct push");
+  });
 });


### PR DESCRIPTION
## Summary

ci-dashboard `/releases` ページに **direct-push-OK repo (auto-merge 無し)** を表示できるようにする。tag-less な claude-hooks / claude-skills / ci-workflows の Refs #N を default-branch 直近 commit から拾い、既存の bulk-close UI に乗せる。

## 設計

### 1. allowlist (SoT 一本化)

`yhonda-ohishi/claude-skills/wt-direct-push/config/direct-push-ok.txt` を ci-dashboard が GitHub API で fetch。`/wt-direct-push` skill と同じファイルを参照することで PR 1 本で両方に反映。KV cache 10min、空 fetch は cache せず graceful fallback。

### 2. synthetic block

allowlist hit + tag 無しの repo について:

- `/repos/{o}/{n}` → default_branch 取得
- `/repos/{o}/{n}/commits?sha=<branch>&per_page=100` → Refs #N 抽出
- `state=="open"` の issue だけ candidate (closed は完全除外、auto-merge 由来の noise を排除)
- tag identity = `<branch>@<sha7>` (close 時の comment に traceability)
- Refs 0 件なら repo 自体を index から落とす

### 3. render 差分

- `TagBlock.synthetic` 追加、`renderTagBlock` で「→ detail」を「direct push」 marker に置換 (compare range 不在で detail 不可)
- `handleIndexPage` の repos = Hub status ∪ allowlist (新規 repo も即表示)

### 4. auto-merge regression 防止

tag が無いだけの PR-merge repo は allowlist にいないので synthetic path に入らない。明示的なテストで保証 (synthetic fetch path に到達したら throw)。

## ローカル検証

- npm run typecheck → 0 error
- npm test → **145 passed (was 135 + 10 new)**
  - direct-push-allowlist.test.ts (7 new): parse / KV hit / GitHub fetch / 404 → empty / no-KV fallback
  - releases-page.test.ts (3 new): synthetic block render / no-Refs → drop / non-allowlist → no synthetic

## Refs

- Refs #57 (this work)
- Refs yhonda-ohishi/claude-skills#5 (/wt-direct-push skill, SoT consumer)
- Refs yhonda-ohishi/claude-skills#7 (allowlist self-add 例)

🤖 Generated with [Claude Code](https://claude.com/claude-code)