### PR TITLE
feat(releases): tagless-repo close-detection via PR merge + TAGLESS_REPOS opt-in

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -332,8 +332,18 @@ export function handleDashboard(): Response {
         (b.detectedAt || "").localeCompare(a.detectedAt || "")
       );
       bannerList.innerHTML = sorted.map(a => {
-        const reviewUrl = "/releases?repo=" + encodeURIComponent(a.repo)
-          + "&tag=" + encodeURIComponent(a.tag);
+        // Tag alerts deep-link to /releases?repo=X&tag=Y which renders the
+        // per-tag confirmation table. PR alerts have no tag pair, so the deep-
+        // link would 404 (tag-not-found); fall back to the index page scoped
+        // to this repo so the synthetic block surfaces instead.
+        const reviewUrl = a.prNumber
+          ? "/releases?repo=" + encodeURIComponent(a.repo)
+          : "/releases?repo=" + encodeURIComponent(a.repo)
+              + "&tag=" + encodeURIComponent(a.tag);
+        const eventLabel = a.prNumber ? "merged" : "released";
+        const eventTag = a.prNumber
+          ? "PR #" + a.prNumber
+          : a.tag;
         const chips = (a.openIssues || []).slice(0, 8).map(i =>
           '<a class="issue-chip" href="' + escapeHtml(i.url)
             + '" target="_blank" rel="noopener" title="' + escapeHtml(i.title) + '">'
@@ -345,7 +355,7 @@ export function handleDashboard(): Response {
         const n = (a.openIssues || []).length;
         return '<div class="release-banner">'
           + '<span class="repo-tag">\\uD83C\\uDFF7\\uFE0F '
-          + escapeHtml(a.repo) + ' <code>' + escapeHtml(a.tag) + '</code> released</span>'
+          + escapeHtml(a.repo) + ' <code>' + escapeHtml(eventTag) + '</code> ' + eventLabel + '</span>'
           + chips + more
           + '<a class="review-link" href="' + reviewUrl + '">'
           + n + ' open related issue' + (n === 1 ? '' : 's') + ' \\u2192 review</a>'

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -5,6 +5,7 @@ import {
   type ReleaseAlert,
   recomputeAlert,
   computeReleaseAlert,
+  computeReleaseAlertForPr,
 } from "./release-alert";
 
 // WebSocket message envelope. All broadcasts now share `{ type, data }` so
@@ -18,12 +19,25 @@ type WsEnvelope =
 const ALERT_KEY_PREFIX = "release-alert:";
 const ALERT_TTL_SECONDS = 7 * 86400;
 
+function tagAlertKey(repo: string): string {
+  return `${ALERT_KEY_PREFIX}${repo}`;
+}
+
+function prAlertKey(repo: string, prNumber: number): string {
+  return `${ALERT_KEY_PREFIX}${repo}:pr-${prNumber}`;
+}
+
 export class CIDashboardHub extends DurableObject<Env> {
   // In-memory cache: run_id → CIStatus
   private cache = new Map<number, CIStatus>();
   private cacheLoaded = false;
 
-  // In-memory cache: "owner/name" → ReleaseAlert
+  // In-memory cache: KV key → ReleaseAlert. Keys take one of two shapes:
+  //   release-alert:<owner>/<name>            — traditional tag-driven alert
+  //   release-alert:<owner>/<name>:pr-<n>     — PR-merge alert for tagless repos
+  // Keying the map by the full KV key (instead of "owner/name") lets us hold
+  // multiple PR-based alerts per repo concurrently while still overwriting
+  // the tag alert in place when a fresh tag release fires.
   private alerts = new Map<string, ReleaseAlert>();
   private alertsLoaded = false;
 
@@ -55,11 +69,14 @@ export class CIDashboardHub extends DurableObject<Env> {
     const values = await Promise.all(
       list.keys.map((key) => this.env.CI_STATUS.get(key.name))
     );
-    for (const v of values) {
+    for (let i = 0; i < list.keys.length; i++) {
+      const v = values[i];
       if (!v) continue;
       try {
         const a = JSON.parse(v) as ReleaseAlert;
-        this.alerts.set(a.repo, a);
+        // Use the KV key directly so tag and PR alerts co-exist in the map
+        // without colliding on `repo`.
+        this.alerts.set(list.keys[i]!.name, a);
       } catch { /* skip corrupt entry */ }
     }
     this.alertsLoaded = true;
@@ -146,7 +163,7 @@ export class CIDashboardHub extends DurableObject<Env> {
         const alert = await computeReleaseAlert(
           this.env.GITHUB_TOKEN, repo, tag, this.env.CI_STATUS,
         );
-        this.persistAlert(repo, alert);
+        this.persistAlertAtKey(tagAlertKey(repo), alert);
         this.broadcastAlerts();
       } catch {
         // Best-effort: a failed compute (e.g. token rate-limit) leaves any
@@ -155,28 +172,64 @@ export class CIDashboardHub extends DurableObject<Env> {
       return new Response("OK");
     }
 
-    // Recompute alert for a repo whose state changed elsewhere (e.g. an
-    // operator just closed issues via /api/release-close{,-batch}). Drops
-    // the alert when no open issues remain.
+    // Tagless-repo variant: a PR was just merged into the default branch on a
+    // repo that doesn't cut release tags. Treat the PR as a mini-release —
+    // walk it for Refs and persist a PR-scoped alert. Each PR gets its own KV
+    // entry so multiple in-flight close-required PRs co-exist.
+    if (url.pathname === "/release-alert-detect-pr") {
+      const { repo, prNumber, mergeSha, defaultBranch } = await request.json<{
+        repo: string;
+        prNumber: number;
+        mergeSha: string | null;
+        defaultBranch: string;
+      }>();
+      await this.ensureAlerts();
+      try {
+        const alert = await computeReleaseAlertForPr(
+          this.env.GITHUB_TOKEN, repo, prNumber, mergeSha, defaultBranch, this.env.CI_STATUS,
+        );
+        this.persistAlertAtKey(prAlertKey(repo, prNumber), alert);
+        this.broadcastAlerts();
+      } catch {
+        // Same best-effort pattern as the tag path — failed compute keeps any
+        // existing PR alert in place.
+      }
+      return new Response("OK");
+    }
+
+    // Recompute alert(s) for a repo whose state changed elsewhere (e.g. an
+    // operator just closed issues via /api/release-close{,-batch}). For repos
+    // with multiple PR-scoped alerts we recompute each one and drop those that
+    // have no open issues left.
     if (url.pathname === "/release-alert-recompute") {
       const { repo } = await request.json<{ repo: string }>();
       await this.ensureAlerts();
-      const existing = this.alerts.get(repo);
-      if (!existing) {
-        // Nothing to recompute — but still broadcast an empty alerts list
-        // is unnecessary because nothing changed for the client.
-        return new Response("OK");
+
+      // Collect every (key, alert) pair for this repo before mutating so we
+      // can iterate without disturbing the live Map.
+      const matching = [...this.alerts.entries()].filter(([_, a]) => a.repo === repo);
+      if (matching.length === 0) return new Response("OK");
+
+      let changed = false;
+      for (const [kvKey, existing] of matching) {
+        try {
+          const fresh = existing.prNumber !== undefined
+            ? await computeReleaseAlertForPr(
+                this.env.GITHUB_TOKEN, repo, existing.prNumber,
+                /* mergeSha */ null,
+                /* defaultBranch */ existing.tag.split("@")[0] ?? "main",
+                this.env.CI_STATUS,
+              )
+            : await recomputeAlert(
+                this.env.GITHUB_TOKEN, repo, existing.tag, this.env.CI_STATUS,
+              );
+          this.persistAlertAtKey(kvKey, fresh);
+          changed = true;
+        } catch {
+          // Leave this particular alert in place; siblings still get a try.
+        }
       }
-      try {
-        const fresh = await recomputeAlert(
-          this.env.GITHUB_TOKEN, repo, existing.tag, this.env.CI_STATUS,
-        );
-        this.persistAlert(repo, fresh);
-        this.broadcastAlerts();
-      } catch {
-        // Leave the existing alert in place; the periodic dashboard poll
-        // will eventually pick up the right state.
-      }
+      if (changed) this.broadcastAlerts();
       return new Response("OK");
     }
 
@@ -326,18 +379,18 @@ export class CIDashboardHub extends DurableObject<Env> {
     );
   }
 
-  // Persist (or delete, when fresh is null) the alert. Same KV-fire-and-forget
-  // pattern as the run cache. Caller is responsible for calling broadcast
-  // afterward.
-  private persistAlert(repo: string, fresh: ReleaseAlert | null): void {
-    const key = `${ALERT_KEY_PREFIX}${repo}`;
+  // Persist (or delete, when fresh is null) the alert at a specific KV key.
+  // Map + KV stay in lockstep — the in-memory `alerts` Map is keyed by the same
+  // KV key so a future `ensureAlerts()` read sees consistent state. Same KV-
+  // fire-and-forget pattern as the run cache. Caller broadcasts afterward.
+  private persistAlertAtKey(kvKey: string, fresh: ReleaseAlert | null): void {
     if (fresh === null) {
-      this.alerts.delete(repo);
-      this.ctx.waitUntil(this.env.CI_STATUS.delete(key));
+      this.alerts.delete(kvKey);
+      this.ctx.waitUntil(this.env.CI_STATUS.delete(kvKey));
     } else {
-      this.alerts.set(repo, fresh);
+      this.alerts.set(kvKey, fresh);
       this.ctx.waitUntil(
-        this.env.CI_STATUS.put(key, JSON.stringify(fresh), {
+        this.env.CI_STATUS.put(kvKey, JSON.stringify(fresh), {
           expirationTtl: ALERT_TTL_SECONDS,
         }),
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,10 @@ export interface Env {
   WEBHOOK_SECRET: string;
   GITHUB_TOKEN: string;
   CI_HUB: DurableObjectNamespace;
+  // Comma-separated `owner/name` list of repos that don't cut tags. PR merges
+  // into the default branch are treated as releases for these. See
+  // wrangler.jsonc and src/tagless-repos.ts.
+  TAGLESS_REPOS?: string;
 }
 
 const app = new Hono<{ Bindings: Env }>();

--- a/src/release-alert.ts
+++ b/src/release-alert.ts
@@ -34,6 +34,7 @@ import {
   cachedCompare,
   cachedCommits,
   cachedPullRequest,
+  cachedPullRequestCommits,
   cachedIssue,
   type RawIssue,
 } from "./release-cache";
@@ -44,6 +45,10 @@ export interface ReleaseAlert {
   prevTag: string | null;
   openIssues: Array<{ number: number; title: string; url: string }>;
   detectedAt: string;    // ISO
+  // Set when this alert was created by a PR merge into the default branch
+  // (tagless repos). When absent the alert represents a traditional tag
+  // release. Banner UI keys off this to render "PR #N" vs "<tag>".
+  prNumber?: number;
 }
 
 export type { RawIssue };
@@ -170,4 +175,67 @@ export async function recomputeAlert(
   kv?: KVNamespace,
 ): Promise<ReleaseAlert | null> {
   return computeReleaseAlert(token, repo, tag, kv);
+}
+
+// PR-merge variant of computeReleaseAlert for tagless repos. A merged PR is
+// treated as a mini-release: walk the PR's commits + body + branch name for
+// `Refs #N`, hydrate the referenced issues, and return open ones.
+//
+// `mergeSha` is used only to produce a human-readable tag label
+// (`<defaultBranch>@<sha7>`). When absent the label falls back to
+// `<defaultBranch>@pr-<n>` — the alert is still functional; the only loss is a
+// less-clickable label.
+export async function computeReleaseAlertForPr(
+  token: string,
+  repo: string,
+  prNumber: number,
+  mergeSha: string | null,
+  defaultBranch: string,
+  kv?: KVNamespace,
+): Promise<ReleaseAlert | null> {
+  const { owner, repo: name } = parseRepo(repo);
+  validateOrg(owner);
+
+  const issueNumbers = new Set<number>();
+
+  // PR metadata: body has `Refs #N`, branch name has the issue prefix
+  // (CLAUDE.md convention <issue>-<type>-<desc>).
+  try {
+    const pr = await cachedPullRequest(token, kv, owner, name, prNumber);
+    const fromBranch = extractBranchIssue(pr.head.ref);
+    if (fromBranch !== null) issueNumbers.add(fromBranch);
+    if (pr.body) {
+      for (const ref of extractRefIssues(pr.body)) issueNumbers.add(ref);
+    }
+  } catch { /* PR fetch failure — still try commit walk */ }
+
+  // PR commits: each commit message can carry its own `Refs #N`. Squash merges
+  // collapse to one commit (often duplicating the PR body), but rebase / true-
+  // merge variants spread the refs across multiple commits.
+  try {
+    const commits = await cachedPullRequestCommits(token, kv, owner, name, prNumber);
+    for (const c of commits) {
+      for (const n of extractRefIssues(c.commit.message)) issueNumbers.add(n);
+    }
+  } catch { /* commits API failure — proceed with what we have */ }
+
+  if (issueNumbers.size === 0) return null;
+
+  const issues = await fetchIssuesByNumbers(token, owner, name, issueNumbers, kv);
+  const openIssues = issues
+    .filter((i) => !i.pull_request && i.state === "open")
+    .map((i) => ({ number: i.number, title: i.title, url: i.html_url }))
+    .sort((a, b) => a.number - b.number);
+
+  if (openIssues.length === 0) return null;
+
+  const sha7 = mergeSha?.slice(0, 7) ?? `pr-${prNumber}`;
+  return {
+    repo: `${owner}/${name}`,
+    tag: `${defaultBranch}@${sha7}`,
+    prevTag: null,
+    openIssues,
+    detectedAt: new Date().toISOString(),
+    prNumber,
+  };
 }

--- a/src/release-cache.ts
+++ b/src/release-cache.ts
@@ -143,6 +143,26 @@ export async function cachedPullRequest(
   );
 }
 
+// Tagless-repo PR-merge detection walks every commit in a merged PR to harvest
+// `Refs #N` from squash / rebase / merge variants. Same TTL as cachedPullRequest
+// — once the PR is merged the commit list is frozen.
+export async function cachedPullRequestCommits(
+  token: string,
+  kv: KVNamespace | undefined,
+  owner: string,
+  name: string,
+  n: number,
+): Promise<RawCommit[]> {
+  const key = `${PREFIX}prcommits:${owner}/${name}:${n}`;
+  return kvCached(kv, key, TTL_PR, () =>
+    githubApi<RawCommit[]>(
+      token, "GET", `/repos/${owner}/${name}/pulls/${n}/commits`,
+      undefined,
+      { per_page: "100" },
+    ),
+  );
+}
+
 export async function cachedIssue(
   token: string,
   kv: KVNamespace | undefined,

--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -17,6 +17,7 @@ import {
   cachedIssue,
 } from "./release-cache";
 import { loadDirectPushAllowlist } from "./direct-push-allowlist";
+import { parseTaglessRepos } from "./tagless-repos";
 import { renderTabs, TAB_STYLES } from "./nav-tabs";
 import { PWA_HEAD_TAGS, PWA_REGISTER_SCRIPT } from "./pwa";
 
@@ -40,6 +41,7 @@ export async function handleReleasesPage(
     GITHUB_TOKEN: string;
     CI_HUB: DurableObjectNamespace;
     CI_STATUS?: KVNamespace;
+    TAGLESS_REPOS?: string;
   },
 ): Promise<Response> {
   const url = new URL(req.url);
@@ -125,18 +127,23 @@ async function handleIndexPage(
     GITHUB_TOKEN: string;
     CI_HUB: DurableObjectNamespace;
     CI_STATUS?: KVNamespace;
+    TAGLESS_REPOS?: string;
   },
   closedFlash: number[],
   failedFlash: number[],
   flashRepo: string | null,
   hasFlash: boolean,
 ): Promise<Response> {
-  // 1. Watched repos come from two sources:
+  // 1. Watched repos come from three sources:
   //   (a) Hub status cache — every repo that has ever fired a CI run.
   //   (b) Direct-push-OK allowlist — repos that never auto-merge a PR and
   //       therefore won't show up in (a) until they happen to push a tag.
   //       Fetched from `yhonda-ohishi/claude-skills` (same SoT as
   //       `/wt-direct-push`); see direct-push-allowlist.ts.
+  //   (c) `TAGLESS_REPOS` wrangler var — opt-in list for repos that PR-merge
+  //       through CI but don't cut release tags. These get the same synthetic-
+  //       block treatment as (b), built from default-branch commits, so the
+  //       operator can see open Refs without ever tagging.
   const watched = new Set<string>();
   try {
     const hubId = env.CI_HUB.idFromName("singleton");
@@ -154,14 +161,19 @@ async function handleIndexPage(
     for (const r of allowlist) watched.add(r);
   } catch { /* graceful: allowlist stays empty, existing tag-flow unaffected */ }
 
+  const tagless = parseTaglessRepos(env.TAGLESS_REPOS);
+  for (const r of tagless) watched.add(r);
+
   const repos = [...watched].sort();
 
   // 2. Per-repo data load in parallel; whole-repo failures get a null view
-  //    we drop in the renderer. Allowlisted repos take the synthetic path
-  //    inside loadRepoView when they have no semver tags.
+  //    we drop in the renderer. Allowlisted or TAGLESS_REPOS-listed repos
+  //    take the synthetic path inside loadRepoView when they have no semver
+  //    tags.
   const views = await Promise.all(repos.map(async (repo) => {
     try {
-      return await loadRepoView(env.GITHUB_TOKEN, repo, allowlist.has(repo), env.CI_STATUS);
+      const useSynthetic = allowlist.has(repo) || tagless.has(repo);
+      return await loadRepoView(env.GITHUB_TOKEN, repo, useSynthetic, env.CI_STATUS);
     } catch {
       return null;
     }
@@ -182,7 +194,7 @@ async function handleIndexPage(
 async function loadRepoView(
   token: string,
   repo: string,
-  isDirectPush: boolean,
+  useSynthetic: boolean,
   kv?: KVNamespace,
 ): Promise<RepoView | null> {
   const { owner, repo: name } = parseRepo(repo);
@@ -194,12 +206,13 @@ async function loadRepoView(
   const sorted = sortSemverDesc(allTags.map((t) => t.name));
   const topTags = sorted.slice(0, TOP_TAGS_INLINE);
   if (topTags.length === 0) {
-    // Direct-push-OK repos that never tag still need a way to surface their
-    // open Refs. Fall back to a synthetic block built from the default
-    // branch's recent commits (#57). Non-allowlisted tag-less repos return
-    // empty as before so we don't accidentally treat an auto-merge repo as a
-    // direct-push one mid-release.
-    if (isDirectPush) {
+    // Tag-less repos opted into synthetic-block rendering (either via the
+    // direct-push allowlist or the TAGLESS_REPOS wrangler var) still need a
+    // way to surface their open Refs. Fall back to a synthetic block built
+    // from the default branch's recent commits (#57). Other tag-less repos
+    // return empty as before so we don't accidentally promote a regular
+    // auto-merge repo into the synthetic path mid-release.
+    if (useSynthetic) {
       const block = await loadSyntheticBlock(token, owner, name, kv);
       return {
         repo: `${owner}/${name}`,

--- a/src/tagless-repos.ts
+++ b/src/tagless-repos.ts
@@ -1,0 +1,17 @@
+// Tagless repos: repos that don't cut release tags, so PR merges into the
+// default branch act as the "release event" for dashboard banner + /releases
+// synthetic-block detection. Sourced from the `TAGLESS_REPOS` wrangler var
+// (comma-separated `owner/name`). See wrangler.jsonc.
+//
+// Kept tiny + pure so webhook + hub + releases-page can call it without taking
+// on a circular import on Env.
+
+export function parseTaglessRepos(raw: string | undefined): Set<string> {
+  if (!raw) return new Set();
+  return new Set(
+    raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0),
+  );
+}

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -1,4 +1,5 @@
 import type { Env } from "./index";
+import { parseTaglessRepos } from "./tagless-repos";
 
 interface WorkflowRunPayload {
   action: string;
@@ -32,6 +33,20 @@ interface WorkflowJobPayload {
   };
   repository: {
     full_name: string;
+  };
+}
+
+interface PullRequestPayload {
+  action: string;
+  pull_request: {
+    number: number;
+    merged: boolean;
+    merge_commit_sha: string | null;
+    base: { ref: string };
+  };
+  repository: {
+    full_name: string;
+    default_branch: string;
   };
 }
 
@@ -140,6 +155,33 @@ export async function handleWebhook(
       method: "POST",
       body: JSON.stringify({ job: payload.workflow_job }),
     }));
+    return new Response("OK", { status: 200 });
+  }
+
+  // Tagless-repo close-detection trigger. For repos that never cut a release
+  // tag (listed in env.TAGLESS_REPOS), a PR merge into the default branch is
+  // the closest analog to a release. We fire a `/release-alert-detect-pr` so
+  // the Hub can compute open-Refs and surface them on the dashboard banner.
+  // Skip silently for repos not on the list — the existing tag flow handles
+  // those.
+  if (event === "pull_request") {
+    const payload: PullRequestPayload = JSON.parse(body);
+    const repo = payload.repository.full_name;
+    const isMergeToDefault =
+      payload.action === "closed" &&
+      payload.pull_request.merged === true &&
+      payload.pull_request.base.ref === payload.repository.default_branch;
+    if (isMergeToDefault && parseTaglessRepos(env.TAGLESS_REPOS).has(repo)) {
+      await hub.fetch(new Request("http://hub/release-alert-detect-pr", {
+        method: "POST",
+        body: JSON.stringify({
+          repo,
+          prNumber: payload.pull_request.number,
+          mergeSha: payload.pull_request.merge_commit_sha,
+          defaultBranch: payload.repository.default_branch,
+        }),
+      }));
+    }
     return new Response("OK", { status: 200 });
   }
 

--- a/test/release-alert.test.ts
+++ b/test/release-alert.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { computeReleaseAlert, recomputeAlert } from "../src/release-alert";
+import {
+  computeReleaseAlert,
+  recomputeAlert,
+  computeReleaseAlertForPr,
+} from "../src/release-alert";
 
 // `computeReleaseAlert` fans out to several GitHub endpoints; we stub
 // globalThis.fetch and route by URL. Each test sets up a fixture map so the
@@ -10,6 +14,8 @@ interface Fixture {
   tags?: Array<{ name: string }>;
   compare?: Record<string, { commits: Array<{ commit: { message: string } }> }>;
   pulls?: Record<number, { head: { ref: string }; body: string | null }>;
+  // For PR-merge alert tests: /pulls/<n>/commits returns this array.
+  prCommits?: Record<number, Array<{ commit: { message: string } }>>;
   issues?: Record<number, {
     number: number;
     title: string;
@@ -35,6 +41,11 @@ function stubGithub(fx: Fixture) {
     if (cmp) {
       const key = `${cmp[1]}...${cmp[2]}`;
       return Response.json(fx.compare?.[key] ?? { commits: [] });
+    }
+    const prCommitsMatch = path.match(/\/pulls\/(\d+)\/commits$/);
+    if (prCommitsMatch) {
+      const n = Number(prCommitsMatch[1]);
+      return Response.json(fx.prCommits?.[n] ?? []);
     }
     const prMatch = path.match(/\/pulls\/(\d+)$/);
     if (prMatch) {
@@ -226,5 +237,98 @@ describe("recomputeAlert", () => {
     });
     const fresh = await recomputeAlert("token", "ippoan/foo", "v1.1.0");
     expect(fresh).toBeNull();
+  });
+});
+
+describe("computeReleaseAlertForPr", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("collects Refs from PR body, branch name, and commits", async () => {
+    stubGithub({
+      pulls: {
+        42: {
+          head: { ref: "10-fix-thing" },
+          body: "Resolves the bug.\n\nRefs #20\nRefs #21",
+        },
+      },
+      prCommits: {
+        42: [
+          { commit: { message: "fix: x\nRefs #30" } },
+          { commit: { message: "test: y" } },
+        ],
+      },
+      issues: {
+        10: openIssue(10, "branch issue"),
+        20: openIssue(20, "body ref one"),
+        21: closedIssue(21, "already closed"),
+        30: openIssue(30, "commit ref"),
+      },
+    });
+    const result = await computeReleaseAlertForPr(
+      "token", "ippoan/secrets-inventory-gcp", 42, "deadbeef12345", "main",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.repo).toBe("ippoan/secrets-inventory-gcp");
+    expect(result!.tag).toBe("main@deadbee");
+    expect(result!.prNumber).toBe(42);
+    expect(result!.prevTag).toBeNull();
+    // 10 (branch) + 20 (body) + 30 (commit). 21 closed → dropped.
+    expect(result!.openIssues.map((i) => i.number)).toEqual([10, 20, 30]);
+  });
+
+  it("returns null when the PR references no issues", async () => {
+    stubGithub({
+      pulls: { 1: { head: { ref: "feat-no-prefix" }, body: "no refs" } },
+      prCommits: { 1: [{ commit: { message: "feat: thing" } }] },
+    });
+    const result = await computeReleaseAlertForPr(
+      "token", "ippoan/foo", 1, "abc1234", "main",
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null when every referenced issue is closed", async () => {
+    stubGithub({
+      pulls: { 2: { head: { ref: "5-fix-x" }, body: null } },
+      prCommits: { 2: [{ commit: { message: "fix: x" } }] },
+      issues: { 5: closedIssue(5) },
+    });
+    const result = await computeReleaseAlertForPr(
+      "token", "ippoan/foo", 2, "abc1234", "main",
+    );
+    expect(result).toBeNull();
+  });
+
+  it("falls back to pr-<n> label when mergeSha is null", async () => {
+    stubGithub({
+      pulls: { 3: { head: { ref: "8-fix" }, body: null } },
+      prCommits: { 3: [] },
+      issues: { 8: openIssue(8) },
+    });
+    const result = await computeReleaseAlertForPr(
+      "token", "ippoan/foo", 3, null, "main",
+    );
+    expect(result?.tag).toBe("main@pr-3");
+  });
+
+  it("rejects disallowed orgs", async () => {
+    await expect(
+      computeReleaseAlertForPr("token", "evil-org/foo", 1, "abc", "main"),
+    ).rejects.toThrow(/Org not allowed/);
+  });
+
+  it("drops PR records that share issue numbers", async () => {
+    stubGithub({
+      pulls: { 4: { head: { ref: "feat-thing" }, body: "Refs #50\nRefs #51" } },
+      prCommits: { 4: [] },
+      issues: {
+        50: openIssue(50, "real issue"),
+        51: { ...openIssue(51, "actually a pr"), pull_request: { url: "x" } },
+      },
+    });
+    const result = await computeReleaseAlertForPr(
+      "token", "ippoan/foo", 4, "abc1234", "main",
+    );
+    expect(result?.openIssues.map((i) => i.number)).toEqual([50]);
   });
 });

--- a/test/tagless-repos.test.ts
+++ b/test/tagless-repos.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { parseTaglessRepos } from "../src/tagless-repos";
+
+describe("parseTaglessRepos", () => {
+  it("returns an empty set when input is undefined", () => {
+    expect(parseTaglessRepos(undefined).size).toBe(0);
+  });
+
+  it("returns an empty set for an empty / whitespace-only string", () => {
+    expect(parseTaglessRepos("").size).toBe(0);
+    expect(parseTaglessRepos("   ").size).toBe(0);
+    expect(parseTaglessRepos(",  ,").size).toBe(0);
+  });
+
+  it("parses comma-separated repos and trims whitespace", () => {
+    const set = parseTaglessRepos("ippoan/foo, ippoan/bar ,ohishi-exp/baz");
+    expect(set.has("ippoan/foo")).toBe(true);
+    expect(set.has("ippoan/bar")).toBe(true);
+    expect(set.has("ohishi-exp/baz")).toBe(true);
+    expect(set.size).toBe(3);
+  });
+
+  it("dedupes repeated repos", () => {
+    const set = parseTaglessRepos("ippoan/foo,ippoan/foo,ippoan/foo");
+    expect(set.size).toBe(1);
+  });
+});

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -492,6 +492,111 @@ describe("POST /webhook", () => {
     expect(hubCalls.filter((c) => c.path === "/release-alert-detect")).toHaveLength(0);
   });
 
+  // Tagless-repo PR-merge detection. When env.TAGLESS_REPOS includes the
+  // PR's repo and the PR was merged into the default branch, the webhook
+  // should fan out to /release-alert-detect-pr on the hub.
+  it("triggers release-alert-detect-pr when a tagless-repo PR merges into default branch", async () => {
+    const body = JSON.stringify({
+      action: "closed",
+      pull_request: {
+        number: 42,
+        merged: true,
+        merge_commit_sha: "abcdef1234567890",
+        base: { ref: "main" },
+      },
+      repository: { full_name: "ippoan/secrets-inventory-gcp", default_branch: "main" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    const taglessEnv: Env = {
+      ...testEnv(),
+      TAGLESS_REPOS: "ippoan/secrets-inventory-gcp,ippoan/ci-workflows",
+    };
+    await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST",
+        body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "pull_request" },
+      }),
+      taglessEnv,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    const calls = hubCalls.filter((c) => c.path === "/release-alert-detect-pr");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.body).toEqual({
+      repo: "ippoan/secrets-inventory-gcp",
+      prNumber: 42,
+      mergeSha: "abcdef1234567890",
+      defaultBranch: "main",
+    });
+  });
+
+  it("does NOT trigger release-alert-detect-pr when repo is not in TAGLESS_REPOS", async () => {
+    const body = JSON.stringify({
+      action: "closed",
+      pull_request: {
+        number: 7, merged: true, merge_commit_sha: "deadbeef", base: { ref: "main" },
+      },
+      repository: { full_name: "ippoan/auth-worker", default_branch: "main" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    const taglessEnv: Env = {
+      ...testEnv(),
+      TAGLESS_REPOS: "ippoan/secrets-inventory-gcp",
+    };
+    await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST", body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "pull_request" },
+      }),
+      taglessEnv, ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(hubCalls.filter((c) => c.path === "/release-alert-detect-pr")).toHaveLength(0);
+  });
+
+  it("does NOT trigger release-alert-detect-pr for closed-but-not-merged PRs", async () => {
+    const body = JSON.stringify({
+      action: "closed",
+      pull_request: { number: 8, merged: false, merge_commit_sha: null, base: { ref: "main" } },
+      repository: { full_name: "ippoan/secrets-inventory-gcp", default_branch: "main" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    const taglessEnv: Env = { ...testEnv(), TAGLESS_REPOS: "ippoan/secrets-inventory-gcp" };
+    await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST", body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "pull_request" },
+      }),
+      taglessEnv, ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(hubCalls.filter((c) => c.path === "/release-alert-detect-pr")).toHaveLength(0);
+  });
+
+  it("does NOT trigger release-alert-detect-pr for PRs merged into non-default branches", async () => {
+    const body = JSON.stringify({
+      action: "closed",
+      pull_request: { number: 9, merged: true, merge_commit_sha: "abc", base: { ref: "develop" } },
+      repository: { full_name: "ippoan/secrets-inventory-gcp", default_branch: "main" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    const taglessEnv: Env = { ...testEnv(), TAGLESS_REPOS: "ippoan/secrets-inventory-gcp" };
+    await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST", body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "pull_request" },
+      }),
+      taglessEnv, ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(hubCalls.filter((c) => c.path === "/release-alert-detect-pr")).toHaveLength(0);
+  });
+
   // Regression guard for issue #51: Tag Release directly must NOT fire — the
   // Hub it would reach is still on the previous version's deploy.
   it("does NOT trigger release-alert-detect on a Tag Release workflow completion", async () => {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,6 +7,14 @@
   "observability": {
     "enabled": true
   },
+  "vars": {
+    // Comma-separated `owner/name` repos that do NOT cut release tags. For these
+    // repos the dashboard treats each PR merge into the default branch as a
+    // mini-release: it scans the merged PR for `Refs #N` and surfaces any still-
+    // open issues on the dashboard banner + /releases synthetic blocks. Repos
+    // not listed here keep the original tag-driven flow.
+    "TAGLESS_REPOS": ""
+  },
   "kv_namespaces": [
     {
       "binding": "CI_STATUS",


### PR DESCRIPTION
## Summary

Adds a per-repo opt-in path for repos that don't cut release tags. Listed in the new `TAGLESS_REPOS` wrangler var (comma-separated `owner/name`), these repos treat each PR merge into the default branch as a mini-release for close-detection purposes — solving the "tag を打たないと releases に出ない" issue for repos like `ippoan/secrets-inventory-gcp` and `ippoan/ci-workflows`.

## What changes

- **webhook** (`src/webhook.ts`): handle `pull_request` events with `merged === true && base.ref === default_branch` for repos on the `TAGLESS_REPOS` list → fire `/release-alert-detect-pr` on the Hub
- **release-alert** (`src/release-alert.ts`): new `computeReleaseAlertForPr` walks PR body, branch name (CLAUDE.md `<issue>-<type>-<desc>` convention), and PR commits for `Refs #N`; returns open referenced issues
- **release-cache** (`src/release-cache.ts`): `cachedPullRequestCommits` for the PR-merge alert path (24h TTL — PR commit list is frozen post-merge)
- **hub** (`src/hub.ts`): PR-scoped alerts stored under `release-alert:<repo>:pr-<n>` so multiple in-flight close-required PRs coexist; tag alerts keep `release-alert:<repo>`. Map keyed by full KV key. Recompute path iterates all matching alerts for the repo.
- **`/releases` page** (`src/releases-page.ts`): TAGLESS_REPOS unioned into the watched set; synthetic-block gating extended from "direct-push allowlist only" to "allowlist OR tagless"
- **dashboard banner** (`src/dashboard.ts`): PR alerts render `PR #N merged` and link to `/releases?repo=X` (the tag-keyed deep-link 404s for PR-based alerts)

## Configuration

To opt a repo in, set `TAGLESS_REPOS` in `wrangler.jsonc`:

```jsonc
"vars": {
  "TAGLESS_REPOS": "ippoan/secrets-inventory-gcp,ippoan/ci-workflows"
}
```

GitHub webhook on each listed repo also needs `pull_request` event enabled (currently only `workflow_run` + `workflow_job` are subscribed).

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 218 tests pass locally (10 new tests added)
- [ ] CI green
- [ ] After deploy: set `TAGLESS_REPOS` to a test repo, enable `pull_request` webhook event, merge a PR with `Refs #N` to default branch, verify banner appears
- [ ] Verify `/releases` shows synthetic block for the tagless repo

---
_Generated by [Claude Code](https://claude.ai/code/session_018WB3xu39LSQE8pymqE53e5)_