### PR TITLE
perf(releases): KV cache GitHub fan-out + Cache-Control on /releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -434,8 +433,7 @@
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260405.1.tgz",
       "integrity": "sha512-PokTmySa+D6MY01R1UfYH48korsN462NK/fl3aw47Hg7XuLuSo/RTpjT0vtWaJhJoFY5tHGOBBIbDcIc8wltLg==",
       "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -461,6 +459,30 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -468,6 +490,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2001,7 +2024,6 @@
       "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.2",
         "pathe": "^2.0.3"
@@ -2016,7 +2038,6 @@
       "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "4.1.2",
         "@vitest/utils": "4.1.2",
@@ -2172,7 +2193,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2844,7 +2864,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3548,7 +3567,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4081,7 +4099,6 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -4141,7 +4158,6 @@
       "integrity": "sha512-baBr4jUVSLJ0RPyZ2nK0zS2+W8hNHbM4hEzfvllukmRPVS3xDG5ATTNtbRXrKIOE2b8/FsPWJAOnuIxcs7g3cw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4220,7 +4236,6 @@
       "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.2",
         "@vitest/mocker": "4.1.2",
@@ -4336,7 +4351,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -4451,7 +4465,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -131,7 +131,9 @@ export class CIDashboardHub extends DurableObject<Env> {
       const { repo, tag } = await request.json<{ repo: string; tag?: string }>();
       await this.ensureAlerts();
       try {
-        const alert = await computeReleaseAlert(this.env.GITHUB_TOKEN, repo, tag);
+        const alert = await computeReleaseAlert(
+          this.env.GITHUB_TOKEN, repo, tag, this.env.CI_STATUS,
+        );
         this.persistAlert(repo, alert);
         this.broadcastAlerts();
       } catch {
@@ -155,7 +157,7 @@ export class CIDashboardHub extends DurableObject<Env> {
       }
       try {
         const fresh = await recomputeAlert(
-          this.env.GITHUB_TOKEN, repo, existing.tag,
+          this.env.GITHUB_TOKEN, repo, existing.tag, this.env.CI_STATUS,
         );
         this.persistAlert(repo, fresh);
         this.broadcastAlerts();

--- a/src/release-alert.ts
+++ b/src/release-alert.ts
@@ -18,7 +18,6 @@
 // it doesn't show.
 
 import {
-  githubApi,
   parseRepo,
   validateOrg,
   GitHubApiError,
@@ -30,6 +29,14 @@ import {
   sortSemverDesc,
   previousTag,
 } from "./release-helpers";
+import {
+  cachedTags,
+  cachedCompare,
+  cachedCommits,
+  cachedPullRequest,
+  cachedIssue,
+  type RawIssue,
+} from "./release-cache";
 
 export interface ReleaseAlert {
   repo: string;          // "owner/name"
@@ -39,20 +46,7 @@ export interface ReleaseAlert {
   detectedAt: string;    // ISO
 }
 
-interface TagListItem { name: string; commit: { sha: string } }
-interface RawCommit { sha: string; commit: { message: string } }
-interface CompareResponse { commits: RawCommit[] }
-interface PrResponse { head: { ref: string }; body: string | null }
-export interface RawIssue {
-  number: number;
-  title: string;
-  state: string;
-  labels: Array<{ name: string }>;
-  assignees: Array<{ login: string }>;
-  html_url: string;
-  updated_at: string;
-  pull_request?: unknown;
-}
+export type { RawIssue };
 
 // Walk the commits introduced by `tag` (using compare against `prevTag` when
 // available, otherwise a bounded log walk for the first-ever release) and
@@ -63,15 +57,11 @@ export async function collectIssueNumbersForRange(
   name: string,
   tag: string,
   prevTag: string | null,
+  kv?: KVNamespace,
 ): Promise<{ issueNumbers: Set<number>; commitCount: number }> {
   const commits = prevTag
-    ? (await githubApi<CompareResponse>(
-        token, "GET", `/repos/${owner}/${name}/compare/${prevTag}...${tag}`,
-      )).commits
-    : await githubApi<RawCommit[]>(
-        token, "GET", `/repos/${owner}/${name}/commits`, undefined,
-        { sha: tag, per_page: "50" },
-      );
+    ? (await cachedCompare(token, kv, owner, name, prevTag, tag)).commits
+    : await cachedCommits(token, kv, owner, name, tag, 50);
 
   const issueNumbers = new Set<number>();
   const prNumbers = new Set<number>();
@@ -86,9 +76,7 @@ export async function collectIssueNumbersForRange(
   // squash-merge subject line drops.
   await Promise.all([...prNumbers].map(async (n) => {
     try {
-      const pr = await githubApi<PrResponse>(
-        token, "GET", `/repos/${owner}/${name}/pulls/${n}`,
-      );
+      const pr = await cachedPullRequest(token, kv, owner, name, n);
       const fromBranch = extractBranchIssue(pr.head.ref);
       if (fromBranch !== null) issueNumbers.add(fromBranch);
       if (pr.body) {
@@ -108,12 +96,11 @@ export async function fetchIssuesByNumbers(
   owner: string,
   name: string,
   numbers: Iterable<number>,
+  kv?: KVNamespace,
 ): Promise<RawIssue[]> {
   const results = await Promise.all([...numbers].map(async (n) => {
     try {
-      return await githubApi<RawIssue>(
-        token, "GET", `/repos/${owner}/${name}/issues/${n}`,
-      );
+      return await cachedIssue(token, kv, owner, name, n);
     } catch {
       return null;
     }
@@ -128,14 +115,12 @@ export async function computeReleaseAlert(
   token: string,
   repo: string,
   tagOverride?: string,
+  kv?: KVNamespace,
 ): Promise<ReleaseAlert | null> {
   const { owner, repo: name } = parseRepo(repo);
   validateOrg(owner);
 
-  const tags = await githubApi<TagListItem[]>(
-    token, "GET", `/repos/${owner}/${name}/tags`, undefined,
-    { per_page: "30" },
-  );
+  const tags = await cachedTags(token, kv, owner, name, 30);
   const tagNames = tags.map((t) => t.name);
   if (tagNames.length === 0) return null;
 
@@ -153,12 +138,12 @@ export async function computeReleaseAlert(
 
   const prevTag = previousTag(sorted, tag);
   const { issueNumbers } = await collectIssueNumbersForRange(
-    token, owner, name, tag, prevTag,
+    token, owner, name, tag, prevTag, kv,
   );
 
   if (issueNumbers.size === 0) return null;
 
-  const issues = await fetchIssuesByNumbers(token, owner, name, issueNumbers);
+  const issues = await fetchIssuesByNumbers(token, owner, name, issueNumbers, kv);
   const openIssues = issues
     .filter((i) => !i.pull_request && i.state === "open")
     .map((i) => ({ number: i.number, title: i.title, url: i.html_url }))
@@ -182,6 +167,7 @@ export async function recomputeAlert(
   token: string,
   repo: string,
   tag: string,
+  kv?: KVNamespace,
 ): Promise<ReleaseAlert | null> {
-  return computeReleaseAlert(token, repo, tag);
+  return computeReleaseAlert(token, repo, tag, kv);
 }

--- a/src/release-cache.ts
+++ b/src/release-cache.ts
@@ -1,0 +1,180 @@
+// KV-backed cache for the GitHub fan-out behind /releases.
+//
+// Background: /releases (both the index and the per-tag detail view) runs N×M
+// GitHub REST calls per page load — tags / compare ranges / per-issue lookups
+// for every watched repo. None of that was cached, so each refresh paid the
+// full round-trip cost. This module wraps the calls that releases-page.ts and
+// release-alert.ts make so the second-and-later loads hit KV instead of the
+// GitHub API.
+//
+// TTL strategy (key invariant: the cache is best-effort, never authoritative):
+//   - `tags`        300 s   — new tags appear, but a 5-min lag at release time
+//                              is fine for a confirmation UI.
+//   - `compare`     24 h    — once both endpoints exist as tags, the diff is
+//                              immutable. Long TTL is safe.
+//   - `commits`     60 s    — synthetic-block HEAD listing; HEAD moves often.
+//   - `repo-meta`   1 h     — default_branch rarely changes.
+//   - `pr`          24 h    — body / head.ref are frozen after merge (we only
+//                              look up PRs that came in from a compare commit).
+//   - `issue`       60 s    — state changes any time; close paths actively
+//                              invalidate via `invalidateIssue`.
+//
+// All keys live under `rcache:v1:` so a schema bump (new key shape, TTL change
+// that needs a flush) is a 1-line rename. Tests should `clearReleaseCache` in
+// afterEach to keep KV pollution from leaking across fixtures.
+
+import { githubApi } from "./github-api";
+
+const PREFIX = "rcache:v1:";
+
+const TTL_TAGS = 300;
+const TTL_COMPARE = 86400;
+const TTL_COMMITS = 60;
+const TTL_REPO_META = 3600;
+const TTL_PR = 86400;
+const TTL_ISSUE = 60;
+
+// Minimum KV expirationTtl is 60s; everything above respects that.
+
+interface TagListItem { name: string; commit: { sha: string } }
+interface RawCommit { sha: string; commit: { message: string } }
+interface CompareResponse { commits: RawCommit[] }
+interface PrResponse { head: { ref: string }; body: string | null }
+interface RepoMeta { default_branch: string }
+export interface RawIssue {
+  number: number;
+  title: string;
+  state: string;
+  labels: Array<{ name: string }>;
+  assignees: Array<{ login: string }>;
+  html_url: string;
+  updated_at: string;
+  pull_request?: unknown;
+}
+
+// Generic wrapper. `kv` is optional so unit tests (and the no-binding path)
+// fall through directly to the loader.
+async function kvCached<T>(
+  kv: KVNamespace | undefined,
+  key: string,
+  ttlSec: number,
+  loader: () => Promise<T>,
+): Promise<T> {
+  if (!kv) return loader();
+  const cached = await kv.get<T>(key, "json");
+  if (cached !== null && cached !== undefined) return cached;
+  const fresh = await loader();
+  // Fire-and-forget the write; freshness already in hand.
+  await kv.put(key, JSON.stringify(fresh), { expirationTtl: ttlSec });
+  return fresh;
+}
+
+export async function cachedTags(
+  token: string,
+  kv: KVNamespace | undefined,
+  owner: string,
+  name: string,
+  perPage: number,
+): Promise<TagListItem[]> {
+  const key = `${PREFIX}tags:${owner}/${name}:${perPage}`;
+  return kvCached(kv, key, TTL_TAGS, () =>
+    githubApi<TagListItem[]>(
+      token, "GET", `/repos/${owner}/${name}/tags`, undefined,
+      { per_page: String(perPage) },
+    ),
+  );
+}
+
+export async function cachedCompare(
+  token: string,
+  kv: KVNamespace | undefined,
+  owner: string,
+  name: string,
+  prev: string,
+  curr: string,
+): Promise<CompareResponse> {
+  const key = `${PREFIX}cmp:${owner}/${name}:${prev}..${curr}`;
+  return kvCached(kv, key, TTL_COMPARE, () =>
+    githubApi<CompareResponse>(
+      token, "GET", `/repos/${owner}/${name}/compare/${prev}...${curr}`,
+    ),
+  );
+}
+
+export async function cachedCommits(
+  token: string,
+  kv: KVNamespace | undefined,
+  owner: string,
+  name: string,
+  sha: string,
+  perPage: number,
+): Promise<RawCommit[]> {
+  const key = `${PREFIX}commits:${owner}/${name}:${sha}:${perPage}`;
+  return kvCached(kv, key, TTL_COMMITS, () =>
+    githubApi<RawCommit[]>(
+      token, "GET", `/repos/${owner}/${name}/commits`, undefined,
+      { sha, per_page: String(perPage) },
+    ),
+  );
+}
+
+export async function cachedRepoMeta(
+  token: string,
+  kv: KVNamespace | undefined,
+  owner: string,
+  name: string,
+): Promise<RepoMeta> {
+  const key = `${PREFIX}repo:${owner}/${name}`;
+  return kvCached(kv, key, TTL_REPO_META, () =>
+    githubApi<RepoMeta>(token, "GET", `/repos/${owner}/${name}`),
+  );
+}
+
+export async function cachedPullRequest(
+  token: string,
+  kv: KVNamespace | undefined,
+  owner: string,
+  name: string,
+  n: number,
+): Promise<PrResponse> {
+  const key = `${PREFIX}pr:${owner}/${name}:${n}`;
+  return kvCached(kv, key, TTL_PR, () =>
+    githubApi<PrResponse>(token, "GET", `/repos/${owner}/${name}/pulls/${n}`),
+  );
+}
+
+export async function cachedIssue(
+  token: string,
+  kv: KVNamespace | undefined,
+  owner: string,
+  name: string,
+  n: number,
+): Promise<RawIssue> {
+  const key = `${PREFIX}issue:${owner}/${name}:${n}`;
+  return kvCached(kv, key, TTL_ISSUE, () =>
+    githubApi<RawIssue>(token, "GET", `/repos/${owner}/${name}/issues/${n}`),
+  );
+}
+
+// Drop the cached issue snapshot so a close roundtrip immediately reflects on
+// the next /releases load instead of showing the still-open row for 60 s.
+export async function invalidateIssue(
+  kv: KVNamespace | undefined,
+  owner: string,
+  name: string,
+  n: number,
+): Promise<void> {
+  if (!kv) return;
+  await kv.delete(`${PREFIX}issue:${owner}/${name}:${n}`);
+}
+
+// Exposed for tests so afterEach can wipe inter-fixture pollution; production
+// callers never need this (TTL handles eviction).
+export async function clearReleaseCache(kv: KVNamespace): Promise<void> {
+  let cursor: string | undefined;
+  do {
+    const list = await kv.list({ prefix: PREFIX, cursor });
+    await Promise.all(list.keys.map((k) => kv.delete(k.name)));
+    cursor = list.list_complete ? undefined : list.cursor;
+  } while (cursor);
+}

--- a/src/release-close-batch.ts
+++ b/src/release-close-batch.ts
@@ -1,4 +1,5 @@
 import { githubApi, parseRepo, validateOrg } from "./github-api";
+import { invalidateIssue } from "./release-cache";
 
 // POST /api/release-close-batch
 //
@@ -16,7 +17,7 @@ const PAIR_RE = /^(.+):(\d+)$/;
 
 export async function handleReleaseCloseBatch(
   req: Request,
-  env: { GITHUB_TOKEN: string },
+  env: { GITHUB_TOKEN: string; CI_STATUS?: KVNamespace },
   hub?: DurableObjectStub,
   ctx?: ExecutionContext,
 ): Promise<Response> {
@@ -90,6 +91,12 @@ export async function handleReleaseCloseBatch(
     if (r.status === "fulfilled") closed.push(r.value);
     else failed.push(ops[i]!.issue);
   });
+
+  // Invalidate cached issue snapshots so the next /releases load reflects the
+  // newly-closed state instead of the 60s-stale "open" row.
+  await Promise.all(
+    closed.map((n) => invalidateIssue(env.CI_STATUS, owner, name, n)),
+  );
 
   // Kick Hub to recompute alert state for this repo when at least one close
   // succeeded. Same waitUntil pattern as release-close.ts so the redirect

--- a/src/release-close.ts
+++ b/src/release-close.ts
@@ -1,4 +1,5 @@
 import { githubApi, parseRepo, validateOrg } from "./github-api";
+import { invalidateIssue } from "./release-cache";
 
 // POST /api/release-close
 // Receives the form submitted from /releases?repo=...&tag=... and closes the
@@ -13,7 +14,7 @@ import { githubApi, parseRepo, validateOrg } from "./github-api";
 
 export async function handleReleaseClose(
   req: Request,
-  env: { GITHUB_TOKEN: string },
+  env: { GITHUB_TOKEN: string; CI_STATUS?: KVNamespace },
   hub?: DurableObjectStub,
   ctx?: ExecutionContext,
 ): Promise<Response> {
@@ -71,6 +72,13 @@ export async function handleReleaseClose(
     if (r.status === "fulfilled") closed.push(r.value);
     else failed.push(issueNumbers[i]!);
   });
+
+  // Drop the just-closed issues from the release cache so the next /releases
+  // load (and the banner recompute below) sees `state: "closed"` instead of
+  // the still-open snapshot from the 60s TTL window.
+  await Promise.all(
+    closed.map((n) => invalidateIssue(env.CI_STATUS, owner, name, n)),
+  );
 
   // Kick the Hub to recompute the banner alert state for this repo when at
   // least one issue actually closed. waitUntil keeps the user-facing redirect

--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -1,4 +1,4 @@
-import { githubApi, parseRepo, validateOrg, GitHubApiError } from "./github-api";
+import { parseRepo, validateOrg, GitHubApiError } from "./github-api";
 import {
   extractRefIssues,
   sortSemverDesc,
@@ -9,6 +9,13 @@ import {
   collectIssueNumbersForRange,
   fetchIssuesByNumbers,
 } from "./release-alert";
+import {
+  cachedTags,
+  cachedCompare,
+  cachedCommits,
+  cachedRepoMeta,
+  cachedIssue,
+} from "./release-cache";
 import { loadDirectPushAllowlist } from "./direct-push-allowlist";
 import { renderTabs, TAB_STYLES } from "./nav-tabs";
 import { PWA_HEAD_TAGS, PWA_REGISTER_SCRIPT } from "./pwa";
@@ -46,10 +53,15 @@ export async function handleReleasesPage(
   // Only the fully-specified pair opens the detail page; every other shape
   // (no params / partial / post-close redirect) falls through to the index so
   // the operator never lands on an empty form by accident (issue #45).
+  // Flash redirects must not be cached by the browser — they encode one-shot
+  // banner state. Same logic for empty post-close redirects (no flash params
+  // but the operator expects to see a fresh table).
+  const hasFlash = closedFlash.length > 0 || failedFlash.length > 0;
+
   if (repoParam && tag) {
     let result: ReleasePayload;
     try {
-      result = await loadRelease(env.GITHUB_TOKEN, repoParam, tag);
+      result = await loadRelease(env.GITHUB_TOKEN, repoParam, tag, env.CI_STATUS);
     } catch (err) {
       if (err instanceof GitHubApiError && err.status === 404) {
         return html(renderError(`Not found: ${err.message}`), 404);
@@ -57,12 +69,30 @@ export async function handleReleasesPage(
       const msg = err instanceof Error ? err.message : String(err);
       return html(renderError(msg), 502);
     }
-    return html(renderHtml(result, closedFlash, failedFlash), 200);
+    return html(
+      renderHtml(result, closedFlash, failedFlash),
+      200,
+      cacheControlFor(hasFlash, /* detail */ true),
+    );
   }
 
   // Index page; `repoParam` (when set without tag, e.g. from the batch-close
   // redirect) tags along so flash links can point at the right GitHub repo.
-  return await handleIndexPage(env, closedFlash, failedFlash, repoParam);
+  return await handleIndexPage(env, closedFlash, failedFlash, repoParam, hasFlash);
+}
+
+// Cache-Control policy:
+//   - Flash redirects: `no-store` so the banner doesn't get pinned in the
+//     browser's bfcache or revisited cache after a back-button click.
+//   - Detail page (single repo+tag): max-age 30, swr 120. Already-cached KV
+//     hits are usually <50ms but the HTML still costs CPU.
+//   - Index page: max-age 15, swr 60. Multi-repo fan-out means even cached
+//     paths are bigger; keep freshness tight so a new tag shows up quickly.
+function cacheControlFor(hasFlash: boolean, detail: boolean): string {
+  if (hasFlash) return "private, no-store";
+  return detail
+    ? "private, max-age=30, stale-while-revalidate=120"
+    : "private, max-age=15, stale-while-revalidate=60";
 }
 
 // --------------------------------------------------------------------------
@@ -99,6 +129,7 @@ async function handleIndexPage(
   closedFlash: number[],
   failedFlash: number[],
   flashRepo: string | null,
+  hasFlash: boolean,
 ): Promise<Response> {
   // 1. Watched repos come from two sources:
   //   (a) Hub status cache — every repo that has ever fired a CI run.
@@ -130,7 +161,7 @@ async function handleIndexPage(
   //    inside loadRepoView when they have no semver tags.
   const views = await Promise.all(repos.map(async (repo) => {
     try {
-      return await loadRepoView(env.GITHUB_TOKEN, repo, allowlist.has(repo));
+      return await loadRepoView(env.GITHUB_TOKEN, repo, allowlist.has(repo), env.CI_STATUS);
     } catch {
       return null;
     }
@@ -144,6 +175,7 @@ async function handleIndexPage(
       flashRepo,
     ),
     200,
+    cacheControlFor(hasFlash, /* detail */ false),
   );
 }
 
@@ -151,16 +183,14 @@ async function loadRepoView(
   token: string,
   repo: string,
   isDirectPush: boolean,
+  kv?: KVNamespace,
 ): Promise<RepoView | null> {
   const { owner, repo: name } = parseRepo(repo);
   validateOrg(owner);
 
   // 1. Recent semver tags. 10 gives us 5 inline + room for the predecessor
   //    pairing on the oldest of those 5 + a small "older" strip.
-  const allTags = await githubApi<TagListItem[]>(
-    token, "GET", `/repos/${owner}/${name}/tags`, undefined,
-    { per_page: "10" },
-  );
+  const allTags = await cachedTags(token, kv, owner, name, 10);
   const sorted = sortSemverDesc(allTags.map((t) => t.name));
   const topTags = sorted.slice(0, TOP_TAGS_INLINE);
   if (topTags.length === 0) {
@@ -170,7 +200,7 @@ async function loadRepoView(
     // empty as before so we don't accidentally treat an auto-merge repo as a
     // direct-push one mid-release.
     if (isDirectPush) {
-      const block = await loadSyntheticBlock(token, owner, name);
+      const block = await loadSyntheticBlock(token, owner, name, kv);
       return {
         repo: `${owner}/${name}`,
         tagBlocks: block ? [block] : [],
@@ -190,9 +220,7 @@ async function loadRepoView(
       return { tag, prevTag: null, refs: [] as number[] };
     }
     try {
-      const cmp = await githubApi<CompareResponse>(
-        token, "GET", `/repos/${owner}/${name}/compare/${prevTag}...${tag}`,
-      );
+      const cmp = await cachedCompare(token, kv, owner, name, prevTag, tag);
       const refs = new Set<number>();
       for (const c of cmp.commits) {
         for (const n of extractRefIssues(c.commit.message)) refs.add(n);
@@ -211,9 +239,7 @@ async function loadRepoView(
   const issueByNum = new Map<number, IssueRow | null>();
   await Promise.all([...uniqueRefs].map(async (n) => {
     try {
-      const issue = await githubApi<RawIssue>(
-        token, "GET", `/repos/${owner}/${name}/issues/${n}`,
-      );
+      const issue = await cachedIssue(token, kv, owner, name, n);
       if (issue.pull_request) { issueByNum.set(n, null); return; }
       const labels = issue.labels.map((l) => l.name);
       issueByNum.set(n, {
@@ -267,10 +293,11 @@ async function loadSyntheticBlock(
   token: string,
   owner: string,
   name: string,
+  kv?: KVNamespace,
 ): Promise<TagBlock | null> {
   let defaultBranch: string;
   try {
-    const meta = await githubApi<RepoMeta>(token, "GET", `/repos/${owner}/${name}`);
+    const meta = await cachedRepoMeta(token, kv, owner, name);
     defaultBranch = meta.default_branch;
   } catch {
     return null;
@@ -279,10 +306,7 @@ async function loadSyntheticBlock(
 
   let commits: RawCommit[] = [];
   try {
-    commits = await githubApi<RawCommit[]>(
-      token, "GET", `/repos/${owner}/${name}/commits`, undefined,
-      { sha: defaultBranch, per_page: String(SYNTHETIC_COMMIT_WINDOW) },
-    );
+    commits = await cachedCommits(token, kv, owner, name, defaultBranch, SYNTHETIC_COMMIT_WINDOW);
   } catch {
     return null;
   }
@@ -299,7 +323,7 @@ async function loadSyntheticBlock(
     return null;
   }
 
-  const issues = await fetchIssuesByNumbers(token, owner, name, refs);
+  const issues = await fetchIssuesByNumbers(token, owner, name, refs, kv);
   const openRows: IssueRow[] = issues
     .filter((i) => !i.pull_request && i.state === "open")
     .map((i) => {
@@ -355,6 +379,7 @@ async function loadRelease(
   token: string,
   repoParam: string,
   tag: string,
+  kv?: KVNamespace,
 ): Promise<ReleasePayload> {
   const { owner, repo: name } = parseRepo(repoParam);
   validateOrg(owner);
@@ -363,10 +388,7 @@ async function loadRelease(
   //    compare endpoint. 30 is plenty given typical release cadence; for
   //    older tags the operator can pass the URL anyway and we fall back to a
   //    bounded commit list below.
-  const tags = await githubApi<TagListItem[]>(
-    token, "GET", `/repos/${owner}/${name}/tags`, undefined,
-    { per_page: "30" },
-  );
+  const tags = await cachedTags(token, kv, owner, name, 30);
   const tagNames = tags.map((t) => t.name);
   if (!tagNames.includes(tag)) {
     throw new GitHubApiError(
@@ -380,12 +402,12 @@ async function loadRelease(
   //    attribute (Refs in commit message, PR body, branch prefix). Shared
   //    with the dashboard banner path so the two views stay in lockstep.
   const { issueNumbers, commitCount } = await collectIssueNumbersForRange(
-    token, owner, name, tag, prev,
+    token, owner, name, tag, prev, kv,
   );
 
   // 3. Hydrate candidates. The /issues/:n endpoint also returns PRs, so we
   //    filter those out below (PRs carry a `pull_request` discriminator).
-  const issues = await fetchIssuesByNumbers(token, owner, name, issueNumbers);
+  const issues = await fetchIssuesByNumbers(token, owner, name, issueNumbers, kv);
 
   const rows: IssueRow[] = issues
     .filter((i) => !i.pull_request)
@@ -413,19 +435,7 @@ async function loadRelease(
   };
 }
 
-interface TagListItem { name: string; commit: { sha: string } }
 interface RawCommit { sha: string; commit: { message: string } }
-interface CompareResponse { commits: RawCommit[] }
-interface RawIssue {
-  number: number;
-  title: string;
-  state: string;
-  labels: Array<{ name: string }>;
-  assignees: Array<{ login: string }>;
-  html_url: string;
-  updated_at: string;
-  pull_request?: unknown;
-}
 
 function numericList(s: string | null): number[] {
   if (!s) return [];
@@ -436,11 +446,12 @@ function numericList(s: string | null): number[] {
 // HTML
 // --------------------------------------------------------------------------
 
-function html(body: string, status: number): Response {
-  return new Response(body, {
-    status,
-    headers: { "Content-Type": "text/html; charset=utf-8" },
-  });
+function html(body: string, status: number, cacheControl?: string): Response {
+  const headers: Record<string, string> = {
+    "Content-Type": "text/html; charset=utf-8",
+  };
+  if (cacheControl) headers["Cache-Control"] = cacheControl;
+  return new Response(body, { status, headers });
 }
 
 function renderHtml(

--- a/test/release-cache.test.ts
+++ b/test/release-cache.test.ts
@@ -1,0 +1,83 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  cachedTags,
+  cachedIssue,
+  cachedCompare,
+  invalidateIssue,
+  clearReleaseCache,
+} from "../src/release-cache";
+
+// The cache layer is meant to be transparent: first call hits GitHub, second
+// call returns the same payload without touching the network. Issue closes
+// then invalidate the slot so the third call re-fetches. We assert on fetch
+// call counts because that's what determines the actual /releases speedup —
+// hitting KV instead of api.github.com.
+describe("release-cache", () => {
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await clearReleaseCache(env.CI_STATUS);
+  });
+
+  it("cachedIssue: first call fetches, second hits KV, invalidate forces re-fetch", async () => {
+    let calls = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      calls++;
+      return Response.json({
+        number: 1, title: "x", state: "open",
+        labels: [], assignees: [],
+        html_url: "u", updated_at: "t",
+      });
+    });
+
+    const a = await cachedIssue("tok", env.CI_STATUS, "ippoan", "ci-dashboard", 1);
+    const b = await cachedIssue("tok", env.CI_STATUS, "ippoan", "ci-dashboard", 1);
+    expect(calls).toBe(1);
+    expect(b).toEqual(a);
+
+    await invalidateIssue(env.CI_STATUS, "ippoan", "ci-dashboard", 1);
+    await cachedIssue("tok", env.CI_STATUS, "ippoan", "ci-dashboard", 1);
+    expect(calls).toBe(2);
+  });
+
+  it("cachedTags: per_page is part of the cache key", async () => {
+    let calls = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      calls++;
+      return Response.json([{ name: "v1.0.0", commit: { sha: "a" } }]);
+    });
+    await cachedTags("tok", env.CI_STATUS, "ippoan", "ci-dashboard", 10);
+    await cachedTags("tok", env.CI_STATUS, "ippoan", "ci-dashboard", 10);
+    await cachedTags("tok", env.CI_STATUS, "ippoan", "ci-dashboard", 30);
+    expect(calls).toBe(2);
+  });
+
+  it("cachedCompare: prev..curr identity caches per range", async () => {
+    let calls = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      calls++;
+      return Response.json({ commits: [] });
+    });
+    await cachedCompare("tok", env.CI_STATUS, "ippoan", "x", "v1.0.0", "v1.1.0");
+    await cachedCompare("tok", env.CI_STATUS, "ippoan", "x", "v1.0.0", "v1.1.0");
+    await cachedCompare("tok", env.CI_STATUS, "ippoan", "x", "v1.1.0", "v1.2.0");
+    expect(calls).toBe(2);
+  });
+
+  it("falls through to the loader when kv is undefined (no caching)", async () => {
+    let calls = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      calls++;
+      return Response.json([]);
+    });
+    await cachedTags("tok", undefined, "ippoan", "ci-dashboard", 10);
+    await cachedTags("tok", undefined, "ippoan", "ci-dashboard", 10);
+    expect(calls).toBe(2);
+  });
+
+  it("invalidateIssue is a no-op when kv is undefined", async () => {
+    await expect(
+      invalidateIssue(undefined, "ippoan", "ci-dashboard", 1),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -2,6 +2,7 @@ import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:
 import { describe, it, expect, vi, afterEach } from "vitest";
 import worker from "../src/index";
 import type { Env } from "../src/index";
+import { clearReleaseCache } from "../src/release-cache";
 
 // `watched` populates the Hub `/statuses` response so the no-params index
 // page can enumerate repos. Defaults to empty so existing tests keep their
@@ -101,7 +102,15 @@ function stubGithubApi(opts: { tagExists?: boolean; failPr?: boolean } = {}) {
 }
 
 describe("GET /releases", () => {
-  afterEach(() => { vi.restoreAllMocks(); });
+  // KV-backed release cache and the direct-push allowlist cache both persist
+  // across tests in the shared CI_STATUS namespace; wipe them so fixture-A
+  // doesn't leak into fixture-B (e.g. the synthetic-block test caching the
+  // claude-hooks allowlist entry).
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await clearReleaseCache(env.CI_STATUS);
+    await env.CI_STATUS.delete("direct-push-allowlist:v1");
+  });
 
   it("renders the empty-state landing page when nothing is watched yet", async () => {
     const req = new Request("http://localhost/releases");
@@ -612,6 +621,97 @@ describe("GET /releases", () => {
     expect(html).toContain("1 closed issue");
     // But the actions row (and its button) is gone.
     expect(html).not.toContain("Close selected as released");
+  });
+
+  it("sets browser-cacheable Cache-Control on the no-flash detail page", async () => {
+    stubGithubApi();
+    const req = new Request("http://localhost/releases?repo=ippoan/ci-dashboard&tag=v1.2.0");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    // Detail page: longer TTL since a single repo+tag changes less often.
+    expect(res.headers.get("Cache-Control")).toMatch(/max-age=30/);
+    expect(res.headers.get("Cache-Control")).toMatch(/stale-while-revalidate/);
+  });
+
+  it("disables browser caching when flash params are present", async () => {
+    // Flash redirects must always re-render with fresh server state — a
+    // cached HTML response would show stale banner content on back/forward.
+    stubGithubApi();
+    const req = new Request(
+      "http://localhost/releases?repo=ippoan/ci-dashboard&tag=v1.2.0&closed=42",
+    );
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+    expect(res.headers.get("Cache-Control")).toBe("private, no-store");
+  });
+
+  it("re-uses cached GitHub responses on the second load (no duplicate fetches)", async () => {
+    // The whole point of the KV cache layer: the SSR page hits api.github.com
+    // once per fixture URL, then serves from KV on the next request. We count
+    // the fetch calls (which the cache helper bypasses on KV-hit) instead of
+    // asserting on KV internals.
+    let fetchCount = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
+      const url = typeof req === "string" ? req : (req as Request).url;
+      fetchCount++;
+      // Empty allowlist so the synthetic path doesn't fire for any other repo.
+      // We cache it on success so the second load skips this round-trip too.
+      if (url.includes("/contents/wt-direct-push/config/direct-push-ok.txt")) {
+        // parseAllowlist drops empty content → repos.length === 0 → NO cache
+        // write. Return a placeholder entry that gets cached and resolves to
+        // a no-op (its tags fetch returns []).
+        return Response.json({ content: btoa("ippoan/placeholder\n"), encoding: "base64" });
+      }
+      if (url.includes("/repos/ippoan/placeholder/tags")) {
+        return Response.json([]);
+      }
+      if (url.match(/\/repos\/ippoan\/placeholder(\?|$)/)) {
+        return Response.json({ default_branch: "main" });
+      }
+      if (url.includes("/repos/ippoan/placeholder/commits")) {
+        return Response.json([]);
+      }
+      if (url.includes("/repos/ippoan/ci-dashboard/tags")) {
+        return Response.json([
+          { name: "v1.2.0", commit: { sha: "a" } },
+          { name: "v1.1.0", commit: { sha: "b" } },
+        ]);
+      }
+      if (url.includes("/compare/v1.1.0...v1.2.0")) {
+        return Response.json({
+          commits: [{ sha: "x", commit: { message: "feat\n\nRefs #1" } }],
+        });
+      }
+      if (url.endsWith("/issues/1")) {
+        return Response.json({
+          number: 1, title: "x", state: "open",
+          labels: [], assignees: [],
+          html_url: "https://github.com/ippoan/ci-dashboard/issues/1",
+          updated_at: "2026-05-01T00:00:00Z",
+        });
+      }
+      return new Response("not stubbed", { status: 500 });
+    });
+
+    const e = testEnv({ watched: ["ippoan/ci-dashboard"] });
+    const req1 = new Request("http://localhost/releases");
+    const ctx1 = createExecutionContext();
+    await worker.fetch(req1, e, ctx1);
+    await waitOnExecutionContext(ctx1);
+    const firstLoadCalls = fetchCount;
+    expect(firstLoadCalls).toBeGreaterThan(0);
+
+    const req2 = new Request("http://localhost/releases");
+    const ctx2 = createExecutionContext();
+    const res2 = await worker.fetch(req2, e, ctx2);
+    await waitOnExecutionContext(ctx2);
+    // Second load should be served entirely from KV — no new GitHub calls.
+    expect(fetchCount).toBe(firstLoadCalls);
+    expect(res2.status).toBe(200);
   });
 
   it("does not turn an unallowlisted tag-less repo into a synthetic block", async () => {


### PR DESCRIPTION
## Summary

- `/releases` was hitting GitHub with `N × (1 tags + 5 compare + M issues)` REST calls per render (no caching). Wrap those calls in a KV-backed cache (`rcache:v1:` prefix, `CI_STATUS` namespace) so the second-and-later loads serve from KV instead of `api.github.com`.
- TTLs match the data's mutability: `compare` 24 h (immutable once both tags exist), `tags` / `repo-meta` minutes-to-hour, `commits` / `issue` 60 s. `release-close{,-batch}` invalidates the just-closed `issue:N` keys so a close round-trip immediately reflects on the next render.
- `Cache-Control` on the SSR responses: detail page `max-age=30, swr=120`, index `max-age=15, swr=60`, flash redirects `no-store` (banner state must not survive bfcache).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 190/190 pass (8 added: 5 cache unit + 3 page-level for Cache-Control & second-load KV-hit)
- [ ] After deploy: hit `/releases` twice, confirm the second load is sub-second (KV hits only) via dashboard / `wrangler tail`
- [ ] Close one issue from the batch form, confirm the redirect shows the closed banner and the same row is gone (cache invalidation working)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBnW8CGxcMUXM6rsdzXJvh)_