### PR TITLE
fix(releases): hide close button when no actionable candidates

### DIFF
--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -595,6 +595,17 @@ function renderIndexRepo(view: RepoView): string {
     .map((b) => renderTagBlock(view.repo, b))
     .join("\n");
 
+  // When every referenced issue across the visible tag blocks is already
+  // closed, the form has nothing to actually do — clicking the button would
+  // just round-trip with an empty selection. Drop the actions row so the
+  // historical `<details>` blocks remain as audit context without inviting a
+  // no-op click (#59). The `<form>` itself stays so future closes (e.g. if
+  // an issue is reopened) still have a working submit path; the operator
+  // would just need a tick + a manual page refresh to re-render the button.
+  const hasVisibleCandidate = view.tagBlocks.some((b) =>
+    b.issues.some((i) => i.state !== "closed"),
+  );
+
   const olderHtml = view.olderTags.length === 0
     ? ""
     : `<div class="older-tags">older: ${view.olderTags
@@ -602,6 +613,13 @@ function renderIndexRepo(view: RepoView): string {
           `<a href="/releases?repo=${encodeURIComponent(view.repo)}&tag=${encodeURIComponent(t)}">${escapeHtml(t)}</a>`,
         )
         .join(" · ")}</div>`;
+
+  const actions = hasVisibleCandidate
+    ? `<div class="actions">
+        <button type="submit">✅ Close selected as released</button>
+        <span class="hint">⚠️ rows start unchecked.</span>
+      </div>`
+    : "";
 
   // Whole repo card is one form so the operator can tick across tags and
   // close them in one shot; the POST handler groups by tag for comment
@@ -611,10 +629,7 @@ function renderIndexRepo(view: RepoView): string {
     <form method="POST" action="/api/release-close-batch" class="batch-close-form">
       <input type="hidden" name="repo" value="${escapeHtml(view.repo)}">
       ${tagSections}
-      <div class="actions">
-        <button type="submit">✅ Close selected as released</button>
-        <span class="hint">⚠️ rows start unchecked.</span>
-      </div>
+      ${actions}
     </form>
     ${olderHtml}
   </section>`;

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -539,6 +539,52 @@ describe("GET /releases", () => {
     expect(html).not.toContain("yhonda-ohishi/claude-hooks");
   });
 
+  // #59: once every referenced issue in a repo card is closed, the
+  // "✅ Close selected as released" button has nothing to act on and
+  // round-trips empty. Hide it; keep the closed-history <details> as
+  // audit context.
+  it("hides the close button when all visible candidates are already closed", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
+      const url = typeof req === "string" ? req : (req as Request).url;
+      if (url.includes("/repos/ippoan/ci-dashboard/tags")) {
+        return Response.json([
+          { name: "v1.0.0", commit: { sha: "a" } },
+          { name: "v0.9.0", commit: { sha: "b" } },
+        ]);
+      }
+      if (url.includes("/compare/v0.9.0...v1.0.0")) {
+        return Response.json({
+          commits: [{ sha: "x", commit: { message: "feat\n\nRefs #1" } }],
+        });
+      }
+      // The referenced issue is already closed → block.issues is non-empty
+      // (so the tag block renders) but hasVisibleCandidate is false.
+      if (url.endsWith("/repos/ippoan/ci-dashboard/issues/1")) {
+        return Response.json({
+          number: 1, title: "old work", state: "closed",
+          labels: [], assignees: [],
+          html_url: "https://github.com/ippoan/ci-dashboard/issues/1",
+          updated_at: "2026-05-01T00:00:00Z",
+        });
+      }
+      return new Response(`not stubbed: ${url}`, { status: 500 });
+    });
+
+    const e = testEnv({ watched: ["ippoan/ci-dashboard"] });
+    const req = new Request("http://localhost/releases");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, e, ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // Card itself still renders so the closed-history <details> stays visible.
+    expect(html).toContain("ippoan/ci-dashboard");
+    expect(html).toContain("1 closed issue");
+    // But the actions row (and its button) is gone.
+    expect(html).not.toContain("Close selected as released");
+  });
+
   it("does not turn an unallowlisted tag-less repo into a synthetic block", async () => {
     // Guard against the auto-merge regression the user called out: a PR repo
     // briefly without tags must NOT show its main-branch commits here.


### PR DESCRIPTION
## Summary

repo card で全 referenced issue が `closed` (`<details>` に畳まれた状態) のとき、「✅ Close selected as released」ボタンを隠す。click しても空 redirect になるだけの no-op button を消す。

## 動機

PR #58 で synthetic block を入れた後、user が ci-dashboard repo card (closed-only) で button が残ったまま無意味に押せるのを発見:

> closeするものがなくても　ボタン出るのやめて

## 振る舞い

| 状態 | 表示 |
|---|---|
| 1+ visible candidate (open) | 既存通り、button あり |
| **all closed** | tag block + `<details>` だけ残り、button 無し |
| repo に referenced issue 0 (`tagBlocks empty`) | 既存通り、card 自体非表示 |

`<form>` は残すので、issue reopen → ページ refresh で button が復活する。

## scope

- `renderIndexRepo`: `hasVisibleCandidate` 計算で `actions` div を条件付きに
- `renderTagBlock`: 変更無し (closed-only block の `visibleTable` は元から空文字)
- synthetic block (#57): 元から open-only なので影響無し

## Local pre-flight

- `npm run typecheck` → 0 error
- `npm test` → **146 passed (was 145 + 1 new)**
  - 新 case: closed-only card で `Close selected as released` 文字列が出ない

## Refs

- Refs #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)