### PR TITLE
fix(banner): lazy-refresh release-alert openIssues on /snapshot read

### DIFF
--- a/src/hub.ts
+++ b/src/hub.ts
@@ -7,6 +7,8 @@ import {
   computeReleaseAlert,
   computeReleaseAlertForPr,
 } from "./release-alert";
+import { parseRepo } from "./github-api";
+import { cachedIssue } from "./release-cache";
 
 // WebSocket message envelope. All broadcasts now share `{ type, data }` so
 // the dashboard JS can dispatch by type. Two channels currently:
@@ -137,17 +139,27 @@ export class CIDashboardHub extends DurableObject<Env> {
     }
 
     // All release alerts from in-memory cache (for /release-alerts endpoint).
+    // Lazy-refresh path: drop openIssues that GitHub now reports as closed
+    // before returning. The KV alert entry has a 7d TTL and is only mutated
+    // on /release-alert-detect{,-pr} / /release-alert-recompute, so an issue
+    // closed outside the dashboard's UI (manually on GitHub, or via a `Closes
+    // #N` from another repo's PR) would otherwise haunt the banner for days.
+    // See #90 follow-up.
     if (url.pathname === "/release-alerts") {
       await this.ensureAlerts();
+      await this.refreshStaleAlerts();
       return Response.json([...this.alerts.values()]);
     }
 
     // Unified snapshot: { statuses, alerts } in one DO call. Dashboard UI
     // uses this on WS connect / reconnect instead of polling /status +
     // /release-alerts every 30s. Refs #64 (90% Worker request reduction).
+    // Same lazy-refresh as /release-alerts above — this is the actual read
+    // path the dashboard JS hits on every page load.
     if (url.pathname === "/snapshot") {
       await this.ensureCache();
       await this.ensureAlerts();
+      await this.refreshStaleAlerts();
       return Response.json({
         statuses: this.computeStatuses(),
         alerts: [...this.alerts.values()],
@@ -395,6 +407,54 @@ export class CIDashboardHub extends DurableObject<Env> {
         }),
       );
     }
+  }
+
+  // For each in-memory alert, re-verify its openIssues against current GitHub
+  // state (via `cachedIssue` 60 s KV TTL). Drop issues now reported closed; if
+  // the alert ends up with no openIssues, delete the alert entirely so the
+  // banner disappears.
+  //
+  // The KV cache layer keeps the cost bounded: the first /snapshot after an
+  // issue close pays N GitHub `/issues/N` fetches, subsequent /snapshot calls
+  // within 60 s hit KV. No GitHub fetches when alerts.size === 0.
+  //
+  // Best-effort: any per-issue fetch error leaves that issue in place (we'd
+  // rather show a banner stale by 60 s than fail the whole /snapshot path on
+  // a transient GitHub 5xx).
+  private async refreshStaleAlerts(): Promise<void> {
+    if (this.alerts.size === 0) return;
+    const entries = [...this.alerts.entries()];
+    let anyChanged = false;
+    await Promise.all(entries.map(async ([kvKey, alert]) => {
+      let owner: string;
+      let name: string;
+      try {
+        ({ owner, repo: name } = parseRepo(alert.repo));
+      } catch {
+        return;
+      }
+      const statuses = await Promise.all(alert.openIssues.map(async (i) => {
+        try {
+          const fresh = await cachedIssue(this.env.GITHUB_TOKEN, this.env.CI_STATUS, owner, name, i.number);
+          return { issue: i, state: fresh.state };
+        } catch {
+          // Keep the issue on transient failure (treat as "still open" so the
+          // banner doesn't quietly disappear because of GitHub rate limits).
+          return { issue: i, state: "open" };
+        }
+      }));
+      const stillOpen = statuses
+        .filter((s) => s.state !== "closed")
+        .map((s) => s.issue);
+      if (stillOpen.length === alert.openIssues.length) return;
+      anyChanged = true;
+      if (stillOpen.length === 0) {
+        this.persistAlertAtKey(kvKey, null);
+      } else {
+        this.persistAlertAtKey(kvKey, { ...alert, openIssues: stillOpen });
+      }
+    }));
+    if (anyChanged) this.broadcastAlerts();
   }
 
   private broadcastFromCache(): void {


### PR DESCRIPTION
## Summary

Dashboard banner kept showing closed issues for up to 7 days. Fix: on every `/snapshot` and `/release-alerts` read, re-verify each alert's `openIssues` against current GitHub state and drop now-closed issues (delete the whole alert if it ends up empty).

## 再現

User's "navigate from /releases to / and the banner re-appears" report:

1. Issue #64 closed on GitHub
2. Hub KV `release-alert:ippoan/ci-dashboard` still has `openIssues: [#64]` (7d TTL, no recompute trigger because the close happened outside the UI)
3. User reloads `/` → /snapshot serves stale alert → banner shows #64
4. User goes to /releases → /releases re-fetches issue → cached `cachedIssue` (60s) goes stale → /releases sees closed and (post-#90) hides it
5. User goes back to `/` → /snapshot still serves stale Hub alert → banner re-appears

After this fix: step 5's /snapshot re-checks each `openIssue` via `cachedIssue`, sees #64 closed, drops it, deletes the empty alert. Banner gone for good.

## Cost analysis

- `cachedIssue` has 60s KV TTL. First /snapshot after an issue close pays N GitHub `/issues/N` fetches (N = total open issues across all alerts). Subsequent /snapshot calls within 60s hit KV.
- When `alerts.size === 0`, **zero** GitHub fetches.
- For typical operation (a few open Refs at any time), the per-load cost is single-digit GitHub calls, well within rate limits.

Best-effort: per-issue fetch error keeps the issue in place (treat transient 5xx as "still open" — better to be 60s stale than to silently hide the banner on a flake).

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 218 tests pass (existing tests mock CI_HUB so the new code is only run in production; manual verification on deploy)
- [ ] CI green
- [ ] Deploy → close an issue on GitHub manually → refresh dashboard → banner drops within 60s
- [ ] Navigate /releases → / repeatedly → no resurrection

---
_Generated by [Claude Code](https://claude.ai/code/session_018WB3xu39LSQE8pymqE53e5)_