### PR TITLE
feat(mcp): unit-test update_issue empty-PATCH rejection (Refs #33)

### DIFF
--- a/src/mcp/tools/issues.ts
+++ b/src/mcp/tools/issues.ts
@@ -2,6 +2,32 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { githubApi, parseRepo, validateOrg } from "../../github-api";
 
+/** Build the PATCH body for `update_issue` from optional fields. Strips
+ *  fields the caller did not provide (= `undefined`); preserves empty
+ *  arrays and `null` (those are intentional clear-the-field signals).
+ *  Throws if no fields would be sent (= empty PATCH is rejected). */
+export function buildUpdateIssuePayload(input: {
+  title?: string;
+  body?: string;
+  labels?: string[];
+  assignees?: string[];
+  milestone?: number | null;
+}): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  if (input.title !== undefined) payload.title = input.title;
+  if (input.body !== undefined) payload.body = input.body;
+  if (input.labels !== undefined) payload.labels = input.labels;
+  if (input.assignees !== undefined) payload.assignees = input.assignees;
+  if (input.milestone !== undefined) payload.milestone = input.milestone;
+
+  if (Object.keys(payload).length === 0) {
+    throw new Error(
+      "update_issue: at least one of title/body/labels/assignees/milestone must be provided",
+    );
+  }
+  return payload;
+}
+
 export function registerIssuesTools(server: McpServer, token: string): void {
   server.registerTool(
     "list_issues",
@@ -149,18 +175,7 @@ export function registerIssuesTools(server: McpServer, token: string): void {
       const { owner, repo: name } = parseRepo(repo);
       validateOrg(owner);
 
-      const payload: Record<string, unknown> = {};
-      if (title !== undefined) payload.title = title;
-      if (body !== undefined) payload.body = body;
-      if (labels !== undefined) payload.labels = labels;
-      if (assignees !== undefined) payload.assignees = assignees;
-      if (milestone !== undefined) payload.milestone = milestone;
-
-      if (Object.keys(payload).length === 0) {
-        throw new Error(
-          "update_issue: at least one of title/body/labels/assignees/milestone must be provided",
-        );
-      }
+      const payload = buildUpdateIssuePayload({ title, body, labels, assignees, milestone });
 
       const updated = await githubApi<Issue>(
         token, "PATCH", `/repos/${owner}/${name}/issues/${issue_number}`, payload,

--- a/test/mcp/tools.test.ts
+++ b/test/mcp/tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { githubApi, githubApiRaw, parseRepo, validateOrg, GitHubApiError } from "../../src/github-api";
+import { buildUpdateIssuePayload } from "../../src/mcp/tools/issues";
 
 // Test MCP tool logic by calling the same functions the tools use.
 // The MCP protocol layer (JSON-RPC, transport) is tested by the SDK itself.
@@ -430,6 +431,25 @@ describe("Issues write tool logic", () => {
     expect(body.labels).toEqual([]);
     expect(body.assignees).toEqual([]);
     expect(body.milestone).toBeNull();
+  });
+
+  it("update_issue rejects an empty PATCH (no fields provided) — buildUpdateIssuePayload throws", () => {
+    expect(() => buildUpdateIssuePayload({})).toThrow(
+      /at least one of title\/body\/labels\/assignees\/milestone/,
+    );
+  });
+
+  it("buildUpdateIssuePayload preserves empty arrays and null milestone as intentional clears", () => {
+    expect(
+      buildUpdateIssuePayload({ labels: [], assignees: [], milestone: null }),
+    ).toEqual({ labels: [], assignees: [], milestone: null });
+  });
+
+  it("buildUpdateIssuePayload omits undefined fields entirely (partial update)", () => {
+    expect(buildUpdateIssuePayload({ title: "new", body: "" })).toEqual({
+      title: "new",
+      body: "",
+    });
   });
 
   it("reopen_issue PATCHes state=open without state_reason", async () => {


### PR DESCRIPTION
## Summary

Refs #33 (per ci-dashboard CLAUDE.md — auto-close is intentionally avoided).

The `update_issue` MCP tool's implementation, README entry, and 2 baseline tests were already shipped before this PR. The only acceptance-checklist item from #33 that wasn't yet satisfied was the "empty PATCH (no fields provided) is rejected" path — the guard exists in the handler but was unreachable from unit tests because tests exercise `githubApi` directly, not the registered tool handler closure.

This PR extracts the payload-building + validation into a named export so it can be unit-tested without spinning up the MCP server, then adds 3 tests covering the previously-uncovered behavior.

## Changes

`src/mcp/tools/issues.ts`:
- Add `export function buildUpdateIssuePayload(input)` — same payload-construction + "no fields → throw" logic that was inline in the handler. No behavior change.
- The `update_issue` handler now calls the new function (one-line replacement of the inline block).

`test/mcp/tools.test.ts` (+3 tests):
- `update_issue rejects an empty PATCH (no fields provided)` — confirms the guard throws with the documented `at least one of title/body/labels/assignees/milestone` message.
- `buildUpdateIssuePayload preserves empty arrays and null milestone` — confirms `labels: []` / `assignees: []` / `milestone: null` pass through verbatim (intentional "clear-the-field" signals, not stripped).
- `buildUpdateIssuePayload omits undefined fields entirely` — confirms partial-update semantics.

## #33's confirmation checklist (re-validated)

- [x] `npm run typecheck` — clean
- [x] `npm test` — 193 pass (up from 190 on main); both the PATCH-body-construction tests and the empty-PATCH rejection test are now covered
- [x] README のツール一覧表 — `update_issue` is already listed at `README.md:42` (no change needed)

## Notes

- Commit/PR uses `Refs #33` (per `CLAUDE.md`'s rule against `Closes #N`); the issue stays open until release-time manual close per the documented flow.
- No public API change: `buildUpdateIssuePayload` is a new export but nothing breaks if a consumer ignores it. The MCP tool surface (`update_issue` schema + behavior) is identical.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vg8MeNAnpFfbkW2m5xemUy)_