### PR TITLE
feat(pwa): add manifest, service worker, and install metadata

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,4 +1,5 @@
 import { renderTabs, TAB_STYLES } from "./nav-tabs";
+import { PWA_HEAD_TAGS, PWA_REGISTER_SCRIPT } from "./pwa";
 
 export function handleDashboard(): Response {
   const html = `<!DOCTYPE html>
@@ -6,7 +7,7 @@ export function handleDashboard(): Response {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>CI Dashboard</title>
+  <title>CI Dashboard</title>${PWA_HEAD_TAGS}
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     ${TAB_STYLES}
@@ -638,6 +639,7 @@ export function handleDashboard(): Response {
 
     connect();
   </script>
+  ${PWA_REGISTER_SCRIPT}
 </body>
 </html>`;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,11 @@ import { handleReleaseCloseBatch } from "./release-close-batch";
 import { handleRecheck } from "./recheck";
 import { handleTagRelease } from "./tag-release";
 import { handleMcpRequest } from "./mcp/server";
+import {
+  handlePwaManifest,
+  handlePwaServiceWorker,
+  handlePwaIcon,
+} from "./pwa";
 
 export { CIDashboardHub } from "./hub";
 
@@ -92,6 +97,12 @@ app.post("/api/dismiss", async (c) => {
   );
   return c.json({ ok: true });
 });
+
+// PWA assets — manifest, service worker, icons. Served from the same origin
+// so the SW can claim scope "/".
+app.get("/manifest.webmanifest", () => handlePwaManifest());
+app.get("/sw.js", () => handlePwaServiceWorker());
+app.get("/icons/:file", (c) => handlePwaIcon("/icons/" + c.req.param("file")));
 
 // MCP endpoint (Streamable HTTP)
 app.all("/mcp", (c) => handleMcpRequest(c.req.raw, c.env.GITHUB_TOKEN));

--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -1,6 +1,7 @@
 import { fetchOrgIssues, type OrgIssue } from "./mcp/tools/issues";
 import { fetchProjectIssueMap, type ProjectRef } from "./mcp/tools/projects";
 import { renderTabs, TAB_STYLES } from "./nav-tabs";
+import { PWA_HEAD_TAGS, PWA_REGISTER_SCRIPT } from "./pwa";
 
 // Orgs fetched in full. Same allowlist as github-api.ts (not imported because
 // ALLOWED_ORGS isn't exported; keep the two in sync if either grows).
@@ -108,7 +109,7 @@ function renderHtml(
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Open Issues — CI Dashboard</title>
+  <title>Open Issues — CI Dashboard</title>${PWA_HEAD_TAGS}
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
@@ -248,6 +249,7 @@ function renderHtml(
   ${repos.length === 0 && projectTagged.length === 0
     ? `<div class="empty">🎉 No open issues. Nice work.</div>`
     : repoSections}
+  ${PWA_REGISTER_SCRIPT}
 </body>
 </html>`;
 }

--- a/src/pwa.ts
+++ b/src/pwa.ts
@@ -1,0 +1,219 @@
+// PWA (Progressive Web App) assets for the ci-dashboard SSR pages.
+//
+// Exposes:
+// - PWA_HEAD_TAGS: <link>/<meta> tags to inject into each page <head>.
+// - PWA_REGISTER_SCRIPT: <script> snippet to register the service worker.
+// - handlePwaManifest / handlePwaServiceWorker / handlePwaIcon: route handlers
+//   served from src/index.ts.
+//
+// The service worker uses a network-first strategy for navigations (so live
+// CI status is always fresh when online) and falls back to a cached shell
+// when offline. Static assets (manifest, icons, SW itself) are cache-first.
+
+const APP_NAME = "CI Dashboard";
+const APP_SHORT_NAME = "CI Dash";
+const THEME_COLOR = "#0d1117";
+const BACKGROUND_COLOR = "#0d1117";
+
+// Bump CACHE_VERSION whenever PWA assets change so old SWs evict caches.
+const CACHE_VERSION = "v1";
+
+export const PWA_HEAD_TAGS = `
+  <link rel="manifest" href="/manifest.webmanifest">
+  <meta name="theme-color" content="${THEME_COLOR}">
+  <meta name="application-name" content="${APP_NAME}">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="apple-mobile-web-app-title" content="${APP_SHORT_NAME}">
+  <link rel="icon" type="image/svg+xml" href="/icons/icon.svg">
+  <link rel="apple-touch-icon" href="/icons/icon-192.png.svg">`;
+
+export const PWA_REGISTER_SCRIPT = `
+  <script>
+    if ("serviceWorker" in navigator) {
+      window.addEventListener("load", function () {
+        navigator.serviceWorker.register("/sw.js").catch(function () {});
+      });
+    }
+  </script>`;
+
+const MANIFEST = {
+  name: APP_NAME,
+  short_name: APP_SHORT_NAME,
+  description: "GitHub Actions CI monitoring dashboard.",
+  start_url: "/",
+  scope: "/",
+  display: "standalone",
+  orientation: "any",
+  background_color: BACKGROUND_COLOR,
+  theme_color: THEME_COLOR,
+  categories: ["developer", "productivity"],
+  icons: [
+    {
+      src: "/icons/icon.svg",
+      sizes: "any",
+      type: "image/svg+xml",
+      purpose: "any",
+    },
+    {
+      src: "/icons/icon-192.png.svg",
+      sizes: "192x192",
+      type: "image/svg+xml",
+      purpose: "any",
+    },
+    {
+      src: "/icons/icon-512.png.svg",
+      sizes: "512x512",
+      type: "image/svg+xml",
+      purpose: "any",
+    },
+    {
+      src: "/icons/icon-maskable.svg",
+      sizes: "512x512",
+      type: "image/svg+xml",
+      purpose: "maskable",
+    },
+  ],
+  shortcuts: [
+    {
+      name: "Open Issues",
+      short_name: "Issues",
+      url: "/issues",
+    },
+    {
+      name: "Releases",
+      short_name: "Releases",
+      url: "/releases",
+    },
+  ],
+};
+
+const SERVICE_WORKER_JS = `// CI Dashboard service worker (${CACHE_VERSION})
+const CACHE_NAME = "ci-dashboard-${CACHE_VERSION}";
+const STATIC_ASSETS = [
+  "/manifest.webmanifest",
+  "/icons/icon.svg",
+  "/icons/icon-192.png.svg",
+  "/icons/icon-512.png.svg",
+  "/icons/icon-maskable.svg",
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(STATIC_ASSETS)),
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)),
+      ),
+    ).then(() => self.clients.claim()),
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const req = event.request;
+  if (req.method !== "GET") return;
+
+  const url = new URL(req.url);
+  if (url.origin !== self.location.origin) return;
+
+  // Never intercept WebSocket / SSE / API / webhook / MCP traffic.
+  if (
+    url.pathname === "/ws" ||
+    url.pathname === "/mcp" ||
+    url.pathname === "/webhook" ||
+    url.pathname === "/status" ||
+    url.pathname === "/release-alerts" ||
+    url.pathname.startsWith("/api/")
+  ) {
+    return;
+  }
+
+  // Navigations: network-first, fall back to cached shell.
+  if (req.mode === "navigate") {
+    event.respondWith(
+      fetch(req)
+        .then((res) => {
+          const copy = res.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(req, copy));
+          return res;
+        })
+        .catch(() =>
+          caches.match(req).then((cached) => cached || caches.match("/")),
+        ),
+    );
+    return;
+  }
+
+  // Static assets: cache-first.
+  event.respondWith(
+    caches.match(req).then((cached) => {
+      if (cached) return cached;
+      return fetch(req).then((res) => {
+        if (res.ok && res.type === "basic") {
+          const copy = res.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(req, copy));
+        }
+        return res;
+      });
+    }),
+  );
+});
+`;
+
+// SVG icon: a stylized "CI" mark on the dashboard's dark background, with
+// the same accent blue used in the dashboard header.
+const ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="96" fill="#0d1117"/>
+  <circle cx="256" cy="256" r="180" fill="none" stroke="#1f6feb" stroke-width="20"/>
+  <circle cx="256" cy="92" r="22" fill="#3fb950"/>
+  <text x="256" y="300" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="170" font-weight="700" fill="#58a6ff" text-anchor="middle">CI</text>
+</svg>`;
+
+// Maskable variant: same artwork inside the safe zone (centered 80%).
+const ICON_MASKABLE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#0d1117"/>
+  <g transform="translate(51 51) scale(0.8)">
+    <rect width="512" height="512" rx="96" fill="#0d1117"/>
+    <circle cx="256" cy="256" r="180" fill="none" stroke="#1f6feb" stroke-width="20"/>
+    <circle cx="256" cy="92" r="22" fill="#3fb950"/>
+    <text x="256" y="300" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" font-size="170" font-weight="700" fill="#58a6ff" text-anchor="middle">CI</text>
+  </g>
+</svg>`;
+
+export function handlePwaManifest(): Response {
+  return new Response(JSON.stringify(MANIFEST, null, 2), {
+    headers: {
+      "Content-Type": "application/manifest+json; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}
+
+export function handlePwaServiceWorker(): Response {
+  return new Response(SERVICE_WORKER_JS, {
+    headers: {
+      "Content-Type": "application/javascript; charset=utf-8",
+      // SWs should not be cached aggressively — browsers re-check on
+      // every navigation so updates roll out promptly.
+      "Cache-Control": "no-cache",
+      "Service-Worker-Allowed": "/",
+    },
+  });
+}
+
+export function handlePwaIcon(path: string): Response {
+  const svg =
+    path === "/icons/icon-maskable.svg" ? ICON_MASKABLE_SVG : ICON_SVG;
+  return new Response(svg, {
+    headers: {
+      "Content-Type": "image/svg+xml; charset=utf-8",
+      "Cache-Control": "public, max-age=86400",
+    },
+  });
+}

--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -11,6 +11,7 @@ import {
 } from "./release-alert";
 import { loadDirectPushAllowlist } from "./direct-push-allowlist";
 import { renderTabs, TAB_STYLES } from "./nav-tabs";
+import { PWA_HEAD_TAGS, PWA_REGISTER_SCRIPT } from "./pwa";
 
 // `/releases` (no params) renders a list of "recent releases" — every watched
 // repo (from Hub `/statuses`) with its latest semver-sorted tags, each linking
@@ -499,7 +500,7 @@ function renderHtml(
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Release ${escapeHtml(data.tag)} — ${escapeHtml(data.repo)}</title>
+  <title>Release ${escapeHtml(data.tag)} — ${escapeHtml(data.repo)}</title>${PWA_HEAD_TAGS}
   <style>${STYLES}</style>
 </head>
 <body>
@@ -511,6 +512,7 @@ function renderHtml(
   ${flash}
   ${empty}
   ${formInner}
+  ${PWA_REGISTER_SCRIPT}
 </body>
 </html>`;
 }
@@ -584,7 +586,7 @@ function renderIndex(
   return `<!DOCTYPE html>
 <html lang="en"><head>
 <meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Releases — CI Dashboard</title><style>${STYLES}</style>
+<title>Releases — CI Dashboard</title>${PWA_HEAD_TAGS}<style>${STYLES}</style>
 </head><body>
 <header>
   ${renderTabs("releases")}
@@ -595,6 +597,7 @@ ${flash}
 ${body}
 <h2 class="lookup-header">Look up another release</h2>
 ${renderLookupForm(null, null)}
+${PWA_REGISTER_SCRIPT}
 </body></html>`;
 }
 

--- a/test/pwa.test.ts
+++ b/test/pwa.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  PWA_HEAD_TAGS,
+  PWA_REGISTER_SCRIPT,
+  handlePwaManifest,
+  handlePwaServiceWorker,
+  handlePwaIcon,
+} from "../src/pwa";
+
+describe("PWA head + register snippets", () => {
+  it("links the manifest and registers the service worker", () => {
+    expect(PWA_HEAD_TAGS).toContain('rel="manifest"');
+    expect(PWA_HEAD_TAGS).toContain('href="/manifest.webmanifest"');
+    expect(PWA_HEAD_TAGS).toContain("theme-color");
+    expect(PWA_REGISTER_SCRIPT).toContain('navigator.serviceWorker.register("/sw.js")');
+  });
+});
+
+describe("handlePwaManifest", () => {
+  it("returns a valid manifest with required PWA fields", async () => {
+    const res = handlePwaManifest();
+    expect(res.headers.get("Content-Type")).toContain("application/manifest+json");
+    const json = await res.json() as Record<string, unknown>;
+    expect(json.name).toBeTruthy();
+    expect(json.short_name).toBeTruthy();
+    expect(json.start_url).toBe("/");
+    expect(json.display).toBe("standalone");
+    expect(Array.isArray(json.icons)).toBe(true);
+    const icons = json.icons as Array<{ purpose: string }>;
+    expect(icons.some((i) => i.purpose.includes("any"))).toBe(true);
+    expect(icons.some((i) => i.purpose.includes("maskable"))).toBe(true);
+  });
+});
+
+describe("handlePwaServiceWorker", () => {
+  it("returns JS with correct content-type and scope header", async () => {
+    const res = handlePwaServiceWorker();
+    expect(res.headers.get("Content-Type")).toContain("application/javascript");
+    expect(res.headers.get("Service-Worker-Allowed")).toBe("/");
+    const body = await res.text();
+    expect(body).toContain("addEventListener(\"install\"");
+    expect(body).toContain("addEventListener(\"fetch\"");
+    // Do not intercept live endpoints.
+    expect(body).toContain("/ws");
+    expect(body).toContain("/mcp");
+    expect(body).toContain("/webhook");
+    expect(body).toContain("/api/");
+  });
+});
+
+describe("handlePwaIcon", () => {
+  it("returns SVG with svg+xml content-type", async () => {
+    const res = handlePwaIcon("/icons/icon.svg");
+    expect(res.headers.get("Content-Type")).toContain("image/svg+xml");
+    const body = await res.text();
+    expect(body.startsWith("<svg")).toBe(true);
+  });
+
+  it("returns the maskable variant for the maskable path", async () => {
+    const normal = await handlePwaIcon("/icons/icon.svg").text();
+    const maskable = await handlePwaIcon("/icons/icon-maskable.svg").text();
+    expect(normal).not.toBe(maskable);
+    expect(maskable).toContain("scale(0.8)");
+  });
+});


### PR DESCRIPTION
## 概要

ci-dashboard を PWA (Progressive Web App) として動作させる。ホーム画面に追加でき、オフライン時にもキャッシュされた shell が表示される。

## 関連 issue

Refs #79

## 変更点

- `src/pwa.ts` 新設
  - `PWA_HEAD_TAGS` / `PWA_REGISTER_SCRIPT` を export
  - `handlePwaManifest` / `handlePwaServiceWorker` / `handlePwaIcon` ハンドラ
- `src/index.ts` にルート追加
  - `GET /manifest.webmanifest`
  - `GET /sw.js` (`Service-Worker-Allowed: /` 付き)
  - `GET /icons/:file` (SVG)
- 既存 SSR ページ (`dashboard.ts` / `issues-page.ts` / `releases-page.ts`) に PWA head タグ + SW 登録 script を注入 (releases は単一 release ビュー + 一覧ビュー両方)

### Service Worker 戦略

- ナビゲーション: network-first (オフライン時はキャッシュ shell へフォールバック)
- 静的アセット: cache-first
- 介入しない: `/ws` / `/mcp` / `/webhook` / `/status` / `/release-alerts` / `/api/*`

### Manifest

- `display: standalone`、`theme_color` / `background_color`: `#0d1117`
- アイコン: SVG (purpose `any` + `maskable`)
- shortcuts: Open Issues / Releases

## 動作確認

- [x] `npm test` (182/182 passing — 既存 177 + 新規 5)
- [x] `npm run typecheck` (クリーン)
- [ ] 手動: deploy 後に DevTools の Application > Manifest / Service Workers タブで確認、Lighthouse PWA audit を実行

## メモ

- WebSocket (`/ws`) と API は SW が一切介入しないので、リアルタイム CI ステータス更新やフォーム送信は従来通り動作する想定
- アイコンは外部画像生成を避けるため SVG のみ。iOS の home screen icon も最近の Safari は SVG をサポートするが、もし PNG が必要なら追加検討

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgPLS72JKkUz2YCH2kUDT6)_