### PR TITLE
refactor(releases): drop bug/regression label default-uncheck

### DIFF
--- a/src/release-helpers.ts
+++ b/src/release-helpers.ts
@@ -66,20 +66,23 @@ export function previousTag(tagsDescending: readonly string[], current: string):
 }
 
 // Warning flags drive whether a candidate row's checkbox defaults to OFF.
-// The list is intentionally narrow for the MVP — comment-after-merge and
-// reaction-based heuristics need extra API calls and can come later.
+// Currently the sole flag is `state === "closed"` — that one is a sanity
+// net so the operator notices an issue that was already manually closed
+// before the release went out (re-closing is harmless but the row should
+// not look like a fresh action).
+//
+// We previously also warned on `bug` / `regression` labels under the
+// "have a human re-check fix issues at release time" rationale, but in
+// practice every fix PR touches a bug-labeled issue so the warning fired
+// on the rows the operator most needed to tick — adding manual work
+// without catching anything. Dropped in #77.
 export interface IssueLike {
   state: string;
   labels: ReadonlyArray<string>;
 }
 
-const WARN_LABELS = new Set(["bug", "regression"]);
-
 export function computeWarnings(issue: IssueLike): string[] {
   const out: string[] = [];
   if (issue.state === "closed") out.push("already closed");
-  for (const l of issue.labels) {
-    if (WARN_LABELS.has(l.toLowerCase())) out.push(`${l} label`);
-  }
   return out;
 }

--- a/test/release-helpers.test.ts
+++ b/test/release-helpers.test.ts
@@ -96,11 +96,12 @@ describe("computeWarnings", () => {
       .toContain("already closed");
   });
 
-  it("flags bug / regression labels (case-insensitive)", () => {
-    expect(computeWarnings({ state: "open", labels: ["bug"] }))
-      .toContain("bug label");
-    expect(computeWarnings({ state: "open", labels: ["Regression"] }))
-      .toContain("Regression label");
+  it("does NOT flag bug / regression labels on open issues (dropped in #77)", () => {
+    // bug-labeled open issues are the common case for fix-PR-driven closes;
+    // warning on them just added manual ticking without catching anything.
+    expect(computeWarnings({ state: "open", labels: ["bug"] })).toEqual([]);
+    expect(computeWarnings({ state: "open", labels: ["Regression"] })).toEqual([]);
+    expect(computeWarnings({ state: "open", labels: ["bug", "regression"] })).toEqual([]);
   });
 
   it("returns [] for a clean open issue", () => {
@@ -108,8 +109,8 @@ describe("computeWarnings", () => {
       .toEqual([]);
   });
 
-  it("stacks warnings", () => {
+  it("closed state remains the sole warning regardless of labels", () => {
     const w = computeWarnings({ state: "closed", labels: ["bug", "regression"] });
-    expect(w.length).toBe(3);
+    expect(w).toEqual(["already closed"]);
   });
 });

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -215,9 +215,11 @@ describe("GET /releases", () => {
     // Detail-page link per tag block ("→ detail").
     expect(html).toMatch(/href="\/releases\?repo=ippoan%2Fci-dashboard&tag=v1\.2\.0"/);
 
-    // Checkbox values are `tag:issue` pairs; clean rows checked, warning OFF.
+    // Checkbox values are `tag:issue` pairs. Per #77 bug-labeled open
+    // issues are no longer warned, so #2 starts checked too. (A closed
+    // row would still be `(?! checked)`; none in this fixture.)
     expect(html).toMatch(/name="pair" value="v1\.2\.0:1" checked/);
-    expect(html).toMatch(/name="pair" value="v1\.1\.0:2"(?! checked)/);
+    expect(html).toMatch(/name="pair" value="v1\.1\.0:2" checked/);
     expect(html).toMatch(/name="pair" value="v0\.5\.0:100" checked/);
 
     // Batch-close form per repo points at the new endpoint.
@@ -354,7 +356,7 @@ describe("GET /releases", () => {
     expect(html).toContain('action="/api/release-close"');
   });
 
-  it("warning rows are NOT checked by default; clean rows ARE", async () => {
+  it("closed rows are NOT checked by default; open rows (including bug-labeled) ARE", async () => {
     stubGithubApi();
     const req = new Request("http://localhost/releases?repo=ippoan/ci-dashboard&tag=v1.2.0");
     const ctx = createExecutionContext();
@@ -364,14 +366,16 @@ describe("GET /releases", () => {
 
     // #42 has no warnings → checkbox starts checked.
     expect(html).toMatch(/name="issue" value="42" checked/);
-    // #50 is closed, #99 has bug label → both start unchecked.
+    // #50 is closed → still unchecked.
     expect(html).toMatch(/name="issue" value="50"(?! checked)/);
-    expect(html).toMatch(/name="issue" value="99"(?! checked)/);
+    // #99 has the `bug` label but is open. Per #77 the label no longer
+    // triggers a warning, so the checkbox starts checked.
+    expect(html).toMatch(/name="issue" value="99" checked/);
 
-    // Warning icon + tooltip present for warning rows.
+    // Warning icon + tooltip remain for the closed row only.
     expect(html).toContain("⚠️");
     expect(html).toContain("already closed");
-    expect(html).toContain("bug label");
+    expect(html).not.toContain("bug label");
   });
 
   it("returns 404 when the tag is not in the recent list", async () => {


### PR DESCRIPTION
## 概要

release 確認画面で **`bug` / `regression` ラベル付き open issue が default で checkbox OFF になる挙動を撤去**。`computeWarnings()` から該当ロジックを削除し、`state === "closed"` の警告だけ残す。

## 関連 issue

Refs #77

## 動機

fix PR は本質的に bug ラベル付き issue を閉じるためのものなので、release 確認画面で **ほぼ常にチェックを付け直す手間** が発生していた。「目で見て確認」が機能していない上に余計な操作を増やす状態。今回の v0.0.54 で #75 (`bug` + `mcp` ラベル) が default OFF になったのが直近の発火例。

## 変更内容

`src/release-helpers.ts`:
```ts
// Before
const WARN_LABELS = new Set(["bug", "regression"]);
export function computeWarnings(issue) {
  const out = [];
  if (issue.state === "closed") out.push("already closed");
  for (const l of issue.labels)
    if (WARN_LABELS.has(l.toLowerCase())) out.push(`${l} label`);
  return out;
}

// After
export function computeWarnings(issue) {
  const out = [];
  if (issue.state === "closed") out.push("already closed");
  return out;
}
```

`IssueLike.labels` は型定義に残す(他の表示で使われている可能性)。

## 振る舞いの差分

| issue 状態 | Before | After |
|---|---|---|
| open / ラベルなし | ✓ ON | ✓ ON(同じ) |
| open / `bug` ラベル | ⚠️ OFF | **✓ ON** |
| open / `regression` ラベル | ⚠️ OFF | **✓ ON** |
| closed | ⚠️ OFF | ⚠️ OFF(同じ) |

ヘッダ文言 `Rows with ⚠️ are unchecked by default. Untick to skip.` は closed ケースで依然正しいので変更なし。

## テスト

- `test/release-helpers.test.ts`: bug/regression のケースを「flags...」から「does NOT flag...」に反転、stacked-warning ケースは「closed のみ残る」に書き換え
- `test/releases-page.test.ts`:
  - 単一-tag 詳細ページ: #99 (open, bug) を `checked` 期待に
  - インデックスページ: #2 (open, bug) を `checked` 期待に
  - 「bug label」ツールチップ文字列が出ない assertion を追加(リグレッションガード)

## 動作確認

- [x] `npm test` — 177/177 passed
- [x] `npm run typecheck` — pass
- [ ] 手動 (デプロイ後): v0.0.55 以降の detail で bug 付き fix issue が default ✓ で並ぶこと

## スコープ外

- `WARN_LABELS` の代替警告(comment-after-merge / 反応ベース等)はこの PR では扱わない
- ヘッダ文言の整理(closed しか出ないなら「closed rows」と明示する案)も別 PR

https://claude.ai/code/session_01P8MvNsNCb1xUKbGecc1cju

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8MvNsNCb1xUKbGecc1cju)_