### PR TITLE
fix(projects): resolve user-owned project logins (yhonda-ohishi 502)

### DIFF
--- a/src/mcp/tools/projects.ts
+++ b/src/mcp/tools/projects.ts
@@ -12,6 +12,13 @@ import { githubGraphQL, parseRepo, validateOrg, GitHubApiError } from "../../git
 //   3. field name → fieldId (+ optionId)   (fetched via getProjectFields)
 // We hide these behind ergonomic tool inputs (name/number) so the caller
 // doesn't have to deal with node IDs.
+//
+// Owner type: every login-keyed query uses `repositoryOwner(login:)` with
+// inline fragments for both `Organization` and `User`. The `organization(...)`
+// resolver alone fails hard on user-account logins ("Could not resolve to an
+// Organization with the login of 'X'") — yhonda-ohishi is a user, not an
+// org, so we need both code paths. `User` and `Organization` both implement
+// `ProjectV2Owner`, exposing `projectsV2` / `projectV2(number:)` identically.
 // --------------------------------------------------------------------------
 
 interface ProjectField {
@@ -40,16 +47,19 @@ export async function resolveProjectId(
   token: string, org: string, number: number,
 ): Promise<string> {
   validateOrg(org);
-  const data = await githubGraphQL<{ organization: { projectV2: { id: string } | null } | null }>(
+  const data = await githubGraphQL<{
+    repositoryOwner: { projectV2?: { id: string } | null } | null;
+  }>(
     token,
-    `query($org:String!,$number:Int!){
-      organization(login:$org){
-        projectV2(number:$number){ id }
+    `query($login:String!,$number:Int!){
+      repositoryOwner(login:$login){
+        ... on Organization { projectV2(number:$number){ id } }
+        ... on User { projectV2(number:$number){ id } }
       }
     }`,
-    { org, number },
+    { login: org, number },
   );
-  const id = data.organization?.projectV2?.id;
+  const id = data.repositoryOwner?.projectV2?.id;
   if (!id) throw new GitHubApiError(404, `Project not found: ${org}/projects/${number}`);
   return id;
 }
@@ -154,21 +164,28 @@ export async function fetchOrgProjects(
   for (const o of orgs) validateOrg(o);
   return Promise.all(orgs.map(async (org) => {
     const data = await githubGraphQL<{
-      organization: {
-        projectsV2: { nodes: OrgProject[] };
+      repositoryOwner: {
+        projectsV2?: { nodes: OrgProject[] };
       } | null;
     }>(
       token,
-      `query($org:String!,$first:Int!){
-        organization(login:$org){
-          projectsV2(first:$first, orderBy:{field:NUMBER,direction:DESC}){
-            nodes{ id number title url closed shortDescription }
+      `query($login:String!,$first:Int!){
+        repositoryOwner(login:$login){
+          ... on Organization {
+            projectsV2(first:$first, orderBy:{field:NUMBER,direction:DESC}){
+              nodes{ id number title url closed shortDescription }
+            }
+          }
+          ... on User {
+            projectsV2(first:$first, orderBy:{field:NUMBER,direction:DESC}){
+              nodes{ id number title url closed shortDescription }
+            }
           }
         }
       }`,
-      { org, first },
+      { login: org, first },
     );
-    const nodes = data.organization?.projectsV2.nodes ?? [];
+    const nodes = data.repositoryOwner?.projectsV2?.nodes ?? [];
     const filtered = include_closed ? nodes : nodes.filter((p) => !p.closed);
     return { org, projects: filtered };
   }));
@@ -308,37 +325,43 @@ export function registerProjectsTools(server: McpServer, token: string): void {
     },
     async ({ org, number }) => {
       validateOrg(org);
+      // Named fragment on `ProjectV2Owner` so the big field-list block only
+      // lives once and the inline-fragment spread covers both User and
+      // Organization owners.
       const data = await githubGraphQL<{
-        organization: { projectV2: ProjectV2 | null } | null;
+        repositoryOwner: { projectV2?: ProjectV2 | null } | null;
       }>(
         token,
-        `query($org:String!,$number:Int!){
-          organization(login:$org){
-            projectV2(number:$number){
-              id number title url closed shortDescription
-              fields(first:50){
-                nodes{
-                  __typename
-                  ... on ProjectV2FieldCommon { id name dataType }
-                  ... on ProjectV2SingleSelectField {
-                    id name dataType
-                    options{ id name }
-                  }
-                  ... on ProjectV2IterationField {
-                    id name dataType
-                    configuration{
-                      iterations{ id title startDate duration }
-                      completedIterations{ id title startDate duration }
-                    }
+        `query($login:String!,$number:Int!){
+          repositoryOwner(login:$login){
+            ... ProjectDetail
+          }
+        }
+        fragment ProjectDetail on ProjectV2Owner {
+          projectV2(number:$number){
+            id number title url closed shortDescription
+            fields(first:50){
+              nodes{
+                __typename
+                ... on ProjectV2FieldCommon { id name dataType }
+                ... on ProjectV2SingleSelectField {
+                  id name dataType
+                  options{ id name }
+                }
+                ... on ProjectV2IterationField {
+                  id name dataType
+                  configuration{
+                    iterations{ id title startDate duration }
+                    completedIterations{ id title startDate duration }
                   }
                 }
               }
             }
           }
         }`,
-        { org, number },
+        { login: org, number },
       );
-      const p = data.organization?.projectV2;
+      const p = data.repositoryOwner?.projectV2;
       if (!p) throw new GitHubApiError(404, `Project not found: ${org}/projects/${number}`);
       const result = {
         id: p.id,
@@ -373,41 +396,44 @@ export function registerProjectsTools(server: McpServer, token: string): void {
     async ({ org, number, first }) => {
       validateOrg(org);
       const data = await githubGraphQL<{
-        organization: { projectV2: { items: { nodes: ProjectItemNode[] } } | null } | null;
+        repositoryOwner: { projectV2?: { items: { nodes: ProjectItemNode[] } } | null } | null;
       }>(
         token,
-        `query($org:String!,$number:Int!,$first:Int!){
-          organization(login:$org){
-            projectV2(number:$number){
-              items(first:$first){
-                nodes{
-                  id
-                  type
-                  content{
+        `query($login:String!,$number:Int!,$first:Int!){
+          repositoryOwner(login:$login){
+            ... ProjectItems
+          }
+        }
+        fragment ProjectItems on ProjectV2Owner {
+          projectV2(number:$number){
+            items(first:$first){
+              nodes{
+                id
+                type
+                content{
+                  __typename
+                  ... on Issue { number title url state repository{ nameWithOwner } }
+                  ... on PullRequest { number title url state repository{ nameWithOwner } }
+                  ... on DraftIssue { title }
+                }
+                fieldValues(first:30){
+                  nodes{
                     __typename
-                    ... on Issue { number title url state repository{ nameWithOwner } }
-                    ... on PullRequest { number title url state repository{ nameWithOwner } }
-                    ... on DraftIssue { title }
-                  }
-                  fieldValues(first:30){
-                    nodes{
-                      __typename
-                      ... on ProjectV2ItemFieldTextValue {
-                        text field{ ... on ProjectV2FieldCommon { name } }
-                      }
-                      ... on ProjectV2ItemFieldNumberValue {
-                        number field{ ... on ProjectV2FieldCommon { name } }
-                      }
-                      ... on ProjectV2ItemFieldDateValue {
-                        date field{ ... on ProjectV2FieldCommon { name } }
-                      }
-                      ... on ProjectV2ItemFieldSingleSelectValue {
-                        name optionId field{ ... on ProjectV2FieldCommon { name } }
-                      }
-                      ... on ProjectV2ItemFieldIterationValue {
-                        title iterationId
-                        field{ ... on ProjectV2FieldCommon { name } }
-                      }
+                    ... on ProjectV2ItemFieldTextValue {
+                      text field{ ... on ProjectV2FieldCommon { name } }
+                    }
+                    ... on ProjectV2ItemFieldNumberValue {
+                      number field{ ... on ProjectV2FieldCommon { name } }
+                    }
+                    ... on ProjectV2ItemFieldDateValue {
+                      date field{ ... on ProjectV2FieldCommon { name } }
+                    }
+                    ... on ProjectV2ItemFieldSingleSelectValue {
+                      name optionId field{ ... on ProjectV2FieldCommon { name } }
+                    }
+                    ... on ProjectV2ItemFieldIterationValue {
+                      title iterationId
+                      field{ ... on ProjectV2FieldCommon { name } }
                     }
                   }
                 }
@@ -415,9 +441,9 @@ export function registerProjectsTools(server: McpServer, token: string): void {
             }
           }
         }`,
-        { org, number, first },
+        { login: org, number, first },
       );
-      const nodes = data.organization?.projectV2?.items.nodes ?? [];
+      const nodes = data.repositoryOwner?.projectV2?.items.nodes ?? [];
       const result = nodes.map(formatItem);
       return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
     },
@@ -727,16 +753,17 @@ export function registerProjectsTools(server: McpServer, token: string): void {
     async ({ org, title, short_description }) => {
       validateOrg(org);
 
-      // Step 1: resolve the org's GraphQL node ID (needed as ownerId).
+      // Step 1: resolve the owner's GraphQL node ID (needed as ownerId).
+      // `repositoryOwner` handles both User and Organization logins.
       const ownerResult = await githubGraphQL<{
-        organization: { id: string } | null;
+        repositoryOwner: { id: string } | null;
       }>(
         token,
-        `query($org:String!){ organization(login:$org){ id } }`,
-        { org },
+        `query($login:String!){ repositoryOwner(login:$login){ id } }`,
+        { login: org },
       );
-      const ownerId = ownerResult.organization?.id;
-      if (!ownerId) throw new GitHubApiError(404, `Organization not found: ${org}`);
+      const ownerId = ownerResult.repositoryOwner?.id;
+      if (!ownerId) throw new GitHubApiError(404, `Owner not found: ${org}`);
 
       // Step 2: createProjectV2 (title only — shortDescription is not part of CreateProjectV2Input).
       const created = await githubGraphQL<{

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -37,7 +37,7 @@ function stubFetch(opts: { withProjects?: boolean } = {}) {
         // these fixtures; the other orgs return an empty list.
         if (body.includes('"ippoan"') && withProjects) {
           return Response.json({
-            data: { organization: { projectsV2: { nodes: [
+            data: { repositoryOwner: { projectsV2: { nodes: [
               { id: "PVT_1", number: 1, title: "Camera Monitoring",
                 url: "https://github.com/orgs/ippoan/projects/1",
                 closed: false, shortDescription: null },
@@ -45,7 +45,7 @@ function stubFetch(opts: { withProjects?: boolean } = {}) {
           });
         }
         return Response.json({
-          data: { organization: { projectsV2: { nodes: [] } } },
+          data: { repositoryOwner: { projectsV2: { nodes: [] } } },
         });
       }
       if (body.includes("items(first:")) {
@@ -63,7 +63,7 @@ function stubFetch(opts: { withProjects?: boolean } = {}) {
           ] } } },
         });
       }
-      return Response.json({ data: { organization: null } });
+      return Response.json({ data: { repositoryOwner: null } });
     }
 
     if (!url.includes("/search/issues")) {
@@ -267,10 +267,10 @@ describe("GET /issues", () => {
       if (url.includes("/graphql")) {
         if (body.includes("projectsV2(first:")) {
           return Response.json({
-            data: { organization: { projectsV2: { nodes: [] } } },
+            data: { repositoryOwner: { projectsV2: { nodes: [] } } },
           });
         }
-        return Response.json({ data: { organization: null } });
+        return Response.json({ data: { repositoryOwner: null } });
       }
       return Response.json({ total_count: 0, incomplete_results: false, items: [] });
     });
@@ -335,7 +335,7 @@ describe("GET /issues — Project section", () => {
         if (body.includes("projectsV2(first:")) {
           if (body.includes('"ippoan"')) {
             return Response.json({
-              data: { organization: { projectsV2: { nodes: [
+              data: { repositoryOwner: { projectsV2: { nodes: [
                 { id: "PVT_1", number: 1, title: "Board A",
                   url: "https://github.com/orgs/ippoan/projects/1",
                   closed: false, shortDescription: null },
@@ -346,7 +346,7 @@ describe("GET /issues — Project section", () => {
             });
           }
           return Response.json({
-            data: { organization: { projectsV2: { nodes: [] } } },
+            data: { repositoryOwner: { projectsV2: { nodes: [] } } },
           });
         }
         // Both projects claim the same issue #7. Map both project IDs to

--- a/test/mcp/projects.test.ts
+++ b/test/mcp/projects.test.ts
@@ -53,7 +53,7 @@ describe("resolveProjectId", () => {
 
   it("returns project id when present", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      Response.json({ data: { organization: { projectV2: { id: "PVT_abc" } } } }),
+      Response.json({ data: { repositoryOwner: { projectV2: { id: "PVT_abc" } } } }),
     );
     const id = await resolveProjectId("token", "ippoan", 7);
     expect(id).toBe("PVT_abc");
@@ -61,7 +61,7 @@ describe("resolveProjectId", () => {
 
   it("throws 404 when project missing", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      Response.json({ data: { organization: { projectV2: null } } }),
+      Response.json({ data: { repositoryOwner: { projectV2: null } } }),
     );
     await expect(resolveProjectId("token", "ippoan", 99))
       .rejects.toMatchObject({ status: 404 });
@@ -78,7 +78,7 @@ describe("resolveProjectId", () => {
     // Each call gets its own Response (a Response body can only be consumed once).
     vi.spyOn(globalThis, "fetch").mockImplementation(() =>
       Promise.resolve(Response.json({
-        data: { organization: { projectV2: { id: "PVT_x" } } },
+        data: { repositoryOwner: { projectV2: { id: "PVT_x" } } },
       })),
     );
     for (const org of ["ippoan", "ohishi-exp", "yhonda-ohishi"]) {
@@ -145,13 +145,13 @@ describe("Projects v2 tools — integration via MCP server", () => {
   it("list_org_projects groups results per org and filters closed by default", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(Response.json({
-        data: { organization: { projectsV2: { nodes: [
+        data: { repositoryOwner: { projectsV2: { nodes: [
           { id: "PVT_1", number: 1, title: "Active", url: "https://github.com/orgs/ippoan/projects/1", closed: false, shortDescription: null },
           { id: "PVT_2", number: 2, title: "Done", url: "https://github.com/orgs/ippoan/projects/2", closed: true, shortDescription: null },
         ] } } },
       }))
       .mockResolvedValueOnce(Response.json({
-        data: { organization: { projectsV2: { nodes: [
+        data: { repositoryOwner: { projectsV2: { nodes: [
           { id: "PVT_3", number: 1, title: "Exp", url: "https://github.com/orgs/ohishi-exp/projects/1", closed: false, shortDescription: "exp" },
         ] } } },
       }));
@@ -171,7 +171,7 @@ describe("Projects v2 tools — integration via MCP server", () => {
 
   it("list_org_projects with include_closed=true returns closed projects too", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(Response.json({
-      data: { organization: { projectsV2: { nodes: [
+      data: { repositoryOwner: { projectsV2: { nodes: [
         { id: "PVT_1", number: 1, title: "A", url: "u", closed: false, shortDescription: null },
         { id: "PVT_2", number: 2, title: "B", url: "u", closed: true, shortDescription: null },
       ] } } },
@@ -190,9 +190,38 @@ describe("Projects v2 tools — integration via MCP server", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it("list_org_projects works for user-owned logins (yhonda-ohishi is a User, not an Organization)", async () => {
+    // GitHub's `organization(login:)` resolver throws "Could not resolve to
+    // an Organization" for user logins. The tool must use `repositoryOwner`
+    // and accept the `User`-branch fragment. Regression guard for #75.
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(Response.json({
+      data: { repositoryOwner: { projectsV2: { nodes: [
+        { id: "PVT_y", number: 3, title: "Personal Roadmap",
+          url: "https://github.com/users/yhonda-ohishi/projects/3",
+          closed: false, shortDescription: null },
+      ] } } },
+    }));
+
+    const result = await callTool("list_org_projects", {
+      orgs: ["yhonda-ohishi"],
+    }) as Array<{ org: string; projects: Array<{ number: number; title: string }> }>;
+
+    expect(result[0]!.org).toBe("yhonda-ohishi");
+    expect(result[0]!.projects[0]!.number).toBe(3);
+    expect(result[0]!.projects[0]!.title).toBe("Personal Roadmap");
+
+    // The outgoing query must use repositoryOwner with both fragments — the
+    // production bug was that the User branch was missing entirely.
+    const query = JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string).query as string;
+    expect(query).toContain("repositoryOwner(login:$login)");
+    expect(query).toContain("... on Organization");
+    expect(query).toContain("... on User");
+    expect(query).not.toContain("organization(login:");
+  });
+
   it("get_project returns fields with options for single_select", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(Response.json({
-      data: { organization: { projectV2: {
+      data: { repositoryOwner: { projectV2: {
         id: "PVT_1", number: 1, title: "P", url: "u", closed: false, shortDescription: null,
         fields: { nodes: [
           { __typename: "ProjectV2FieldCommon", id: "F_t", name: "Title", dataType: "TITLE" },
@@ -218,7 +247,7 @@ describe("Projects v2 tools — integration via MCP server", () => {
   it("add_issue_to_project resolves projectId + contentId then mutates", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(Response.json({
-        data: { organization: { projectV2: { id: "PVT_1" } } },
+        data: { repositoryOwner: { projectV2: { id: "PVT_1" } } },
       }))
       .mockResolvedValueOnce(Response.json({
         data: { repository: { issueOrPullRequest: { id: "I_42" } } },
@@ -246,7 +275,7 @@ describe("Projects v2 tools — integration via MCP server", () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch")
       // resolveProjectId
       .mockResolvedValueOnce(Response.json({
-        data: { organization: { projectV2: { id: "PVT_1" } } },
+        data: { repositoryOwner: { projectV2: { id: "PVT_1" } } },
       }))
       // getProjectFields
       .mockResolvedValueOnce(Response.json({
@@ -280,7 +309,7 @@ describe("Projects v2 tools — integration via MCP server", () => {
   it("set_project_item_field surfaces a useful error when option missing", async () => {
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(Response.json({
-        data: { organization: { projectV2: { id: "PVT_1" } } },
+        data: { repositoryOwner: { projectV2: { id: "PVT_1" } } },
       }))
       .mockResolvedValueOnce(Response.json({
         data: { node: { fields: { nodes: [
@@ -298,7 +327,7 @@ describe("Projects v2 tools — integration via MCP server", () => {
   it("set_project_item_field with text field passes value as text", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(Response.json({
-        data: { organization: { projectV2: { id: "PVT_1" } } },
+        data: { repositoryOwner: { projectV2: { id: "PVT_1" } } },
       }))
       .mockResolvedValueOnce(Response.json({
         data: { node: { fields: { nodes: [
@@ -321,7 +350,7 @@ describe("Projects v2 tools — integration via MCP server", () => {
   it("set_project_item_field with value=null calls clearProjectV2ItemFieldValue", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(Response.json({
-        data: { organization: { projectV2: { id: "PVT_1" } } },
+        data: { repositoryOwner: { projectV2: { id: "PVT_1" } } },
       }))
       .mockResolvedValueOnce(Response.json({
         data: { node: { fields: { nodes: [
@@ -345,7 +374,7 @@ describe("Projects v2 tools — integration via MCP server", () => {
   it("remove_project_item issues deleteProjectV2Item mutation", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(Response.json({
-        data: { organization: { projectV2: { id: "PVT_1" } } },
+        data: { repositoryOwner: { projectV2: { id: "PVT_1" } } },
       }))
       .mockResolvedValueOnce(Response.json({
         data: { deleteProjectV2Item: { deletedItemId: "PVTI_xyz" } },
@@ -364,7 +393,7 @@ describe("Projects v2 tools — integration via MCP server", () => {
   it("create_project_field for single_select sends options with default color", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(Response.json({
-        data: { organization: { projectV2: { id: "PVT_1" } } },
+        data: { repositoryOwner: { projectV2: { id: "PVT_1" } } },
       }))
       .mockResolvedValueOnce(Response.json({
         data: { createProjectV2Field: { projectV2Field: {
@@ -390,7 +419,7 @@ describe("Projects v2 tools — integration via MCP server", () => {
 
   it("create_project_field rejects single_select without options", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(Response.json({
-      data: { organization: { projectV2: { id: "PVT_1" } } },
+      data: { repositoryOwner: { projectV2: { id: "PVT_1" } } },
     }));
     await expect(callTool("create_project_field", {
       org: "ippoan", project_number: 1,
@@ -400,7 +429,7 @@ describe("Projects v2 tools — integration via MCP server", () => {
 
   it("list_project_items flattens content + field values", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(Response.json({
-      data: { organization: { projectV2: { items: { nodes: [
+      data: { repositoryOwner: { projectV2: { items: { nodes: [
         {
           id: "PVTI_1", type: "ISSUE",
           content: {
@@ -436,7 +465,7 @@ describe("Projects v2 tools — integration via MCP server", () => {
   it("create_project resolves ownerId then creates and returns id/number/title/url", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(Response.json({
-        data: { organization: { id: "O_ippoan" } },
+        data: { repositoryOwner: { id: "O_ippoan" } },
       }))
       .mockResolvedValueOnce(Response.json({
         data: { createProjectV2: { projectV2: {
@@ -455,10 +484,11 @@ describe("Projects v2 tools — integration via MCP server", () => {
     expect(result.title).toBe("監視カメラ死活管理");
     expect(result.url).toBe("https://github.com/orgs/ippoan/projects/7");
 
-    // ownerId query
+    // ownerId query — uses `repositoryOwner(login:)` so both User and
+    // Organization logins resolve.
     const ownerQ = JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string);
-    expect(ownerQ.query).toContain("organization(login:$org)");
-    expect(ownerQ.variables).toEqual({ org: "ippoan" });
+    expect(ownerQ.query).toContain("repositoryOwner(login:$login)");
+    expect(ownerQ.variables).toEqual({ login: "ippoan" });
 
     // createProjectV2 mutation
     const createQ = JSON.parse(fetchSpy.mock.calls[1]![1]!.body as string);
@@ -470,7 +500,7 @@ describe("Projects v2 tools — integration via MCP server", () => {
   it("create_project applies short_description via a second updateProjectV2 mutation", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(Response.json({
-        data: { organization: { id: "O_ippoan" } },
+        data: { repositoryOwner: { id: "O_ippoan" } },
       }))
       .mockResolvedValueOnce(Response.json({
         data: { createProjectV2: { projectV2: {
@@ -499,7 +529,7 @@ describe("Projects v2 tools — integration via MCP server", () => {
   it("create_project returns the project + warning when shortDescription update fails", async () => {
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(Response.json({
-        data: { organization: { id: "O_ippoan" } },
+        data: { repositoryOwner: { id: "O_ippoan" } },
       }))
       .mockResolvedValueOnce(Response.json({
         data: { createProjectV2: { projectV2: {
@@ -524,12 +554,12 @@ describe("Projects v2 tools — integration via MCP server", () => {
 
   it("create_project throws 404 when org not found", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(Response.json({
-      data: { organization: null },
+      data: { repositoryOwner: null },
     }));
 
     await expect(callTool("create_project", {
       org: "ippoan", title: "T",
-    })).rejects.toThrow(/Organization not found: ippoan/);
+    })).rejects.toThrow(/Owner not found: ippoan/);
   });
 
   it("create_project rejects disallowed orgs (no fetch issued)", async () => {


### PR DESCRIPTION
## 概要

`/issues` ページの 502 を修正。GraphQL の `organization(login:)` を `repositoryOwner(login:)` + `... on Organization` / `... on User` インラインフラグメントに置き換え、user アカウント (`yhonda-ohishi`) の Project も解決できるようにする。

## 関連 issue

Refs #75

## 症状

```
Failed to fetch issues: GitHub GraphQL error:
Could not resolve to an Organization with the login of 'yhonda-ohishi'.
```

PR #74 で `fetchProjectIssueMap` が 3 org (含 yhonda-ohishi) を走査するようになった結果、user 側のクエリが top-level GraphQL error で返り、`Promise.all` が reject されてページ全体が 502 化。

## 原因

`yhonda-ohishi` は organization ではなく **user account**。GitHub GraphQL の `organization(login:)` は org 限定 resolver なので user login で hard fail する。一方 Search API (`org:yhonda-ohishi`) は user/org どちらでも動くので、Issue 検索だけは通っていてギャップが見えていなかった。

## 修正

`User` と `Organization` 両方が実装する `ProjectV2Owner` インターフェース経由で取得する。

**Before**:
```graphql
organization(login: $org) {
  projectsV2(first: $first, ...) { nodes { ... } }
}
```

**After**:
```graphql
repositoryOwner(login: $login) {
  ... on Organization { projectsV2(first: $first, ...) { nodes { ... } } }
  ... on User         { projectsV2(first: $first, ...) { nodes { ... } } }
}
```

大きめの `get_project` / `list_project_items` クエリは GraphQL named fragment にして重複を抑えた:
```graphql
query(...) { repositoryOwner(login:$login) { ... ProjectDetail } }
fragment ProjectDetail on ProjectV2Owner { projectV2(number:$number) { ... } }
```

`User` と `Organization` の両方が `ProjectV2Owner` を実装しているため、`RepositoryOwner` インターフェースに対する型条件 `ProjectV2Owner` の spread が valid。

### 影響範囲

| 関数 / ツール | 状態 |
|---|---|
| `resolveProjectId` (write tool 全部の前段) | ✅ 修正 |
| `fetchOrgProjects` (`list_org_projects` + `/issues` ページ) | ✅ 修正 |
| `get_project` ツール | ✅ 修正 (named fragment) |
| `list_project_items` ツール | ✅ 修正 (named fragment) |
| `create_project` ツールの ownerId 解決 | ✅ 修正 (`repositoryOwner.id`) |
| `fetchProjectIssueMap` の項目取得 (`node(id:$id)`) | 影響なし |

`create_project` の 404 メッセージは `Organization not found` → `Owner not found` に変更(User でもありうるため)。

## 動作確認

- [x] `npm test` — 177/177 passed (+1 リグレッションテスト)
- [x] `npm run typecheck` — pass
- [ ] 手動 (デプロイ後): `/issues` が yhonda-ohishi 配下を含んでも 502 にならない
- [ ] 手動: yhonda-ohishi に user-owned Project があれば上段集約セクションに項目が並ぶ

## 追加テスト

`test/mcp/projects.test.ts` に新規 case:

```ts
it("list_org_projects works for user-owned logins (yhonda-ohishi is a User, not an Organization)", ...)
```

- yhonda-ohishi に対して projects が返ること
- 送信クエリが `repositoryOwner(login:$login)` を含み、`... on Organization` と `... on User` 両方の fragment が入り、`organization(login:` が**含まれない**ことを assert(リグレッションガード)

## メモ

- `ALLOWED_ORGS` のセマンティクスは「allowlist of valid logins for tooling」であって org/user の区別は無い、という前提を以後守る形に変わる
- 既存の `validateOrg` 名前は紛らわしいが、本 PR では rename しない(差分肥大化を避ける)

https://claude.ai/code/session_01P8MvNsNCb1xUKbGecc1cju

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8MvNsNCb1xUKbGecc1cju)_