### PR TITLE
feat(mcp): add Projects v2 tools (list/get/items/add/set-field/remove/create-field)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ src/
 │       ├── commits.ts   # コミット情報
 │       ├── issues.ts    # issue 読取 + 書込
 │       ├── logs.ts      # ジョブログ取得・検索
+│       ├── projects.ts  # GitHub Projects v2 (GraphQL)
 │       ├── pulls.ts     # PR 読取 + マージ
 │       ├── releases.ts  # タグ・リリース
 │       └── repository.ts # ファイルツリー・コード検索
-└── github-api.ts        # 共通 HTTP ラッパー (validateOrg / githubApi / githubApiRaw)
+└── github-api.ts        # 共通 HTTP / GraphQL ラッパー (validateOrg / githubApi / githubGraphQL / githubApiRaw)
 ```
 
 各ツールは `server.registerTool(name, schema, handler)` で登録される。新ツール追加時は対応する `src/mcp/tools/*.ts` の `registerXxxTools` 関数内に追記するだけで `server.ts` の変更は不要。
@@ -52,6 +53,13 @@ src/
 | `list_tags` | releases | read | List tags for a repository. |
 | `get_latest_release` | releases | read | Get the latest release for a repository. |
 | `create_tag_release` | releases | write | Dispatch `tag-release.yml` workflow. |
+| `list_org_projects` | projects | read | List Projects v2 across one or more orgs (number/title/url/closed). |
+| `get_project` | projects | read | Get a Project's metadata + field definitions (incl. single-select options / iterations). |
+| `list_project_items` | projects | read | List items (issues/PRs/draft) attached to a Project with their field values. |
+| `add_issue_to_project` | projects | write | Add an issue/PR to a Project (resolves project number + issue number internally). |
+| `remove_project_item` | projects | write | Remove an item from a Project (does not delete the issue). |
+| `set_project_item_field` | projects | write | Update a field value on a Project item (single_select/iteration resolved by name). |
+| `create_project_field` | projects | write | Create a custom field (text/number/date/single_select). |
 | `get_file_tree` | repository | read | Get the file tree of a repository. |
 | `get_file_content` | repository | read | Get file content with optional line range. |
 | `search_code` | repository | read | grep-like code search. |
@@ -61,7 +69,7 @@ src/
 
 ## 認可
 
-- 操作対象は `ALLOWED_ORGS = ["ippoan", "ohishi-exp"]` 配下のリポジトリのみ (`src/github-api.ts`)
+- 操作対象は `ALLOWED_ORGS = ["ippoan", "ohishi-exp", "yhonda-ohishi"]` 配下のリポジトリ / Project のみ (`src/github-api.ts`)
 - それ以外の owner を指定すると `GitHubApiError(403, "Org not allowed: ...")` で拒否
 - リポジトリ指定は `"owner/name"` または `"name"` (後者は `ippoan/` を補完)
 
@@ -88,6 +96,8 @@ wrangler secret put GITHUB_TOKEN
 ```
 
 `repo` / `workflow` スコープが必要 (issue 書込・PR マージ・workflow dispatch のため)。
+Projects v2 ツールを使う場合は **`project`** (write) または `read:project` (read のみ) スコープも追加。
+GitHub App で運用する場合は **Organization → Projects: Read & Write** 権限が必要 (App 再インストール / 権限受諾)。
 
 ## 開発ルール
 

--- a/src/github-api.ts
+++ b/src/github-api.ts
@@ -66,6 +66,41 @@ export async function githubApi<T>(
   return res.json() as Promise<T>;
 }
 
+/**
+ * GitHub GraphQL API caller. Used by Projects v2 tools (REST has no Projects v2
+ * surface). On `errors[]` in the response, throws `GitHubApiError(400, ...)`
+ * with the concatenated error messages so callers don't have to peek inside.
+ */
+export async function githubGraphQL<T>(
+  token: string,
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<T> {
+  const res = await fetch(`${GITHUB_API}/graphql`, {
+    method: "POST",
+    headers: {
+      ...headers(token),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query, variables: variables ?? {} }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new GitHubApiError(res.status, `GitHub GraphQL ${res.status}: ${text}`);
+  }
+
+  const json = (await res.json()) as { data?: T; errors?: Array<{ message: string }> };
+  if (json.errors && json.errors.length > 0) {
+    const msg = json.errors.map((e) => e.message).join("; ");
+    throw new GitHubApiError(400, `GitHub GraphQL error: ${msg}`);
+  }
+  if (json.data === undefined) {
+    throw new GitHubApiError(500, "GitHub GraphQL: empty data");
+  }
+  return json.data;
+}
+
 export async function githubApiRaw(
   token: string,
   method: string,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -7,6 +7,7 @@ import { registerLogsTools } from "./tools/logs";
 import { registerRepositoryTools } from "./tools/repository";
 import { registerCommitsTools } from "./tools/commits";
 import { registerIssuesTools } from "./tools/issues";
+import { registerProjectsTools } from "./tools/projects";
 
 function createMcpServer(token: string): McpServer {
   const server = new McpServer({
@@ -21,6 +22,7 @@ function createMcpServer(token: string): McpServer {
   registerRepositoryTools(server, token);
   registerCommitsTools(server, token);
   registerIssuesTools(server, token);
+  registerProjectsTools(server, token);
 
   return server;
 }

--- a/src/mcp/tools/projects.ts
+++ b/src/mcp/tools/projects.ts
@@ -1,0 +1,647 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { githubGraphQL, parseRepo, validateOrg, GitHubApiError } from "../../github-api";
+
+// --------------------------------------------------------------------------
+// GitHub Projects v2 tooling.
+//
+// Projects v2 is GraphQL-only — there is no REST surface. Most write
+// operations need three indirections:
+//   1. project number → projectId          (resolveProjectId)
+//   2. issue/PR number → contentId         (resolveIssueContentId)
+//   3. field name → fieldId (+ optionId)   (fetched via getProjectFields)
+// We hide these behind ergonomic tool inputs (name/number) so the caller
+// doesn't have to deal with node IDs.
+// --------------------------------------------------------------------------
+
+interface ProjectField {
+  __typename: string;
+  id: string;
+  name: string;
+  dataType: string;
+  options?: Array<{ id: string; name: string }>;
+  configuration?: {
+    iterations?: Array<{ id: string; title: string; startDate: string; duration: number }>;
+    completedIterations?: Array<{ id: string; title: string; startDate: string; duration: number }>;
+  };
+}
+
+interface ProjectV2 {
+  id: string;
+  number: number;
+  title: string;
+  url: string;
+  closed: boolean;
+  shortDescription: string | null;
+  fields: { nodes: ProjectField[] };
+}
+
+export async function resolveProjectId(
+  token: string, org: string, number: number,
+): Promise<string> {
+  validateOrg(org);
+  const data = await githubGraphQL<{ organization: { projectV2: { id: string } | null } | null }>(
+    token,
+    `query($org:String!,$number:Int!){
+      organization(login:$org){
+        projectV2(number:$number){ id }
+      }
+    }`,
+    { org, number },
+  );
+  const id = data.organization?.projectV2?.id;
+  if (!id) throw new GitHubApiError(404, `Project not found: ${org}/projects/${number}`);
+  return id;
+}
+
+export async function resolveIssueContentId(
+  token: string, owner: string, repo: string, number: number,
+): Promise<string> {
+  validateOrg(owner);
+  const data = await githubGraphQL<{
+    repository: { issueOrPullRequest: { id: string } | null } | null;
+  }>(
+    token,
+    `query($owner:String!,$repo:String!,$number:Int!){
+      repository(owner:$owner, name:$repo){
+        issueOrPullRequest(number:$number){
+          ... on Issue { id }
+          ... on PullRequest { id }
+        }
+      }
+    }`,
+    { owner, repo, number },
+  );
+  const id = data.repository?.issueOrPullRequest?.id;
+  if (!id) throw new GitHubApiError(404, `Issue/PR not found: ${owner}/${repo}#${number}`);
+  return id;
+}
+
+async function getProjectFields(
+  token: string, projectId: string,
+): Promise<ProjectField[]> {
+  const data = await githubGraphQL<{ node: { fields: { nodes: ProjectField[] } } | null }>(
+    token,
+    `query($id:ID!){
+      node(id:$id){
+        ... on ProjectV2 {
+          fields(first:50){
+            nodes{
+              __typename
+              ... on ProjectV2FieldCommon { id name dataType }
+              ... on ProjectV2SingleSelectField {
+                id name dataType
+                options{ id name }
+              }
+              ... on ProjectV2IterationField {
+                id name dataType
+                configuration{
+                  iterations{ id title startDate duration }
+                  completedIterations{ id title startDate duration }
+                }
+              }
+            }
+          }
+        }
+      }
+    }`,
+    { id: projectId },
+  );
+  return data.node?.fields.nodes ?? [];
+}
+
+function summarizeField(f: ProjectField) {
+  const base: Record<string, unknown> = { id: f.id, name: f.name, dataType: f.dataType };
+  if (f.options) base.options = f.options.map((o) => ({ id: o.id, name: o.name }));
+  if (f.configuration?.iterations) {
+    base.iterations = [
+      ...f.configuration.iterations,
+      ...(f.configuration.completedIterations ?? []),
+    ].map((i) => ({ id: i.id, title: i.title, startDate: i.startDate, duration: i.duration }));
+  }
+  return base;
+}
+
+export function registerProjectsTools(server: McpServer, token: string): void {
+  // --------------------------------------------------------------------
+  // Read tools
+  // --------------------------------------------------------------------
+
+  server.registerTool(
+    "list_org_projects",
+    {
+      description:
+        "List GitHub Projects v2 across one or more organizations. " +
+        "Returns number/title/url/closed for each project, grouped by org. " +
+        "Use `get_project` afterwards to inspect fields.",
+      inputSchema: {
+        orgs: z.array(z.string()).min(1)
+          .describe("Organization logins (e.g. ['ippoan', 'ohishi-exp', 'yhonda-ohishi'])"),
+        first: z.number().min(1).max(100).default(50)
+          .describe("Max projects per org (default 50)"),
+        include_closed: z.boolean().default(false)
+          .describe("Include closed projects (default false)"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ orgs, first, include_closed }) => {
+      for (const o of orgs) validateOrg(o);
+      const perOrg = await Promise.all(orgs.map(async (org) => {
+        const data = await githubGraphQL<{
+          organization: {
+            projectsV2: { nodes: Array<{
+              id: string; number: number; title: string;
+              url: string; closed: boolean; shortDescription: string | null;
+            }> };
+          } | null;
+        }>(
+          token,
+          `query($org:String!,$first:Int!){
+            organization(login:$org){
+              projectsV2(first:$first, orderBy:{field:NUMBER,direction:DESC}){
+                nodes{ id number title url closed shortDescription }
+              }
+            }
+          }`,
+          { org, first },
+        );
+        const nodes = data.organization?.projectsV2.nodes ?? [];
+        const filtered = include_closed ? nodes : nodes.filter((p) => !p.closed);
+        return {
+          org,
+          projects: filtered.map((p) => ({
+            number: p.number,
+            title: p.title,
+            url: p.url,
+            closed: p.closed,
+            shortDescription: p.shortDescription,
+          })),
+        };
+      }));
+      return { content: [{ type: "text" as const, text: JSON.stringify(perOrg, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "get_project",
+    {
+      description:
+        "Get a Projects v2 project's metadata and full field definitions " +
+        "(including single-select options and iteration values). Required " +
+        "before `set_project_item_field` if you need to know valid option names.",
+      inputSchema: {
+        org: z.string().describe("Organization login"),
+        number: z.number().describe("Project number (the integer in the project URL)"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ org, number }) => {
+      validateOrg(org);
+      const data = await githubGraphQL<{
+        organization: { projectV2: ProjectV2 | null } | null;
+      }>(
+        token,
+        `query($org:String!,$number:Int!){
+          organization(login:$org){
+            projectV2(number:$number){
+              id number title url closed shortDescription
+              fields(first:50){
+                nodes{
+                  __typename
+                  ... on ProjectV2FieldCommon { id name dataType }
+                  ... on ProjectV2SingleSelectField {
+                    id name dataType
+                    options{ id name }
+                  }
+                  ... on ProjectV2IterationField {
+                    id name dataType
+                    configuration{
+                      iterations{ id title startDate duration }
+                      completedIterations{ id title startDate duration }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }`,
+        { org, number },
+      );
+      const p = data.organization?.projectV2;
+      if (!p) throw new GitHubApiError(404, `Project not found: ${org}/projects/${number}`);
+      const result = {
+        id: p.id,
+        number: p.number,
+        title: p.title,
+        url: p.url,
+        closed: p.closed,
+        shortDescription: p.shortDescription,
+        fields: p.fields.nodes.map(summarizeField),
+      };
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "list_project_items",
+    {
+      description:
+        "List items (issues / PRs / draft issues) attached to a Projects v2 " +
+        "project. Each item includes its current field values.",
+      inputSchema: {
+        org: z.string().describe("Organization login"),
+        number: z.number().describe("Project number"),
+        first: z.number().min(1).max(100).default(50)
+          .describe("Max items to return (default 50)"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ org, number, first }) => {
+      validateOrg(org);
+      const data = await githubGraphQL<{
+        organization: { projectV2: { items: { nodes: ProjectItemNode[] } } | null } | null;
+      }>(
+        token,
+        `query($org:String!,$number:Int!,$first:Int!){
+          organization(login:$org){
+            projectV2(number:$number){
+              items(first:$first){
+                nodes{
+                  id
+                  type
+                  content{
+                    __typename
+                    ... on Issue { number title url state repository{ nameWithOwner } }
+                    ... on PullRequest { number title url state repository{ nameWithOwner } }
+                    ... on DraftIssue { title }
+                  }
+                  fieldValues(first:30){
+                    nodes{
+                      __typename
+                      ... on ProjectV2ItemFieldTextValue {
+                        text field{ ... on ProjectV2FieldCommon { name } }
+                      }
+                      ... on ProjectV2ItemFieldNumberValue {
+                        number field{ ... on ProjectV2FieldCommon { name } }
+                      }
+                      ... on ProjectV2ItemFieldDateValue {
+                        date field{ ... on ProjectV2FieldCommon { name } }
+                      }
+                      ... on ProjectV2ItemFieldSingleSelectValue {
+                        name optionId field{ ... on ProjectV2FieldCommon { name } }
+                      }
+                      ... on ProjectV2ItemFieldIterationValue {
+                        title iterationId
+                        field{ ... on ProjectV2FieldCommon { name } }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }`,
+        { org, number, first },
+      );
+      const nodes = data.organization?.projectV2?.items.nodes ?? [];
+      const result = nodes.map(formatItem);
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  // --------------------------------------------------------------------
+  // Write tools
+  // --------------------------------------------------------------------
+
+  server.registerTool(
+    "add_issue_to_project",
+    {
+      description:
+        "Add an issue (or PR) to a Projects v2 project. Returns the new item's id, " +
+        "which is needed by `set_project_item_field` and `remove_project_item`.",
+      inputSchema: {
+        org: z.string().describe("Project owner organization (e.g. 'ippoan')"),
+        project_number: z.number().describe("Project number"),
+        repo: z.string()
+          .describe("Repository hosting the issue/PR (e.g. 'rust-alc-api' or 'ippoan/rust-alc-api')"),
+        issue_number: z.number().describe("Issue or PR number to add"),
+      },
+      annotations: { destructiveHint: true },
+    },
+    async ({ org, project_number, repo, issue_number }) => {
+      validateOrg(org);
+      const { owner, repo: name } = parseRepo(repo);
+      validateOrg(owner);
+      const [projectId, contentId] = await Promise.all([
+        resolveProjectId(token, org, project_number),
+        resolveIssueContentId(token, owner, name, issue_number),
+      ]);
+      const data = await githubGraphQL<{
+        addProjectV2ItemById: { item: { id: string } };
+      }>(
+        token,
+        `mutation($projectId:ID!,$contentId:ID!){
+          addProjectV2ItemById(input:{projectId:$projectId, contentId:$contentId}){
+            item{ id }
+          }
+        }`,
+        { projectId, contentId },
+      );
+      const result = {
+        item_id: data.addProjectV2ItemById.item.id,
+        project_id: projectId,
+        content_id: contentId,
+        repo: `${owner}/${name}`,
+        issue_number,
+      };
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "remove_project_item",
+    {
+      description: "Remove an item from a Projects v2 project (does not delete the underlying issue/PR).",
+      inputSchema: {
+        org: z.string().describe("Project owner organization"),
+        project_number: z.number().describe("Project number"),
+        item_id: z.string().describe("Item node ID (from `list_project_items` or `add_issue_to_project`)"),
+      },
+      annotations: { destructiveHint: true },
+    },
+    async ({ org, project_number, item_id }) => {
+      const projectId = await resolveProjectId(token, org, project_number);
+      const data = await githubGraphQL<{
+        deleteProjectV2Item: { deletedItemId: string };
+      }>(
+        token,
+        `mutation($projectId:ID!,$itemId:ID!){
+          deleteProjectV2Item(input:{projectId:$projectId, itemId:$itemId}){
+            deletedItemId
+          }
+        }`,
+        { projectId, itemId: item_id },
+      );
+      const result = { deleted_item_id: data.deleteProjectV2Item.deletedItemId };
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "set_project_item_field",
+    {
+      description:
+        "Update a field value on a Projects v2 item. Specify the field by name; " +
+        "for single_select / iteration fields, pass the option name / iteration title " +
+        "in `value` (it is resolved to the underlying option/iteration ID internally). " +
+        "For text/number/date, pass the literal value. Pass `value: null` to clear " +
+        "the field.",
+      inputSchema: {
+        org: z.string().describe("Project owner organization"),
+        project_number: z.number().describe("Project number"),
+        item_id: z.string().describe("Item node ID"),
+        field_name: z.string().describe("Field name (matches `name` from `get_project`)"),
+        value: z.union([z.string(), z.number(), z.null()])
+          .describe("New field value (string for text/date/single_select/iteration, number for number, null to clear)"),
+      },
+      annotations: { destructiveHint: true },
+    },
+    async ({ org, project_number, item_id, field_name, value }) => {
+      const projectId = await resolveProjectId(token, org, project_number);
+      const fields = await getProjectFields(token, projectId);
+      const field = fields.find((f) => f.name === field_name);
+      if (!field) {
+        const available = fields.map((f) => f.name).join(", ");
+        throw new GitHubApiError(404, `Field not found: ${field_name}. Available: ${available}`);
+      }
+
+      // Build the GraphQL `value` input based on the field's data type.
+      const valueInput: Record<string, unknown> = {};
+      if (value === null) {
+        // Clearing → use clearProjectV2ItemFieldValue mutation instead.
+        const data = await githubGraphQL<{
+          clearProjectV2ItemFieldValue: { projectV2Item: { id: string } };
+        }>(
+          token,
+          `mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!){
+            clearProjectV2ItemFieldValue(input:{
+              projectId:$projectId, itemId:$itemId, fieldId:$fieldId
+            }){ projectV2Item{ id } }
+          }`,
+          { projectId, itemId: item_id, fieldId: field.id },
+        );
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({
+            item_id: data.clearProjectV2ItemFieldValue.projectV2Item.id,
+            field: field_name,
+            cleared: true,
+          }, null, 2) }],
+        };
+      }
+
+      switch (field.dataType) {
+        case "TEXT":
+          if (typeof value !== "string") {
+            throw new GitHubApiError(400, `Field ${field_name} (TEXT) requires a string value`);
+          }
+          valueInput.text = value;
+          break;
+        case "NUMBER": {
+          const n = typeof value === "number" ? value : Number(value);
+          if (Number.isNaN(n)) {
+            throw new GitHubApiError(400, `Field ${field_name} (NUMBER) requires a numeric value`);
+          }
+          valueInput.number = n;
+          break;
+        }
+        case "DATE":
+          if (typeof value !== "string") {
+            throw new GitHubApiError(400, `Field ${field_name} (DATE) requires an ISO date string (YYYY-MM-DD)`);
+          }
+          valueInput.date = value;
+          break;
+        case "SINGLE_SELECT": {
+          const optionName = String(value);
+          const opt = field.options?.find((o) => o.name === optionName);
+          if (!opt) {
+            const avail = (field.options ?? []).map((o) => o.name).join(", ");
+            throw new GitHubApiError(404, `Option not found on ${field_name}: ${optionName}. Available: ${avail}`);
+          }
+          valueInput.singleSelectOptionId = opt.id;
+          break;
+        }
+        case "ITERATION": {
+          const iterTitle = String(value);
+          const all = [
+            ...(field.configuration?.iterations ?? []),
+            ...(field.configuration?.completedIterations ?? []),
+          ];
+          const it = all.find((i) => i.title === iterTitle);
+          if (!it) {
+            const avail = all.map((i) => i.title).join(", ");
+            throw new GitHubApiError(404, `Iteration not found on ${field_name}: ${iterTitle}. Available: ${avail}`);
+          }
+          valueInput.iterationId = it.id;
+          break;
+        }
+        default:
+          throw new GitHubApiError(
+            400,
+            `Field ${field_name} has unsupported dataType ${field.dataType} for set_project_item_field`,
+          );
+      }
+
+      const data = await githubGraphQL<{
+        updateProjectV2ItemFieldValue: { projectV2Item: { id: string } };
+      }>(
+        token,
+        `mutation($projectId:ID!,$itemId:ID!,$fieldId:ID!,$value:ProjectV2FieldValue!){
+          updateProjectV2ItemFieldValue(input:{
+            projectId:$projectId, itemId:$itemId, fieldId:$fieldId, value:$value
+          }){ projectV2Item{ id } }
+        }`,
+        { projectId, itemId: item_id, fieldId: field.id, value: valueInput },
+      );
+      const result = {
+        item_id: data.updateProjectV2ItemFieldValue.projectV2Item.id,
+        field: field_name,
+        dataType: field.dataType,
+        value,
+      };
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
+    "create_project_field",
+    {
+      description:
+        "Create a custom field on a Projects v2 project. For `single_select`, " +
+        "supply `single_select_options` (array of option names). `iteration` " +
+        "fields are not supported here — create them in the GitHub UI.",
+      inputSchema: {
+        org: z.string().describe("Project owner organization"),
+        project_number: z.number().describe("Project number"),
+        name: z.string().describe("Field name"),
+        data_type: z.enum(["text", "number", "date", "single_select"])
+          .describe("Field data type"),
+        single_select_options: z.array(z.string()).optional()
+          .describe("Required when data_type='single_select': option names"),
+      },
+      annotations: { destructiveHint: true },
+    },
+    async ({ org, project_number, name, data_type, single_select_options }) => {
+      const projectId = await resolveProjectId(token, org, project_number);
+
+      const dataTypeMap = {
+        text: "TEXT", number: "NUMBER", date: "DATE", single_select: "SINGLE_SELECT",
+      } as const;
+      const gqlDataType = dataTypeMap[data_type];
+
+      const input: Record<string, unknown> = {
+        projectId, dataType: gqlDataType, name,
+      };
+      if (data_type === "single_select") {
+        if (!single_select_options || single_select_options.length === 0) {
+          throw new GitHubApiError(400, "single_select_options is required for data_type='single_select'");
+        }
+        // GitHub requires a color and description per option; default to GRAY/empty.
+        input.singleSelectOptions = single_select_options.map((n) => ({
+          name: n, color: "GRAY", description: "",
+        }));
+      }
+
+      const data = await githubGraphQL<{
+        createProjectV2Field: { projectV2Field: { __typename: string } };
+      }>(
+        token,
+        `mutation($input:CreateProjectV2FieldInput!){
+          createProjectV2Field(input:$input){
+            projectV2Field{
+              __typename
+              ... on ProjectV2FieldCommon { id name dataType }
+              ... on ProjectV2SingleSelectField {
+                id name dataType options{ id name }
+              }
+            }
+          }
+        }`,
+        { input },
+      );
+      const result = {
+        field: data.createProjectV2Field.projectV2Field,
+      };
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+}
+
+// --------------------------------------------------------------------------
+// Internal item formatting (kept out of the schema namespace)
+// --------------------------------------------------------------------------
+
+interface ProjectItemNode {
+  id: string;
+  type: string;
+  content:
+    | {
+        __typename: "Issue" | "PullRequest";
+        number: number; title: string; url: string; state: string;
+        repository: { nameWithOwner: string };
+      }
+    | { __typename: "DraftIssue"; title: string }
+    | null;
+  fieldValues: { nodes: ProjectFieldValueNode[] };
+}
+
+type ProjectFieldValueNode =
+  | { __typename: "ProjectV2ItemFieldTextValue"; text: string; field: { name?: string } }
+  | { __typename: "ProjectV2ItemFieldNumberValue"; number: number; field: { name?: string } }
+  | { __typename: "ProjectV2ItemFieldDateValue"; date: string; field: { name?: string } }
+  | { __typename: "ProjectV2ItemFieldSingleSelectValue"; name: string; optionId: string; field: { name?: string } }
+  | { __typename: "ProjectV2ItemFieldIterationValue"; title: string; iterationId: string; field: { name?: string } }
+  | { __typename: string };
+
+function formatItem(node: ProjectItemNode) {
+  const content = node.content;
+  let contentSummary: Record<string, unknown> = { type: "unknown" };
+  if (content) {
+    if (content.__typename === "Issue" || content.__typename === "PullRequest") {
+      contentSummary = {
+        type: content.__typename === "Issue" ? "issue" : "pull_request",
+        repo: content.repository.nameWithOwner,
+        number: content.number,
+        title: content.title,
+        state: content.state,
+        url: content.url,
+      };
+    } else if (content.__typename === "DraftIssue") {
+      contentSummary = { type: "draft_issue", title: content.title };
+    }
+  }
+
+  const values: Record<string, unknown> = {};
+  for (const v of node.fieldValues.nodes) {
+    const fname = (v as { field?: { name?: string } }).field?.name;
+    if (!fname) continue;
+    switch (v.__typename) {
+      case "ProjectV2ItemFieldTextValue":
+        values[fname] = (v as { text: string }).text; break;
+      case "ProjectV2ItemFieldNumberValue":
+        values[fname] = (v as { number: number }).number; break;
+      case "ProjectV2ItemFieldDateValue":
+        values[fname] = (v as { date: string }).date; break;
+      case "ProjectV2ItemFieldSingleSelectValue":
+        values[fname] = (v as { name: string }).name; break;
+      case "ProjectV2ItemFieldIterationValue":
+        values[fname] = (v as { title: string }).title; break;
+    }
+  }
+
+  return {
+    item_id: node.id,
+    item_type: node.type,
+    content: contentSummary,
+    fields: values,
+  };
+}

--- a/test/mcp/projects.test.ts
+++ b/test/mcp/projects.test.ts
@@ -1,0 +1,435 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { githubGraphQL, GitHubApiError } from "../../src/github-api";
+import { resolveProjectId, resolveIssueContentId } from "../../src/mcp/tools/projects";
+
+// These tests exercise the GraphQL helper + Projects v2 tool logic against
+// mocked fetch responses. The MCP transport itself is covered by tools.test.ts.
+
+describe("githubGraphQL helper", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("POSTs to /graphql with query + variables and returns data", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({ data: { ok: true } }),
+    );
+
+    const result = await githubGraphQL<{ ok: boolean }>(
+      "token", "query{ ok }", { foo: "bar" },
+    );
+
+    expect(result.ok).toBe(true);
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    expect(url).toBe("https://api.github.com/graphql");
+    const init = fetchSpy.mock.calls[0]![1]!;
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body as string);
+    expect(body.query).toBe("query{ ok }");
+    expect(body.variables).toEqual({ foo: "bar" });
+  });
+
+  it("throws GitHubApiError(400) on errors[]", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({ errors: [{ message: "boom" }, { message: "kaboom" }] }),
+    );
+
+    await expect(githubGraphQL("token", "query{}"))
+      .rejects.toMatchObject({
+        name: "GitHubApiError",
+        status: 400,
+        message: expect.stringContaining("boom; kaboom"),
+      });
+  });
+
+  it("throws GitHubApiError on non-2xx", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("Unauthorized", { status: 401 }),
+    );
+    await expect(githubGraphQL("token", "query{}")).rejects.toThrow(GitHubApiError);
+  });
+});
+
+describe("resolveProjectId", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("returns project id when present", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({ data: { organization: { projectV2: { id: "PVT_abc" } } } }),
+    );
+    const id = await resolveProjectId("token", "ippoan", 7);
+    expect(id).toBe("PVT_abc");
+  });
+
+  it("throws 404 when project missing", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({ data: { organization: { projectV2: null } } }),
+    );
+    await expect(resolveProjectId("token", "ippoan", 99))
+      .rejects.toMatchObject({ status: 404 });
+  });
+
+  it("rejects disallowed org before hitting network", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await expect(resolveProjectId("token", "evil-org", 1))
+      .rejects.toMatchObject({ status: 403 });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("accepts each allowed org (ippoan, ohishi-exp, yhonda-ohishi)", async () => {
+    // Each call gets its own Response (a Response body can only be consumed once).
+    vi.spyOn(globalThis, "fetch").mockImplementation(() =>
+      Promise.resolve(Response.json({
+        data: { organization: { projectV2: { id: "PVT_x" } } },
+      })),
+    );
+    for (const org of ["ippoan", "ohishi-exp", "yhonda-ohishi"]) {
+      await expect(resolveProjectId("token", org, 1)).resolves.toBe("PVT_x");
+    }
+  });
+});
+
+describe("resolveIssueContentId", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("returns issue/PR node id from issueOrPullRequest union", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        data: { repository: { issueOrPullRequest: { id: "I_xyz" } } },
+      }),
+    );
+    const id = await resolveIssueContentId("token", "ippoan", "ci-dashboard", 63);
+    expect(id).toBe("I_xyz");
+  });
+
+  it("throws 404 when issue/PR missing", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({ data: { repository: { issueOrPullRequest: null } } }),
+    );
+    await expect(resolveIssueContentId("token", "ippoan", "ci-dashboard", 9999))
+      .rejects.toMatchObject({ status: 404 });
+  });
+});
+
+describe("Projects v2 tools — integration via MCP server", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  // Helper: drive a tool through the MCP HTTP transport, returning the parsed
+  // text payload. Each call uses its own fetch mock queue.
+  async function callTool(name: string, args: Record<string, unknown>) {
+    const { handleMcpRequest } = await import("../../src/mcp/server");
+    const req = new Request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0", id: 1, method: "tools/call",
+        params: { name, arguments: args },
+      }),
+    });
+    const res = await handleMcpRequest(req, "test-token");
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      result?: { content?: Array<{ type: string; text: string }>; isError?: boolean };
+      error?: { message: string };
+    };
+    if (body.error) throw new Error(body.error.message);
+    if (body.result?.isError) {
+      const text = body.result.content?.[0]?.text ?? "(no message)";
+      throw new Error(text);
+    }
+    const text = body.result?.content?.[0]?.text ?? "";
+    return JSON.parse(text) as unknown;
+  }
+
+  it("list_org_projects groups results per org and filters closed by default", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(Response.json({
+        data: { organization: { projectsV2: { nodes: [
+          { id: "PVT_1", number: 1, title: "Active", url: "https://github.com/orgs/ippoan/projects/1", closed: false, shortDescription: null },
+          { id: "PVT_2", number: 2, title: "Done", url: "https://github.com/orgs/ippoan/projects/2", closed: true, shortDescription: null },
+        ] } } },
+      }))
+      .mockResolvedValueOnce(Response.json({
+        data: { organization: { projectsV2: { nodes: [
+          { id: "PVT_3", number: 1, title: "Exp", url: "https://github.com/orgs/ohishi-exp/projects/1", closed: false, shortDescription: "exp" },
+        ] } } },
+      }));
+
+    const result = await callTool("list_org_projects", {
+      orgs: ["ippoan", "ohishi-exp"],
+    }) as Array<{ org: string; projects: Array<{ number: number; closed: boolean }> }>;
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(2);
+    expect(result[0]!.org).toBe("ippoan");
+    expect(result[0]!.projects).toHaveLength(1);
+    expect(result[0]!.projects[0]!.number).toBe(1);
+    expect(result[1]!.org).toBe("ohishi-exp");
+    expect(result[1]!.projects[0]!.number).toBe(1);
+  });
+
+  it("list_org_projects with include_closed=true returns closed projects too", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(Response.json({
+      data: { organization: { projectsV2: { nodes: [
+        { id: "PVT_1", number: 1, title: "A", url: "u", closed: false, shortDescription: null },
+        { id: "PVT_2", number: 2, title: "B", url: "u", closed: true, shortDescription: null },
+      ] } } },
+    }));
+
+    const result = await callTool("list_org_projects", {
+      orgs: ["ippoan"], include_closed: true,
+    }) as Array<{ projects: unknown[] }>;
+    expect(result[0]!.projects).toHaveLength(2);
+  });
+
+  it("list_org_projects rejects disallowed orgs (no fetch issued)", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await expect(callTool("list_org_projects", { orgs: ["evil-org"] }))
+      .rejects.toThrow(/not allowed/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("get_project returns fields with options for single_select", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(Response.json({
+      data: { organization: { projectV2: {
+        id: "PVT_1", number: 1, title: "P", url: "u", closed: false, shortDescription: null,
+        fields: { nodes: [
+          { __typename: "ProjectV2FieldCommon", id: "F_t", name: "Title", dataType: "TITLE" },
+          { __typename: "ProjectV2SingleSelectField", id: "F_s", name: "Status", dataType: "SINGLE_SELECT",
+            options: [
+              { id: "opt_todo", name: "Todo" },
+              { id: "opt_doing", name: "In Progress" },
+              { id: "opt_done", name: "Done" },
+            ] },
+        ] },
+      } } },
+    }));
+
+    const result = await callTool("get_project", { org: "ippoan", number: 1 }) as {
+      number: number; fields: Array<{ name: string; options?: Array<{ name: string }> }>;
+    };
+    expect(result.number).toBe(1);
+    expect(result.fields).toHaveLength(2);
+    const status = result.fields.find((f) => f.name === "Status")!;
+    expect(status.options!.map((o) => o.name)).toEqual(["Todo", "In Progress", "Done"]);
+  });
+
+  it("add_issue_to_project resolves projectId + contentId then mutates", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(Response.json({
+        data: { organization: { projectV2: { id: "PVT_1" } } },
+      }))
+      .mockResolvedValueOnce(Response.json({
+        data: { repository: { issueOrPullRequest: { id: "I_42" } } },
+      }))
+      .mockResolvedValueOnce(Response.json({
+        data: { addProjectV2ItemById: { item: { id: "PVTI_xyz" } } },
+      }));
+
+    const result = await callTool("add_issue_to_project", {
+      org: "ippoan", project_number: 1,
+      repo: "ippoan/ci-dashboard", issue_number: 42,
+    }) as { item_id: string; project_id: string; content_id: string };
+
+    expect(result.item_id).toBe("PVTI_xyz");
+    expect(result.project_id).toBe("PVT_1");
+    expect(result.content_id).toBe("I_42");
+
+    const mutationBody = JSON.parse(fetchSpy.mock.calls[2]![1]!.body as string);
+    expect(mutationBody.query).toContain("addProjectV2ItemById");
+    expect(mutationBody.variables.projectId).toBe("PVT_1");
+    expect(mutationBody.variables.contentId).toBe("I_42");
+  });
+
+  it("set_project_item_field maps single_select option name → optionId", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      // resolveProjectId
+      .mockResolvedValueOnce(Response.json({
+        data: { organization: { projectV2: { id: "PVT_1" } } },
+      }))
+      // getProjectFields
+      .mockResolvedValueOnce(Response.json({
+        data: { node: { fields: { nodes: [
+          { __typename: "ProjectV2SingleSelectField", id: "F_s", name: "Status",
+            dataType: "SINGLE_SELECT", options: [
+              { id: "opt_todo", name: "Todo" },
+              { id: "opt_done", name: "Done" },
+            ] },
+        ] } } },
+      }))
+      // updateProjectV2ItemFieldValue
+      .mockResolvedValueOnce(Response.json({
+        data: { updateProjectV2ItemFieldValue: { projectV2Item: { id: "PVTI_xyz" } } },
+      }));
+
+    const result = await callTool("set_project_item_field", {
+      org: "ippoan", project_number: 1,
+      item_id: "PVTI_xyz", field_name: "Status", value: "Done",
+    }) as { field: string; dataType: string; value: unknown };
+
+    expect(result.field).toBe("Status");
+    expect(result.dataType).toBe("SINGLE_SELECT");
+    expect(result.value).toBe("Done");
+
+    const mutationBody = JSON.parse(fetchSpy.mock.calls[2]![1]!.body as string);
+    expect(mutationBody.variables.value.singleSelectOptionId).toBe("opt_done");
+    expect(mutationBody.variables.fieldId).toBe("F_s");
+  });
+
+  it("set_project_item_field surfaces a useful error when option missing", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(Response.json({
+        data: { organization: { projectV2: { id: "PVT_1" } } },
+      }))
+      .mockResolvedValueOnce(Response.json({
+        data: { node: { fields: { nodes: [
+          { __typename: "ProjectV2SingleSelectField", id: "F_s", name: "Status",
+            dataType: "SINGLE_SELECT", options: [{ id: "opt_todo", name: "Todo" }] },
+        ] } } },
+      }));
+
+    await expect(callTool("set_project_item_field", {
+      org: "ippoan", project_number: 1,
+      item_id: "PVTI_xyz", field_name: "Status", value: "Done",
+    })).rejects.toThrow(/Option not found.*Available: Todo/);
+  });
+
+  it("set_project_item_field with text field passes value as text", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(Response.json({
+        data: { organization: { projectV2: { id: "PVT_1" } } },
+      }))
+      .mockResolvedValueOnce(Response.json({
+        data: { node: { fields: { nodes: [
+          { __typename: "ProjectV2FieldCommon", id: "F_t", name: "Notes", dataType: "TEXT" },
+        ] } } },
+      }))
+      .mockResolvedValueOnce(Response.json({
+        data: { updateProjectV2ItemFieldValue: { projectV2Item: { id: "PVTI_xyz" } } },
+      }));
+
+    await callTool("set_project_item_field", {
+      org: "ippoan", project_number: 1,
+      item_id: "PVTI_xyz", field_name: "Notes", value: "hello",
+    });
+
+    const mutationBody = JSON.parse(fetchSpy.mock.calls[2]![1]!.body as string);
+    expect(mutationBody.variables.value).toEqual({ text: "hello" });
+  });
+
+  it("set_project_item_field with value=null calls clearProjectV2ItemFieldValue", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(Response.json({
+        data: { organization: { projectV2: { id: "PVT_1" } } },
+      }))
+      .mockResolvedValueOnce(Response.json({
+        data: { node: { fields: { nodes: [
+          { __typename: "ProjectV2FieldCommon", id: "F_t", name: "Notes", dataType: "TEXT" },
+        ] } } },
+      }))
+      .mockResolvedValueOnce(Response.json({
+        data: { clearProjectV2ItemFieldValue: { projectV2Item: { id: "PVTI_xyz" } } },
+      }));
+
+    const result = await callTool("set_project_item_field", {
+      org: "ippoan", project_number: 1,
+      item_id: "PVTI_xyz", field_name: "Notes", value: null,
+    }) as { cleared: boolean };
+
+    expect(result.cleared).toBe(true);
+    const mutationBody = JSON.parse(fetchSpy.mock.calls[2]![1]!.body as string);
+    expect(mutationBody.query).toContain("clearProjectV2ItemFieldValue");
+  });
+
+  it("remove_project_item issues deleteProjectV2Item mutation", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(Response.json({
+        data: { organization: { projectV2: { id: "PVT_1" } } },
+      }))
+      .mockResolvedValueOnce(Response.json({
+        data: { deleteProjectV2Item: { deletedItemId: "PVTI_xyz" } },
+      }));
+
+    const result = await callTool("remove_project_item", {
+      org: "ippoan", project_number: 1, item_id: "PVTI_xyz",
+    }) as { deleted_item_id: string };
+
+    expect(result.deleted_item_id).toBe("PVTI_xyz");
+    const mutationBody = JSON.parse(fetchSpy.mock.calls[1]![1]!.body as string);
+    expect(mutationBody.query).toContain("deleteProjectV2Item");
+    expect(mutationBody.variables.itemId).toBe("PVTI_xyz");
+  });
+
+  it("create_project_field for single_select sends options with default color", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(Response.json({
+        data: { organization: { projectV2: { id: "PVT_1" } } },
+      }))
+      .mockResolvedValueOnce(Response.json({
+        data: { createProjectV2Field: { projectV2Field: {
+          __typename: "ProjectV2SingleSelectField",
+          id: "F_new", name: "Priority", dataType: "SINGLE_SELECT",
+          options: [{ id: "o1", name: "P0" }, { id: "o2", name: "P1" }],
+        } } },
+      }));
+
+    await callTool("create_project_field", {
+      org: "ippoan", project_number: 1,
+      name: "Priority", data_type: "single_select",
+      single_select_options: ["P0", "P1"],
+    });
+
+    const mutationBody = JSON.parse(fetchSpy.mock.calls[1]![1]!.body as string);
+    expect(mutationBody.variables.input.dataType).toBe("SINGLE_SELECT");
+    expect(mutationBody.variables.input.singleSelectOptions).toEqual([
+      { name: "P0", color: "GRAY", description: "" },
+      { name: "P1", color: "GRAY", description: "" },
+    ]);
+  });
+
+  it("create_project_field rejects single_select without options", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(Response.json({
+      data: { organization: { projectV2: { id: "PVT_1" } } },
+    }));
+    await expect(callTool("create_project_field", {
+      org: "ippoan", project_number: 1,
+      name: "Priority", data_type: "single_select",
+    })).rejects.toThrow(/single_select_options is required/);
+  });
+
+  it("list_project_items flattens content + field values", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(Response.json({
+      data: { organization: { projectV2: { items: { nodes: [
+        {
+          id: "PVTI_1", type: "ISSUE",
+          content: {
+            __typename: "Issue", number: 63, title: "MCP: Projects v2",
+            url: "https://github.com/ippoan/ci-dashboard/issues/63",
+            state: "OPEN", repository: { nameWithOwner: "ippoan/ci-dashboard" },
+          },
+          fieldValues: { nodes: [
+            { __typename: "ProjectV2ItemFieldSingleSelectValue",
+              name: "In Progress", optionId: "opt_doing",
+              field: { name: "Status" } },
+            { __typename: "ProjectV2ItemFieldTextValue",
+              text: "epic-001", field: { name: "Epic" } },
+          ] },
+        },
+      ] } } } },
+    }));
+
+    const items = await callTool("list_project_items", {
+      org: "ippoan", number: 1,
+    }) as Array<{
+      content: { type: string; number: number; repo: string };
+      fields: Record<string, unknown>;
+    }>;
+
+    expect(items).toHaveLength(1);
+    expect(items[0]!.content.type).toBe("issue");
+    expect(items[0]!.content.number).toBe(63);
+    expect(items[0]!.content.repo).toBe("ippoan/ci-dashboard");
+    expect(items[0]!.fields).toEqual({ Status: "In Progress", Epic: "epic-001" });
+  });
+});


### PR DESCRIPTION
## 概要

GitHub Projects v2 を MCP から操作するためのツール 7 種を追加。REST に Projects v2 のサーフェスは無いので、`src/github-api.ts` に `githubGraphQL` ヘルパを追加し、その上に新カテゴリ `projects` を構築した。

## 関連 issue

Refs #63

## 変更点

新ツール:

| name | type | 用途 |
|------|------|------|
| `list_org_projects` | read | **複数 org 対応** (`orgs: string[]` で `ippoan` / `ohishi-exp` / `yhonda-ohishi` を一括) |
| `get_project` | read | フィールド定義 + single_select オプション + iteration 一覧 |
| `list_project_items` | read | item の content + フィールド値をフラット化 |
| `add_issue_to_project` | write | project番号 + issue番号 → 内部で projectId/contentId 解決 |
| `remove_project_item` | write | item 削除 (issue は残す) |
| `set_project_item_field` | write | フィールド名指定。SINGLE_SELECT/ITERATION は名前 → ID 解決。`value: null` で `clearProjectV2ItemFieldValue` に分岐 |
| `create_project_field` | write | text/number/date/single_select (iteration は GitHub UI 専用) |

設計ポイント:

- **GraphQL 層**: `githubGraphQL<T>(token, query, variables)` を追加。`errors[]` を `GitHubApiError(400)` に正規化し、既存 REST ラッパと同じ呼び口に揃えた。
- **org 横断**: `list_org_projects` は `list_org_issues` と同じ `orgs: string[]` パターン。各 org に並列で `projectsV2` クエリを投げてグルーピング。
- **ID 解決を全部隠す**: caller は `org` + `project_number` + `issue_number` + `field_name` + 人間可読な値だけ。`projectId`/`contentId`/`fieldId`/`optionId`/`iterationId` は内部で解決。
- **エラーが親切**: 該当 option/iteration が無いときは `Available: Todo, In Progress, Done` のように候補を併記。
- **権限**: `ALLOWED_ORGS` には既に 3 org とも入っているので、各ツールの先頭で `validateOrg` するだけ。

## 動作確認

- [x] `npm test` — 169/169 passed (うち本 PR で +22 件)
- [x] `npm run typecheck` — pass
- [ ] 手動確認: GitHub App permissions に **Organization → Projects: Read & Write** を追加して再インストールが必要 (本 PR ではコード変更のみ)

## メモ

- `create_project` (Project 自体の新規作成) は issue でも優先度低と明記されていたため未実装。必要なら別 PR で追加。
- `iteration` フィールドの新規作成は GitHub の `createProjectV2Field` mutation で公式にサポートされていないので `create_project_field` の `data_type` enum から外している (GitHub UI で作る前提)。
- README のツール一覧表 / アーキ図 / 必要スコープ説明も追記済み。

https://claude.ai/code/session_01P8MvNsNCb1xUKbGecc1cju

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8MvNsNCb1xUKbGecc1cju)_