### PR TITLE
feat(nav): add GCP Secrets tab linking to Secret Manager console

### DIFF
--- a/src/nav-tabs.ts
+++ b/src/nav-tabs.ts
@@ -9,16 +9,21 @@
 export type TabKey = "dashboard" | "issues" | "releases" | "secret-gen";
 
 interface TabDef {
-  key: TabKey | "branch-protection";
+  key: TabKey | "branch-protection" | "gcp-secrets";
   href: string;
   label: string;
-  // External tabs live on a different origin (auth-worker), so they open in a
-  // new tab and are never marked active here. The destination handler does its
-  // own auth gating — visiting `/dashboard/branch-protection` without an
-  // elevation flag bounces the browser into `/mcp/elevate`, so this is the
-  // single entry point operators need to click.
+  // External tabs live on a different origin, so they open in a new tab and
+  // are never marked active here. The destination handler does its own auth
+  // gating — `branch-protection` bounces non-elevated browsers into
+  // `/mcp/elevate`; `gcp-secrets` requires Google IAM (the operator already
+  // has accessor permissions on the project).
   external?: boolean;
 }
+
+// secrets-inventory (ippoan/secrets-inventory) で source of truth として扱う
+// GCP project。値取得 1-click の入口として GCP Secret Manager コンソールに
+// 直接飛ばす。project を変える場合はここを差し替える。
+const SECRETS_GCP_PROJECT = "cloudsql-sv";
 
 const TABS: ReadonlyArray<TabDef> = [
   { key: "dashboard",  href: "/",           label: "📊 Dashboard" },
@@ -29,6 +34,12 @@ const TABS: ReadonlyArray<TabDef> = [
     key: "branch-protection",
     href: "https://auth-staging.ippoan.org/dashboard/branch-protection",
     label: "🛡️ Branch Protection",
+    external: true,
+  },
+  {
+    key: "gcp-secrets",
+    href: `https://console.cloud.google.com/security/secret-manager?project=${encodeURIComponent(SECRETS_GCP_PROJECT)}`,
+    label: "🗝️ GCP Secrets",
     external: true,
   },
 ];

--- a/test/nav-tabs.test.ts
+++ b/test/nav-tabs.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Smoke tests for the shared nav-tabs strip. The strip is rendered on every
+ * SSR page (dashboard / issues / releases / secret-gen), so a missing or
+ * malformed tab silently breaks navigation everywhere.
+ */
+import { describe, it, expect } from "vitest";
+import { renderTabs } from "../src/nav-tabs";
+
+describe("renderTabs — internal tabs", () => {
+  it("marks the active tab with tab-active and the rest plain", () => {
+    const html = renderTabs("issues");
+    expect(html).toMatch(/tab tab-active[^>]*>\s*📋 Open Issues/);
+    expect(html).toMatch(/class="tab"[^>]*>\s*📊 Dashboard/);
+  });
+
+  it("renders the Secret Generator tab", () => {
+    const html = renderTabs("dashboard");
+    expect(html).toContain('href="/secret-gen"');
+    expect(html).toContain("🔐 Secret Generator");
+  });
+});
+
+describe("renderTabs — external tabs", () => {
+  it("renders Branch Protection tab pointing at the auth-worker dashboard, opens in new tab", () => {
+    const html = renderTabs("dashboard");
+    expect(html).toContain(
+      'href="https://auth-staging.ippoan.org/dashboard/branch-protection"',
+    );
+    expect(html).toContain("🛡️ Branch Protection");
+    // external tabs MUST get target="_blank" + rel="noopener" so the
+    // destination origin can't reach back into ci-dashboard via window.opener
+    expect(html).toMatch(
+      /href="https:\/\/auth-staging\.ippoan\.org[^"]*"[^>]*target="_blank"[^>]*rel="noopener"/,
+    );
+  });
+
+  it("renders GCP Secrets tab pointing at the Secret Manager console for cloudsql-sv", () => {
+    const html = renderTabs("dashboard");
+    expect(html).toContain(
+      'href="https://console.cloud.google.com/security/secret-manager?project=cloudsql-sv"',
+    );
+    expect(html).toContain("🗝️ GCP Secrets");
+    // same anti-tabnabbing requirement as branch-protection
+    expect(html).toMatch(
+      /href="https:\/\/console\.cloud\.google\.com[^"]*"[^>]*target="_blank"[^>]*rel="noopener"/,
+    );
+  });
+
+  it("never marks an external tab as active even if its key string is passed in (defensive)", () => {
+    // Internal tabs are typed via TabKey, but a future contributor could
+    // widen the type by mistake — make sure external tabs stay plain.
+    const html = renderTabs("dashboard");
+    expect(html).not.toMatch(/tab tab-active[^>]*>\s*🛡️ Branch Protection/);
+    expect(html).not.toMatch(/tab tab-active[^>]*>\s*🗝️ GCP Secrets/);
+  });
+});


### PR DESCRIPTION
Refs ippoan/secrets-inventory#1 (PR5)

secrets-inventory issue #1 の PR5 (ci-dashboard 側): GCP Secret Manager コンソールへの導線を top nav に追加し、operator が値を取りに行く時に 1-click でアクセスできるようにする。

## 変更

- `src/nav-tabs.ts`: 新規 external tab `🗝️ GCP Secrets` を追加。href は `https://console.cloud.google.com/security/secret-manager?project=cloudsql-sv` (secrets-inventory が source of truth として扱っている GCP project)。既存 `🛡️ Branch Protection` と同じく external (`target="_blank"`, `rel="noopener"`) 扱いなので active 表示にはならず、auth は Google IAM 側 (accessor 権限を持つ人だけが値を見られる) に委譲される。
- `src/nav-tabs.ts`: `TabKey | "branch-protection"` に `"gcp-secrets"` を追加 (internal `TabKey` ではなく external 専用キー)。
- `src/nav-tabs.ts`: `SECRETS_GCP_PROJECT` 定数を導入し、project を変える際は 1 行で済むように。コメントも external tabs の auth 委譲先について更新。

## テスト

- `test/nav-tabs.test.ts` 新規: `renderTabs()` の smoke test を集約。これまで Secret Generator tab の存在は `secret-gen-page.test.ts` の sub-describe で見ていたが、tab の数が増えてきたので nav-tabs 専用のテストに移した方が将来のメンテが楽。
  - internal tabs (Secret Generator / active marker)
  - external tabs (Branch Protection / GCP Secrets) の `href` / `target="_blank"` / `rel="noopener"` を assertion で固定 (tabnabbing 対策)
  - external tabs が決して active にならない (defensive)

合計 **204 tests passed** (旧 200 + 新 4), `tsc --noEmit` clean。

## なぜ GCP console 直リンクで、secrets-inventory UI 経由ではないか

issue 本文「ci-dashboard 側に GCP Secret Manager コンソールへのリンクを表示するタスクを含める (値取得の入口をダッシュボードから1クリックで)」を文字通り「1-click で GCP コンソールに着く」と解釈。

secrets-inventory UI (`/ui`、PR3+PR4 で実装) は別途 `https://<staging>/ui` でアクセスでき、そちらにも GCP console リンクが prominently 出ているので、ci-dashboard からの直リンクと inventory UI からのリンクは併存する形になる。

inventory UI 側のリンクも ci-dashboard に並べたい (= "🔐 Inventory" tab を別途追加したい) 場合は、別 PR で `secrets-inventory` の canonical URL が確定してから追加する想定。

## 動作確認 (本 PR merge + deploy 後)

- [ ] ci-dashboard のどのページ (/, /issues, /releases, /secret-gen) でも top nav に `🗝️ GCP Secrets` tab が出る
- [ ] tab クリックで新規 tab に GCP Secret Manager console (`cloudsql-sv` project) が開く
- [ ] 既存 tab (Dashboard / Issues / Releases / Secret Generator / Branch Protection) が壊れていない

---
_Generated by [Claude Code](https://claude.ai/code/session_017jzqiJUGFq45f55s9R1Ztb)_