### PR TITLE
fix(nav): point Branch Protection tab to auth-staging

### DIFF
--- a/src/nav-tabs.ts
+++ b/src/nav-tabs.ts
@@ -26,7 +26,7 @@ const TABS: ReadonlyArray<TabDef> = [
   { key: "releases",  href: "/releases", label: "🏷️ Releases" },
   {
     key: "branch-protection",
-    href: "https://auth.ippoan.org/dashboard/branch-protection",
+    href: "https://auth-staging.ippoan.org/dashboard/branch-protection",
     label: "🛡️ Branch Protection",
     external: true,
   },


### PR DESCRIPTION
## 概要

#82 で追加した Branch Protection ナビタブのリンク先を production (`auth.ippoan.org`) から staging (`auth-staging.ippoan.org`) に変更する。production 側はまだ `/dashboard/branch-protection` の準備が無く、staging で確認するのが正しいフロー。

旧 #83 は base が #82 マージ前で conflict (`mergeable_state: dirty`) していたため close し、main から切り直した本 PR で差し替え。

## 変更点

- `src/nav-tabs.ts`: `href` を `https://auth-staging.ippoan.org/dashboard/branch-protection` へ (1 行)

## 動作確認

- [ ] 手動確認: タブから別タブで staging UI が開くこと

## メモ

production へ戻したい時は同じ箇所を 1 行で書き戻す。


---
_Generated by [Claude Code](https://claude.ai/code/session_018rkg7pQQbL7vDgunEbP5Cg)_