### PR TITLE
fix(nav): point Branch Protection tab to auth-staging

### DIFF
--- a/src/nav-tabs.ts
+++ b/src/nav-tabs.ts
@@ -26,7 +26,7 @@ const TABS: ReadonlyArray<TabDef> = [
   { key: "releases",  href: "/releases", label: "🏷️ Releases" },
   {
     key: "branch-protection",
-    href: "https://auth.ippoan.org/dashboard/branch-protection",
+    href: "https://auth-staging.ippoan.org/dashboard/branch-protection",
     label: "🛡️ Branch Protection",
     external: true,
   },

--- a/src/nav-tabs.ts
+++ b/src/nav-tabs.ts
@@ -9,20 +9,35 @@
 export type TabKey = "dashboard" | "issues" | "releases";
 
 interface TabDef {
-  key: TabKey;
+  key: TabKey | "branch-protection";
   href: string;
   label: string;
+  // External tabs live on a different origin (auth-worker), so they open in a
+  // new tab and are never marked active here. The destination handler does its
+  // own auth gating — visiting `/dashboard/branch-protection` without an
+  // elevation flag bounces the browser into `/mcp/elevate`, so this is the
+  // single entry point operators need to click.
+  external?: boolean;
 }
 
 const TABS: ReadonlyArray<TabDef> = [
   { key: "dashboard", href: "/",         label: "📊 Dashboard" },
   { key: "issues",    href: "/issues",   label: "📋 Open Issues" },
   { key: "releases",  href: "/releases", label: "🏷️ Releases" },
+  {
+    key: "branch-protection",
+    href: "https://auth.ippoan.org/dashboard/branch-protection",
+    label: "🛡️ Branch Protection",
+    external: true,
+  },
 ];
 
 export function renderTabs(active: TabKey): string {
   const items = TABS.map((t) => {
     const cls = t.key === active ? "tab tab-active" : "tab";
+    if (t.external) {
+      return `<a href="${t.href}" class="${cls}" target="_blank" rel="noopener">${t.label}</a>`;
+    }
     return `<a href="${t.href}" class="${cls}">${t.label}</a>`;
   }).join("");
   return `<nav class="tabs">${items}</nav>`;


### PR DESCRIPTION
## 概要

#82 で追加した Branch Protection ナビタブのリンク先を production (`auth.ippoan.org`) から staging (`auth-staging.ippoan.org`) に変更する。production 側はまだ `/dashboard/branch-protection` の準備が無く、staging で確認するのが正しいフロー。

#82 は staging URL 修正 commit を push する前に auto-merge で main へ取り込まれてしまったため、別 PR として切り出した。

## 関連 issue

Refs #

## 変更点

- `src/nav-tabs.ts`: `href` を `https://auth-staging.ippoan.org/dashboard/branch-protection` へ

## 動作確認

- [x] `npm test` (190 passed, 前 PR 時点で確認済み — diff は文字列 1 行のみ)
- [ ] 手動確認: タブから別タブで staging UI が開くこと

## メモ

production へ戻したい時は同じ箇所を 1 行で書き戻す。

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7sQtj98p4KmjpYVLXDY2b)_