### PR TITLE
fix(releases): hide detail-page form when flash empties all candidates

### DIFF
--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -447,10 +447,13 @@ function renderHtml(
   closedFlash: number[],
   failedFlash: number[],
 ): string {
-  const candidateRows = data.rows
-    .filter((r) => !closedFlash.includes(r.number))
-    .map((r) => renderRow(r))
-    .join("\n");
+  // The flash filter strips just-closed rows from the candidate set so a
+  // close-then-redirect lands on a page that no longer offers them. We then
+  // gate the form by the *remaining* candidates rather than the unfiltered
+  // payload — otherwise the operator sees a header-only table with a button
+  // that round-trips empty (#61, sibling of the index-side fix in #59).
+  const candidates = data.rows.filter((r) => !closedFlash.includes(r.number));
+  const candidateRows = candidates.map((r) => renderRow(r)).join("\n");
 
   const flash = renderFlash(closedFlash, failedFlash, data.repo);
 
@@ -460,11 +463,17 @@ function renderHtml(
       ? ` (since <code>${escapeHtml(data.previousTag)}</code>, ${data.commits} commits)`
       : ` (first release; last ${data.commits} commits scanned)`);
 
+  // Two distinct "nothing to do" states share the same hint slot:
+  //   - data.rows.length === 0 → tag had no Refs at all
+  //   - data.rows.length > 0 but candidates.length === 0 → everything just got
+  //     closed in this round-trip; show the celebratory variant instead.
   const empty = data.rows.length === 0
     ? `<div class="empty">🎉 No referenced issues for this release.</div>`
-    : "";
+    : candidates.length === 0
+      ? `<div class="empty">✅ All referenced issues for this release are closed.</div>`
+      : "";
 
-  const formInner = data.rows.length === 0 ? "" : `
+  const formInner = candidates.length === 0 ? "" : `
     <form method="POST" action="/api/release-close" class="close-form">
       <input type="hidden" name="repo" value="${escapeHtml(data.repo)}">
       <input type="hidden" name="tag" value="${escapeHtml(data.tag)}">

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -434,6 +434,31 @@ describe("GET /releases", () => {
     expect(html).toContain("evil-org");
   });
 
+  // #61: detail-page sibling of the index fix. When the flash redirect lands
+  // after closing every row, the form/button must disappear; only the closed
+  // flash banner + the "all closed" hint should remain.
+  it("hides the detail form when the flash filter removes every remaining candidate", async () => {
+    stubGithubApi();
+    // Pass every candidate (42, 50, 99) through `closed=` so the filter empties
+    // the table. The data loader still sees them, but the renderer should
+    // recognize there's nothing left to act on.
+    const req = new Request(
+      "http://localhost/releases?repo=ippoan/ci-dashboard&tag=v1.2.0&closed=42,50,99",
+    );
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    const html = await res.text();
+    // Flash banner survives (operator sees what just got closed).
+    expect(html).toContain("Closed:");
+    // No button, no form-shaped checkboxes.
+    expect(html).not.toContain("Close selected as released");
+    expect(html).not.toMatch(/name="issue" value="\d+"/);
+    // Reassuring hint takes the form's slot.
+    expect(html).toContain("All referenced issues for this release are closed");
+  });
+
   // #57: synthetic block for tag-less direct-push-OK repos. The allowlist
   // comes from `yhonda-ohishi/claude-skills`; only repos appearing in it get
   // the fallback path so auto-merge PR repos in a brief tag-less window stay


### PR DESCRIPTION
## Summary

`/releases?repo=...&tag=vX.Y.Z` の detail page で、flash redirect で全候補 row が消えても form/button が残る問題 (sibling of #59 index fix)。

`formInner` の判定を `data.rows.length` (pre-flash) から `candidates.length` (post-flash) に変更。0 なら form を非表示、代わりに「All referenced issues for this release are closed」hint を出す。

## Refs

Refs #61

## Local pre-flight

- `npm run typecheck` → 0 error
- `npm test` → **147 passed (was 146 + 1 new)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)