### PR TITLE
feat(issues): aggregate Project-tagged issues into a top section

### DIFF
--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -1,4 +1,5 @@
 import { fetchOrgIssues, type OrgIssue } from "./mcp/tools/issues";
+import { fetchProjectIssueMap, type ProjectRef } from "./mcp/tools/projects";
 import { renderTabs, TAB_STYLES } from "./nav-tabs";
 
 // Orgs fetched in full. Same allowlist as github-api.ts (not imported because
@@ -10,10 +11,20 @@ const ORGS = ["ippoan", "ohishi-exp"];
 // active claude-tooling repos by filtering on `repo:` qualifiers.
 const YHONDA_REPOS = ["yhonda-ohishi/claude-skills", "yhonda-ohishi/claude-hooks"];
 
+// Orgs scanned for Projects v2 (used by `fetchProjectIssueMap`). yhonda-ohishi
+// is included so the user's claude-tooling repos can still be pinned to a
+// board, even though only a subset of their repos surface as issues here.
+const PROJECT_ORGS = ["ippoan", "ohishi-exp", "yhonda-ohishi"];
+
 export async function handleIssuesPage(env: { GITHUB_TOKEN: string }): Promise<Response> {
   let merged;
+  let projectMap: Map<string, ProjectRef[]>;
   try {
-    const [main, yhonda] = await Promise.all([
+    // Three parallel fetches: main-org search, yhonda repo-pinned search, and
+    // the cross-org project→issue map. Errors from any one of them are
+    // surfaced via the friendly error page — partial results aren't worth
+    // the extra ambiguity in the UI.
+    const [main, yhonda, pm] = await Promise.all([
       fetchOrgIssues(env.GITHUB_TOKEN, {
         orgs: ORGS,
         state: "open",
@@ -25,12 +36,14 @@ export async function handleIssuesPage(env: { GITHUB_TOKEN: string }): Promise<R
         per_page: 100,
         query: YHONDA_REPOS.map((r) => `repo:${r}`).join(" "),
       }),
+      fetchProjectIssueMap(env.GITHUB_TOKEN, { orgs: PROJECT_ORGS }),
     ]);
     merged = {
       total_count: main.total_count + yhonda.total_count,
       incomplete: main.incomplete || yhonda.incomplete,
       items: [...main.items, ...yhonda.items],
     };
+    projectMap = pm;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return new Response(renderError(msg), {
@@ -39,13 +52,26 @@ export async function handleIssuesPage(env: { GITHUB_TOKEN: string }): Promise<R
     });
   }
 
-  const grouped = new Map<string, OrgIssue[]>();
+  // Split issues into "Project-tagged" (top aggregate section) and
+  // "ungrouped per-repo" (bottom sections). An issue belongs to the project
+  // section iff `projectMap` has at least one ProjectRef for `repo#number`.
+  const projectTagged: Array<{ issue: OrgIssue; projects: ProjectRef[] }> = [];
+  const ungrouped: OrgIssue[] = [];
   for (const item of merged.items) {
+    const key = `${item.repo}#${item.number}`;
+    const refs = projectMap.get(key);
+    if (refs && refs.length > 0) projectTagged.push({ issue: item, projects: refs });
+    else ungrouped.push(item);
+  }
+  // Top section is one flat list ordered by recency across repos.
+  projectTagged.sort((a, b) => b.issue.updated_at.localeCompare(a.issue.updated_at));
+
+  // Per-repo grouping (existing behavior) for the ungrouped half.
+  const grouped = new Map<string, OrgIssue[]>();
+  for (const item of ungrouped) {
     if (!grouped.has(item.repo)) grouped.set(item.repo, []);
     grouped.get(item.repo)!.push(item);
   }
-  // Sort repos alphabetically and issues by `updated_at` desc within each repo
-  // so the page is deterministic even when GitHub's order shifts.
   const repos = [...grouped.entries()]
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([repo, items]) => [
@@ -53,19 +79,25 @@ export async function handleIssuesPage(env: { GITHUB_TOKEN: string }): Promise<R
       [...items].sort((a, b) => b.updated_at.localeCompare(a.updated_at)),
     ] as const);
 
-  return new Response(renderHtml(merged.total_count, merged.incomplete, repos), {
-    headers: { "Content-Type": "text/html; charset=utf-8" },
-  });
+  return new Response(
+    renderHtml(merged.total_count, merged.incomplete, projectTagged, repos),
+    { headers: { "Content-Type": "text/html; charset=utf-8" } },
+  );
 }
 
 function renderHtml(
   total: number,
   incomplete: boolean,
+  projectTagged: ReadonlyArray<{ issue: OrgIssue; projects: ProjectRef[] }>,
   repos: ReadonlyArray<readonly [string, OrgIssue[]]>,
 ): string {
   const repoSections = repos
     .map(([repo, items]) => renderRepoSection(repo, items))
     .join("\n");
+
+  const projectSection = projectTagged.length > 0
+    ? renderProjectSection(projectTagged)
+    : "";
 
   const incompleteBanner = incomplete
     ? `<div class="banner">⚠️ Result was truncated by GitHub search. Showing ${total} issues but more may exist.</div>`
@@ -100,21 +132,26 @@ function renderHtml(
       font-size: 13px;
       margin-bottom: 16px;
     }
-    section.repo {
+    section.repo, section.projects {
       background: #161b22;
       border: 1px solid #30363d;
       border-radius: 8px;
       margin-bottom: 16px;
       overflow: hidden;
     }
-    section.repo h2 {
+    section.repo h2, section.projects h2 {
       font-size: 14px;
       font-weight: 600;
       padding: 10px 14px;
       background: #1f2630;
       border-bottom: 1px solid #30363d;
     }
-    section.repo h2 .count {
+    section.projects h2 {
+      /* Distinguish the aggregate section from per-repo blocks below */
+      background: #1c2433;
+      border-bottom-color: #1f6feb55;
+    }
+    section.repo h2 .count, section.projects h2 .count {
       color: #8b949e;
       font-weight: 400;
       margin-left: 6px;
@@ -144,6 +181,15 @@ function renderHtml(
     td.num { width: 60px; color: #8b949e; font-variant-numeric: tabular-nums; }
     td.num a { color: #58a6ff; text-decoration: none; }
     td.num a:hover { text-decoration: underline; }
+    td.repo {
+      width: 200px;
+      color: #8b949e;
+      font-size: 12px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      white-space: nowrap;
+    }
+    td.repo a { color: #8b949e; text-decoration: none; }
+    td.repo a:hover { color: #58a6ff; }
     td.title a { color: #c9d1d9; text-decoration: none; font-weight: 500; }
     td.title a:hover { color: #58a6ff; text-decoration: underline; }
     td.author { width: 130px; color: #8b949e; }
@@ -164,6 +210,20 @@ function renderHtml(
       margin-right: 4px;
       margin-bottom: 2px;
     }
+    /* Project chips: brighter than label chips so the board affiliation pops */
+    .project-chip {
+      display: inline-block;
+      font-size: 11px;
+      padding: 1px 8px;
+      border-radius: 10px;
+      background: #1f6feb44;
+      color: #a5d6ff;
+      border: 1px solid #1f6feb88;
+      margin-right: 4px;
+      margin-bottom: 2px;
+      text-decoration: none;
+    }
+    .project-chip:hover { background: #1f6feb66; }
     .empty {
       padding: 32px;
       text-align: center;
@@ -178,17 +238,48 @@ function renderHtml(
     <h1>📋 Open Issues</h1>
     <div class="summary">
       ${escapeHtml(String(total))} issue${total === 1 ? "" : "s"} across
-      ${escapeHtml(String(repos.length))} repo${repos.length === 1 ? "" : "s"}
+      ${escapeHtml(String(repos.length + (projectTagged.length > 0 ? 1 : 0)))} section${repos.length === 0 && projectTagged.length <= 1 ? "" : "s"}
       (orgs: ${ORGS.map((o) => escapeHtml(o)).join(", ")}
       + ${YHONDA_REPOS.map((r) => escapeHtml(r)).join(", ")})
     </div>
   </header>
   ${incompleteBanner}
-  ${repos.length === 0
+  ${projectSection}
+  ${repos.length === 0 && projectTagged.length === 0
     ? `<div class="empty">🎉 No open issues. Nice work.</div>`
     : repoSections}
 </body>
 </html>`;
+}
+
+function renderProjectSection(
+  items: ReadonlyArray<{ issue: OrgIssue; projects: ProjectRef[] }>,
+): string {
+  const rows = items.map(({ issue, projects }) => renderProjectRow(issue, projects)).join("\n");
+  return `<section class="projects">
+  <h2>📋 Project 付き<span class="count">(${items.length})</span></h2>
+  <table>
+    <thead><tr><th>#</th><th>Repo</th><th>Title</th><th>Author</th><th>Updated</th></tr></thead>
+    <tbody>${rows}</tbody>
+  </table>
+</section>`;
+}
+
+function renderProjectRow(i: OrgIssue, projects: ReadonlyArray<ProjectRef>): string {
+  const chips = projects.map((p) =>
+    `<a class="project-chip" href="${escapeHtml(p.url)}" target="_blank" rel="noopener">${escapeHtml(p.title)}</a>`,
+  ).join("");
+  const labelChips = i.labels.length > 0
+    ? `<div class="labels">${i.labels.map((l) =>
+        `<span class="label">${escapeHtml(l)}</span>`).join("")}</div>`
+    : "";
+  return `<tr>
+    <td class="num"><a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">#${i.number}</a></td>
+    <td class="repo"><a href="https://github.com/${escapeHtml(i.repo)}/issues" target="_blank" rel="noopener">${escapeHtml(i.repo)}</a></td>
+    <td class="title"><a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">${escapeHtml(i.title)}</a><div class="labels">${chips}</div>${labelChips}</td>
+    <td class="author">@${escapeHtml(i.author)}</td>
+    <td class="updated">${escapeHtml(i.updated_at.slice(0, 10))}</td>
+  </tr>`;
 }
 
 function renderRepoSection(repo: string, items: OrgIssue[]): string {

--- a/src/mcp/tools/projects.ts
+++ b/src/mcp/tools/projects.ts
@@ -122,6 +122,133 @@ function summarizeField(f: ProjectField) {
   return base;
 }
 
+// --------------------------------------------------------------------------
+// Exported read-side helpers (used by both MCP tool handlers and the SSR
+// `/issues` page in `src/issues-page.ts`). Keep these as plain async
+// functions so callers don't have to go through the MCP transport.
+// --------------------------------------------------------------------------
+
+export interface OrgProject {
+  id: string;
+  number: number;
+  title: string;
+  url: string;
+  closed: boolean;
+  shortDescription: string | null;
+}
+
+export interface OrgProjectsResult {
+  org: string;
+  projects: OrgProject[];
+}
+
+/**
+ * List open (and optionally closed) Projects v2 across one or more orgs.
+ * `validateOrg` is enforced for every org before any network call.
+ */
+export async function fetchOrgProjects(
+  token: string,
+  params: { orgs: string[]; first?: number; include_closed?: boolean },
+): Promise<OrgProjectsResult[]> {
+  const { orgs, first = 50, include_closed = false } = params;
+  for (const o of orgs) validateOrg(o);
+  return Promise.all(orgs.map(async (org) => {
+    const data = await githubGraphQL<{
+      organization: {
+        projectsV2: { nodes: OrgProject[] };
+      } | null;
+    }>(
+      token,
+      `query($org:String!,$first:Int!){
+        organization(login:$org){
+          projectsV2(first:$first, orderBy:{field:NUMBER,direction:DESC}){
+            nodes{ id number title url closed shortDescription }
+          }
+        }
+      }`,
+      { org, first },
+    );
+    const nodes = data.organization?.projectsV2.nodes ?? [];
+    const filtered = include_closed ? nodes : nodes.filter((p) => !p.closed);
+    return { org, projects: filtered };
+  }));
+}
+
+export interface ProjectRef {
+  org: string;
+  number: number;
+  title: string;
+  url: string;
+}
+
+/**
+ * Build a `repo#issueNumber → ProjectRef[]` map covering every open Project
+ * across the supplied orgs. Items that are PRs or draft issues are skipped
+ * (this map exists so the `/issues` page can flag which **issues** are on a
+ * board). One issue may show up in multiple Projects, hence the array value.
+ *
+ * Cost: one `projectsV2` list query per org, then one items query per open
+ * project — typically <20 GraphQL calls for the current orgs/projects volume,
+ * each well under 1 point of the 5000/h rate-limit budget.
+ */
+export async function fetchProjectIssueMap(
+  token: string,
+  params: { orgs: string[]; first?: number },
+): Promise<Map<string, ProjectRef[]>> {
+  const { orgs, first = 100 } = params;
+  const orgsProjects = await fetchOrgProjects(token, { orgs, include_closed: false });
+
+  const map = new Map<string, ProjectRef[]>();
+  await Promise.all(
+    orgsProjects.flatMap(({ org, projects }) =>
+      projects.map(async (p) => {
+        const data = await githubGraphQL<{
+          node: {
+            items: { nodes: Array<{
+              content: {
+                __typename: string;
+                number?: number;
+                repository?: { nameWithOwner: string };
+              } | null;
+            }> };
+          } | null;
+        }>(
+          token,
+          `query($id:ID!,$first:Int!){
+            node(id:$id){
+              ... on ProjectV2 {
+                items(first:$first){
+                  nodes{
+                    content{
+                      __typename
+                      ... on Issue { number repository{ nameWithOwner } }
+                    }
+                  }
+                }
+              }
+            }
+          }`,
+          { id: p.id, first },
+        );
+        const items = data.node?.items.nodes ?? [];
+        for (const item of items) {
+          const c = item.content;
+          if (!c || c.__typename !== "Issue") continue;
+          if (!c.repository || c.number === undefined) continue;
+          const key = `${c.repository.nameWithOwner}#${c.number}`;
+          const ref: ProjectRef = {
+            org, number: p.number, title: p.title, url: p.url,
+          };
+          const cur = map.get(key);
+          if (cur) cur.push(ref);
+          else map.set(key, [ref]);
+        }
+      }),
+    ),
+  );
+  return map;
+}
+
 export function registerProjectsTools(server: McpServer, token: string): void {
   // --------------------------------------------------------------------
   // Read tools
@@ -147,40 +274,20 @@ export function registerProjectsTools(server: McpServer, token: string): void {
       annotations: { readOnlyHint: true },
     },
     async ({ orgs, first, include_closed }) => {
-      for (const o of orgs) validateOrg(o);
-      const perOrg = await Promise.all(orgs.map(async (org) => {
-        const data = await githubGraphQL<{
-          organization: {
-            projectsV2: { nodes: Array<{
-              id: string; number: number; title: string;
-              url: string; closed: boolean; shortDescription: string | null;
-            }> };
-          } | null;
-        }>(
-          token,
-          `query($org:String!,$first:Int!){
-            organization(login:$org){
-              projectsV2(first:$first, orderBy:{field:NUMBER,direction:DESC}){
-                nodes{ id number title url closed shortDescription }
-              }
-            }
-          }`,
-          { org, first },
-        );
-        const nodes = data.organization?.projectsV2.nodes ?? [];
-        const filtered = include_closed ? nodes : nodes.filter((p) => !p.closed);
-        return {
-          org,
-          projects: filtered.map((p) => ({
-            number: p.number,
-            title: p.title,
-            url: p.url,
-            closed: p.closed,
-            shortDescription: p.shortDescription,
-          })),
-        };
+      const perOrg = await fetchOrgProjects(token, { orgs, first, include_closed });
+      // Tool shape stays the same (number/title/url/closed/shortDescription)
+      // — the `id` is internal-only and dropped here.
+      const result = perOrg.map(({ org, projects }) => ({
+        org,
+        projects: projects.map((p) => ({
+          number: p.number,
+          title: p.title,
+          url: p.url,
+          closed: p.closed,
+          shortDescription: p.shortDescription,
+        })),
       }));
-      return { content: [{ type: "text" as const, text: JSON.stringify(perOrg, null, 2) }] };
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
     },
   );
 

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -13,13 +13,59 @@ function testEnv(): Env {
   };
 }
 
-// Stub /search/issues. The handler fires two queries (main orgs + yhonda repo
-// filter) so we branch on the `q` param to return different items per call.
-// Main response covers two repos and a PR that must be filtered out; yhonda
-// response covers one claude-skills issue. A hostile title verifies escaping.
-function stubSearchIssues() {
-  return vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
+// Stub /search/issues + /graphql. The page fires three parallel calls:
+//   - /search/issues with main-org `q` (ippoan + ohishi-exp)
+//   - /search/issues with yhonda-ohishi `repo:` filter
+//   - /graphql for the per-org Projects v2 listing + per-project items
+// We branch on URL + (for GraphQL) on the request body so each call gets the
+// data its handler expects. By default the project map is empty so existing
+// assertions still see the per-repo grouping. Pass `withProjects` to seed a
+// project that maps to `ippoan/rust-alc-api#7` (i.e. the hostile-title issue),
+// which is what the project-section tests below rely on.
+function stubFetch(opts: { withProjects?: boolean } = {}) {
+  const withProjects = !!opts.withProjects;
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (req, init) => {
     const url = typeof req === "string" ? req : (req as Request).url;
+    // `init.body` is set by `githubGraphQL`; a bare Request also exposes it.
+    const body = (init?.body as string | undefined)
+      ?? (typeof req === "string" ? "" : await (req as Request).clone().text());
+
+    // ---- GraphQL branch (Projects v2) ----
+    if (url.includes("/graphql")) {
+      if (body.includes("projectsV2(first:")) {
+        // First-pass: list of projects per org. Only `ippoan` has one in
+        // these fixtures; the other orgs return an empty list.
+        if (body.includes('"ippoan"') && withProjects) {
+          return Response.json({
+            data: { organization: { projectsV2: { nodes: [
+              { id: "PVT_1", number: 1, title: "Camera Monitoring",
+                url: "https://github.com/orgs/ippoan/projects/1",
+                closed: false, shortDescription: null },
+            ] } } },
+          });
+        }
+        return Response.json({
+          data: { organization: { projectsV2: { nodes: [] } } },
+        });
+      }
+      if (body.includes("items(first:")) {
+        // Second-pass: items for a specific project. Map our seed project to
+        // the rust-alc-api#7 issue (the hostile-title one), plus a draft we
+        // must ignore.
+        return Response.json({
+          data: { node: { items: { nodes: [
+            { content: {
+              __typename: "Issue",
+              number: 7,
+              repository: { nameWithOwner: "ippoan/rust-alc-api" },
+            } },
+            { content: { __typename: "DraftIssue" } },
+          ] } } },
+        });
+      }
+      return Response.json({ data: { organization: null } });
+    }
+
     if (!url.includes("/search/issues")) {
       return new Response("not stubbed: " + url, { status: 500 });
     }
@@ -94,6 +140,12 @@ function stubSearchIssues() {
   });
 }
 
+// Backwards-compatible alias for the assertion suite that pre-dated the
+// project section.
+function stubSearchIssues() {
+  return stubFetch();
+}
+
 describe("GET /issues", () => {
   afterEach(() => { vi.restoreAllMocks(); });
 
@@ -153,8 +205,12 @@ describe("GET /issues", () => {
     await worker.fetch(req, testEnv(), ctx);
     await waitOnExecutionContext(ctx);
 
-    expect(spy).toHaveBeenCalledTimes(2);
-    const urls = spy.mock.calls.map((c) => c[0] as string);
+    // `/search/issues` is hit exactly twice; the extra `/graphql` calls for
+    // the Projects v2 map are ignored by this assertion.
+    const searchCalls = spy.mock.calls.filter((c) =>
+      String(c[0]).includes("/search/issues"));
+    expect(searchCalls).toHaveLength(2);
+    const urls = searchCalls.map((c) => c[0] as string);
     const decoded = urls.map((u) => decodeURIComponent(u));
 
     // Main call: ippoan + ohishi-exp orgs without a repo: qualifier.
@@ -200,11 +256,24 @@ describe("GET /issues", () => {
   });
 
   it("renders an empty-state message when no issues match", async () => {
-    // Use mockImplementation, not mockResolvedValue: handleIssuesPage fires two
-    // fetches in parallel and a single Response instance has a one-shot body.
-    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
-      Response.json({ total_count: 0, incomplete_results: false, items: [] }),
-    );
+    // Use mockImplementation, not mockResolvedValue: the page fires three
+    // fetches in parallel (2× /search/issues, 1+ /graphql) and a single
+    // Response instance has a one-shot body. The /graphql branch must return
+    // a GraphQL-shaped payload (`data.organization`) so the projects helper
+    // doesn't throw — an empty projectsV2 keeps the project section absent.
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (req, init) => {
+      const url = typeof req === "string" ? req : (req as Request).url;
+      const body = (init?.body as string | undefined) ?? "";
+      if (url.includes("/graphql")) {
+        if (body.includes("projectsV2(first:")) {
+          return Response.json({
+            data: { organization: { projectsV2: { nodes: [] } } },
+          });
+        }
+        return Response.json({ data: { organization: null } });
+      }
+      return Response.json({ total_count: 0, incomplete_results: false, items: [] });
+    });
     const req = new Request("http://localhost/issues");
     const ctx = createExecutionContext();
     const res = await worker.fetch(req, testEnv(), ctx);
@@ -214,6 +283,117 @@ describe("GET /issues", () => {
     const html = await res.text();
     expect(html).toContain("No open issues");
     expect((html.match(/<section class="repo">/g) ?? []).length).toBe(0);
+    expect((html.match(/<section class="projects">/g) ?? []).length).toBe(0);
+  });
+});
+
+describe("GET /issues — Project section", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("renders a 'Project 付き' section with project chips and excludes those issues from their repo section", async () => {
+    stubFetch({ withProjects: true });
+    const req = new Request("http://localhost/issues");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    // The project section exists and labels the seeded board.
+    expect(html).toContain('<section class="projects">');
+    expect(html).toContain("Project 付き");
+    expect(html).toContain("Camera Monitoring");
+    // Chip is rendered as an anchor with the project URL.
+    expect(html).toMatch(
+      /<a class="project-chip"[^>]*href="https:\/\/github\.com\/orgs\/ippoan\/projects\/1"/,
+    );
+
+    // rust-alc-api#7 lives in the project section, so its per-repo section
+    // must drop it. Issue #7 was the only rust-alc-api issue (PR #99 already
+    // filtered), so the rust-alc-api per-repo section should disappear
+    // entirely.
+    const repoSectionTags = html.match(/<section class="repo">[\s\S]*?<\/section>/g) ?? [];
+    for (const sec of repoSectionTags) {
+      if (sec.includes("ippoan/rust-alc-api")) {
+        // If it did render, it must not contain #7.
+        expect(sec).not.toContain(">#7<");
+      }
+    }
+    // The remaining per-repo sections are ohishi-exp/daiun-salary and
+    // yhonda-ohishi/claude-skills (neither tagged with a project).
+    expect(html).toContain("ohishi-exp/daiun-salary");
+    expect(html).toContain("yhonda-ohishi/claude-skills");
+  });
+
+  it("renders multiple project chips when an issue belongs to multiple projects", async () => {
+    // Override the stub to add a second project that also contains rust-alc-api#7.
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (req, init) => {
+      const url = typeof req === "string" ? req : (req as Request).url;
+      const body = (init?.body as string | undefined) ?? "";
+      if (url.includes("/graphql")) {
+        if (body.includes("projectsV2(first:")) {
+          if (body.includes('"ippoan"')) {
+            return Response.json({
+              data: { organization: { projectsV2: { nodes: [
+                { id: "PVT_1", number: 1, title: "Board A",
+                  url: "https://github.com/orgs/ippoan/projects/1",
+                  closed: false, shortDescription: null },
+                { id: "PVT_2", number: 2, title: "Board B",
+                  url: "https://github.com/orgs/ippoan/projects/2",
+                  closed: false, shortDescription: null },
+              ] } } },
+            });
+          }
+          return Response.json({
+            data: { organization: { projectsV2: { nodes: [] } } },
+          });
+        }
+        // Both projects claim the same issue #7. Map both project IDs to
+        // the same item list so the issue ends up with two refs.
+        return Response.json({
+          data: { node: { items: { nodes: [
+            { content: {
+              __typename: "Issue",
+              number: 7,
+              repository: { nameWithOwner: "ippoan/rust-alc-api" },
+            } },
+          ] } } },
+        });
+      }
+      // Search responses — only the rust-alc-api#7 issue matters here.
+      if (decodeURIComponent(url).includes("repo:yhonda-ohishi/claude-skills")) {
+        return Response.json({ total_count: 0, incomplete_results: false, items: [] });
+      }
+      return Response.json({
+        total_count: 1,
+        incomplete_results: false,
+        items: [{
+          number: 7, title: "shared between two projects", state: "open",
+          user: { login: "yhonda-ohishi" }, labels: [], assignees: [], comments: 0,
+          created_at: "2026-05-10T00:00:00Z", updated_at: "2026-05-10T03:00:00Z",
+          html_url: "https://github.com/ippoan/rust-alc-api/issues/7",
+          repository_url: "https://api.github.com/repos/ippoan/rust-alc-api",
+        }],
+      });
+    });
+
+    const req = new Request("http://localhost/issues");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    const html = await res.text();
+    // Both chips appear in the project row for #7.
+    const projectSection = html.match(
+      /<section class="projects">[\s\S]*?<\/section>/,
+    );
+    expect(projectSection).not.toBeNull();
+    const sec = projectSection![0];
+    expect(sec).toContain("Board A");
+    expect(sec).toContain("Board B");
+    const chipMatches = sec.match(/project-chip/g) ?? [];
+    expect(chipMatches.length).toBeGreaterThanOrEqual(2);
   });
 });
 


### PR DESCRIPTION
## 概要

`/issues` ページの最上段に **「📋 Project 付き」集約セクション**を追加。Projects v2 ボードに card として乗っている issue を org 横断で 1 リストに集め、各行に Project 名のチップを表示する。下段の repo 別セクションからは Project 付き issue を **除外** するので二重表示は起きない。Project 付き issue だけだった repo は空になりそのまま非表示。

## 関連 issue

Refs #73

## データ取得

issue → Project の逆引きは Search API では取れない (GitHub Search の `projectsV2` フィールドは無い) ので、**Project 側から items を引いて `repo#番号 → Project[]` Map を作る**方針 (issue で提案された筋)。

`src/mcp/tools/projects.ts` をリファクタして read 側ロジックを純粋関数として export:

```ts
export async function fetchOrgProjects(token, { orgs, first?, include_closed? })
  : Promise<Array<{ org, projects: OrgProject[] }>>

export async function fetchProjectIssueMap(token, { orgs, first? })
  : Promise<Map<string /* "owner/repo#N" */, ProjectRef[]>>
```

- `list_org_projects` MCP ツールも `fetchOrgProjects` を呼ぶよう書き換え(挙動・出力 shape 不変)
- `get_project` / `list_project_items` は item の field 値返却で重めの GraphQL なのでツール内インラインのまま据え置き (issue でも「最初は読み 3 ツールのうち」とあるので read の主軸である Org Projects 取得を中心に extract)

## UI 変更

| | |
|------|------|
| 上段 | `📋 Project 付き` セクション。`#` / `Repo` / `Title` / `Author` / `Updated` 列。Title セルに **Project チップ**(複数 Project に属していれば複数チップ)。並びは `updated_at desc` |
| 下段 | 既存の repo 別セクション。**Project 付き issue は `filter` で除外**。0 件になった repo は非表示 |
| チップ色 | label chip は青系 (`#1f6feb22`)、project chip はより濃い `#1f6feb44` + 枠線で識別 |

## 並列フェッチ

```
Promise.all([
  fetchOrgIssues(main orgs),
  fetchOrgIssues(yhonda repo filter),
  fetchProjectIssueMap(3 orgs),
])
```

`fetchProjectIssueMap` は 3 org × 開いてる Project 数 (~数件) × items クエリで現状 ~10-20 GraphQL コール。1 ページロードでの rate-limit 食いは僅か。将来必要なら KV キャッシュ層(別 issue スコープ外)。

## 動作確認

- [x] `npm test` — 176/176 passed (+2 new)
- [x] `npm run typecheck` — pass
- [ ] 手動: デプロイ後 `/issues` を開き、`ippoan/projects/2 (監視カメラ死活管理)` の card が上段に集約 / 元 repo から除外されること

## テスト

`test/issues-page.test.ts` の `stubFetch` を `/graphql` 対応に拡張(request body で `projectsV2(first:` / `items(first:` を分岐)。新規ケース:

1. Project 付きセクションが描画され、project chip が `<a href="...projects/1">` で出る
2. Project 付き issue が元の repo セクションから消える(元 repo の他の issue が無ければ repo ごと消える)
3. 同じ issue が複数 Project に属するとき、project chip が複数描画される

## スコープ外 (issue にも記載)

- Status / Priority などのフィールド値をチップに併記
- Project 単位ページ (`/projects/:org/:number`)
- KV キャッシュ層

https://claude.ai/code/session_01P8MvNsNCb1xUKbGecc1cju

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8MvNsNCb1xUKbGecc1cju)_