### PR TITLE
feat(nav): add Branch Protection tab linking to auth-worker dashboard

### DIFF
--- a/src/nav-tabs.ts
+++ b/src/nav-tabs.ts
@@ -9,20 +9,35 @@
 export type TabKey = "dashboard" | "issues" | "releases";
 
 interface TabDef {
-  key: TabKey;
+  key: TabKey | "branch-protection";
   href: string;
   label: string;
+  // External tabs live on a different origin (auth-worker), so they open in a
+  // new tab and are never marked active here. The destination handler does its
+  // own auth gating — visiting `/dashboard/branch-protection` without an
+  // elevation flag bounces the browser into `/mcp/elevate`, so this is the
+  // single entry point operators need to click.
+  external?: boolean;
 }
 
 const TABS: ReadonlyArray<TabDef> = [
   { key: "dashboard", href: "/",         label: "📊 Dashboard" },
   { key: "issues",    href: "/issues",   label: "📋 Open Issues" },
   { key: "releases",  href: "/releases", label: "🏷️ Releases" },
+  {
+    key: "branch-protection",
+    href: "https://auth.ippoan.org/dashboard/branch-protection",
+    label: "🛡️ Branch Protection",
+    external: true,
+  },
 ];
 
 export function renderTabs(active: TabKey): string {
   const items = TABS.map((t) => {
     const cls = t.key === active ? "tab tab-active" : "tab";
+    if (t.external) {
+      return `<a href="${t.href}" class="${cls}" target="_blank" rel="noopener">${t.label}</a>`;
+    }
     return `<a href="${t.href}" class="${cls}">${t.label}</a>`;
   }).join("");
   return `<nav class="tabs">${items}</nav>`;


### PR DESCRIPTION
## 概要

ci-dashboard のナビタブに `🛡️ Branch Protection` を追加し、auth-worker 側の `/dashboard/branch-protection` UI への単一エントリポイントを提供する。auth-worker は elevate flag が無ければ `/mcp/elevate` に自動 redirect するので、未昇格状態でクリックすればそのまま昇格フローが起動する。

## 関連 issue

Refs #

## 変更点

- `src/nav-tabs.ts`: `external: true` をサポートする TabDef を追加し、`target="_blank" rel="noopener"` でリンク。external タブは active 判定対象外。
- リンク先は `https://auth.ippoan.org/dashboard/branch-protection`。

## 動作確認

- [x] `npm test` (190 passed)
- [ ] `npm run typecheck`
- [ ] 手動確認: 各ページ (`/`, `/issues`, `/releases`) からタブが見え、クリックで auth-worker UI が別タブで開くこと。未 elevate 状態だと `/mcp/elevate` 経由で GitHub OAuth に飛ぶこと。

## メモ

external タブのため `TabKey` は変更せず、`TabDef.key` だけ `TabKey | "branch-protection"` に広げた。SSR 各ページ (`renderTabs("dashboard"|"issues"|"releases")`) は無変更。

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7sQtj98p4KmjpYVLXDY2b)_