### PR TITLE
fix(releases): hide already-closed rows from detail-page form

### DIFF
--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -472,13 +472,43 @@ function renderHtml(
   closedFlash: number[],
   failedFlash: number[],
 ): string {
-  // The flash filter strips just-closed rows from the candidate set so a
-  // close-then-redirect lands on a page that no longer offers them. We then
-  // gate the form by the *remaining* candidates rather than the unfiltered
-  // payload — otherwise the operator sees a header-only table with a button
-  // that round-trips empty (#61, sibling of the index-side fix in #59).
-  const candidates = data.rows.filter((r) => !closedFlash.includes(r.number));
+  // Two filters drop rows from the form's candidate set:
+  //   1. flash: just-closed rows from a close-then-redirect must not be offered
+  //      again on the landing page (#61).
+  //   2. state === "closed": issues that GitHub already reports as closed have
+  //      nothing left to act on — the operator (or auto-close from `Closes #N`
+  //      in some other PR) already handled them. Mirrors the index page's
+  //      visible/hidden split in `renderTagBlock` so the detail and index views
+  //      behave consistently. Pre-fix the row stayed in the form with the ⚠
+  //      "already closed" warning and an un-ticked checkbox, which read as
+  //      "still pending" to the operator (#90).
+  const candidates = data.rows.filter(
+    (r) => !closedFlash.includes(r.number) && r.state !== "closed",
+  );
   const candidateRows = candidates.map((r) => renderRow(r)).join("\n");
+
+  // Already-closed rows still live in the page as audit context (collapsed
+  // <details>) so the operator can confirm which referenced issues this tag
+  // actually resolved. flash-closed go in here too — the form has already
+  // dropped them and the celebratory `empty` banner above shows the success;
+  // the details strip just lists what got closed for reference.
+  const closedRows = data.rows.filter(
+    (r) => r.state === "closed" || closedFlash.includes(r.number),
+  );
+  const closedDetails = closedRows.length === 0 ? "" : `
+    <details class="closed-details">
+      <summary>${closedRows.length} closed issue${closedRows.length === 1 ? "" : "s"} (already resolved)</summary>
+      <table>
+        <thead><tr>
+          <th>#</th>
+          <th>Title</th>
+          <th>State</th>
+          <th>Labels</th>
+          <th>Assignees</th>
+        </tr></thead>
+        <tbody>${closedRows.map((r) => renderClosedRow(r)).join("\n")}</tbody>
+      </table>
+    </details>`;
 
   const flash = renderFlash(closedFlash, failedFlash, data.repo);
 
@@ -490,8 +520,9 @@ function renderHtml(
 
   // Two distinct "nothing to do" states share the same hint slot:
   //   - data.rows.length === 0 → tag had no Refs at all
-  //   - data.rows.length > 0 but candidates.length === 0 → everything just got
-  //     closed in this round-trip; show the celebratory variant instead.
+  //   - data.rows.length > 0 but candidates.length === 0 → everything is
+  //     already closed (either before this page load, or just-closed via the
+  //     redirect); show the celebratory variant.
   const empty = data.rows.length === 0
     ? `<div class="empty">🎉 No referenced issues for this release.</div>`
     : candidates.length === 0
@@ -536,9 +567,32 @@ function renderHtml(
   ${flash}
   ${empty}
   ${formInner}
+  ${closedDetails}
   ${PWA_REGISTER_SCRIPT}
 </body>
 </html>`;
+}
+
+// Render an already-closed row for the audit <details> strip. No checkbox
+// (nothing to act on), no warning icon (the "already closed" warn is implied
+// by the section header). Same column layout as renderRow minus col-check.
+function renderClosedRow(r: IssueRow): string {
+  const labelChips = r.labels.length > 0
+    ? `<div class="labels">${r.labels
+        .map((l) => `<span class="label">${escapeHtml(l)}</span>`).join("")}</div>`
+    : "";
+  const assignees = r.assignees.length > 0
+    ? r.assignees.map((a) => `@${escapeHtml(a)}`).join(", ")
+    : "—";
+  const stateChip =
+    `<span class="state state-${escapeHtml(r.state)}">${escapeHtml(r.state)}</span>`;
+  return `<tr>
+    <td class="num"><a href="${escapeHtml(r.url)}" target="_blank" rel="noopener">#${r.number}</a></td>
+    <td class="title"><a href="${escapeHtml(r.url)}" target="_blank" rel="noopener">${escapeHtml(r.title)}</a></td>
+    <td>${stateChip}</td>
+    <td>${labelChips || "—"}</td>
+    <td class="assignees">${assignees}</td>
+  </tr>`;
 }
 
 function renderRow(r: IssueRow): string {

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -365,7 +365,7 @@ describe("GET /releases", () => {
     expect(html).toContain('action="/api/release-close"');
   });
 
-  it("closed rows are NOT checked by default; open rows (including bug-labeled) ARE", async () => {
+  it("already-closed rows move to the audit <details>; open rows stay in the form and are checked by default", async () => {
     stubGithubApi();
     const req = new Request("http://localhost/releases?repo=ippoan/ci-dashboard&tag=v1.2.0");
     const ctx = createExecutionContext();
@@ -373,18 +373,20 @@ describe("GET /releases", () => {
     await waitOnExecutionContext(ctx);
     const html = await res.text();
 
-    // #42 has no warnings → checkbox starts checked.
+    // #42 (open, no warnings) → in form, checked.
     expect(html).toMatch(/name="issue" value="42" checked/);
-    // #50 is closed → still unchecked.
-    expect(html).toMatch(/name="issue" value="50"(?! checked)/);
-    // #99 has the `bug` label but is open. Per #77 the label no longer
-    // triggers a warning, so the checkbox starts checked.
+    // #99 (open, "bug" label — no longer warned per #77) → in form, checked.
     expect(html).toMatch(/name="issue" value="99" checked/);
+    // #50 is closed → NOT in the form at all (no checkbox / no `name="issue"`
+    // value="50") so the operator can't accidentally re-close it.
+    expect(html).not.toMatch(/name="issue" value="50"/);
 
-    // Warning icon + tooltip remain for the closed row only.
-    expect(html).toContain("⚠️");
-    expect(html).toContain("already closed");
-    expect(html).not.toContain("bug label");
+    // #50 still appears in the audit strip so the operator can confirm what
+    // got resolved by this tag.
+    expect(html).toContain("closed-details");
+    expect(html).toMatch(/1 closed issue \(already resolved\)/);
+    expect(html).toContain("#50");
+    expect(html).toContain("already done");
   });
 
   it("returns 404 when the tag is not in the recent list", async () => {


### PR DESCRIPTION
## Summary

`/releases?repo=X&tag=Y` 詳細ページから既に closed の issue 行を form table から取り除き、`<details class="closed-details">` 監査ストリップに移動。index ページの `renderTagBlock` と挙動を揃える。

## 問題

screenshot で報告された通り、ippoan/ci-dashboard tag v0.0.63 を開くと #64 (closed) が ⚠ 警告付き + チェックボックス未選択の状態でずっと表示され、operator には「まだ未対応」に見えていた。

```
| ☐ | #64 | ⚠ Reduce Worker requests... | closed | — | — |
```

「Rows with ⚠ are unchecked by default. Untick to skip.」のヒントは「既に closed なので何もする必要がない」状況に対しては誤誘導。

## 修正

`renderHtml` の candidates filter に `r.state !== "closed"` を追加。closed 行は `renderClosedRow` で別 table に出し、`<details>` で折りたたみ。すべて closed なら既存の "All referenced issues for this release are closed." バナーが出る。

Index ページの `renderTagBlock` は元から同じ split を持っており、detail ↔ index で挙動が一致する。

## Cache layers (参考)

本修正は render 段階のフィルタなので cache とは独立:

- Browser HTTP: `max-age=30, swr=120` (detail page)
- Worker KV `rcache:v1:issue:...`: 60s (GitHub issue state)
- Hub KV `release-alert:<repo>`: 7d (banner snapshot) ← 別 fix で対応予定

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 218 tests pass (1 test rewritten: "closed rows are NOT checked by default" → "already-closed rows move to the audit <details>")
- [ ] CI green
- [ ] Deploy 後: `/releases?repo=ippoan/ci-dashboard&tag=v0.0.63` で #64 が form から消え、`<details>` 内に表示されることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_018WB3xu39LSQE8pymqE53e5)_