### PR TITLE
fix(dashboard): refetch /snapshot on visibilitychange so banner converges after tab return

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -493,9 +493,10 @@ export function handleDashboard(): Response {
       }).join("");
     }
 
-    // Pull the unified snapshot once. Used on initial WS connect and on
-    // explicit Reconnect button. WS broadcasts then keep the page in sync
-    // (= no periodic polling, no visibilitychange refresh). Refs #64.
+    // Pull the unified snapshot. Used on initial WS connect, on explicit
+    // Reconnect button, and on tab visibility return (Refs #92). NOT used as
+    // periodic polling — between snapshots we rely entirely on WS broadcasts
+    // (= Refs #64's worker-request reduction is preserved).
     async function loadSnapshot() {
       if (document.hidden) return;
       try {
@@ -568,6 +569,21 @@ export function handleDashboard(): Response {
     // schedules an auto-reconnect after 3s, which then calls loadSnapshot().
     document.getElementById("reconnect-btn").addEventListener("click", () => {
       if (ws) ws.close();
+    });
+
+    // Tab-return path (#92): WS stays connected while the user is on a
+    // different tab / different page in the same tab (e.g. /releases). With
+    // no server-side push for "an issue you referenced is now closed", the
+    // banner DOM stays frozen on whatever the last WS broadcast was. When
+    // the user returns, re-fetch the snapshot once — /snapshot triggers the
+    // Hub's refreshStaleAlerts (#91) which drops now-closed issues, so the
+    // banner converges within a single round-trip.
+    //
+    // NOT a setInterval — there is no polling here. The cost per
+    // tab-return is exactly one /snapshot, far cheaper than the 30 s polling
+    // removed in #64.
+    document.addEventListener("visibilitychange", () => {
+      if (!document.hidden) loadSnapshot();
     });
 
     async function deployTag(btn) {

--- a/test/status.test.ts
+++ b/test/status.test.ts
@@ -142,6 +142,11 @@ describe("GET /", () => {
     // Snapshot-based loading (WS-driven, no polling). Refs #64.
     expect(html).toContain("loadSnapshot");
     expect(html).toContain("reconnect-btn");
+    // Tab-return refetch hook (Refs #92): visibilitychange listener that
+    // calls loadSnapshot when the tab becomes visible. Not a setInterval —
+    // just a one-shot per tab return.
+    expect(html).toContain("visibilitychange");
+    expect(html).not.toContain("setInterval(loadSnapshot");
   });
 });
 


### PR DESCRIPTION
## Summary

Refs #92

`/releases` から dashboard (`/`) に戻った時 banner に古いデータ (`v0.0.63 released #64`) が残る件の修正。WebSocket は接続したままで `/snapshot` を再 fetch するパスが無かったため。

## 修正

`dashboard.ts` の WS connect 確立後に `visibilitychange` リスナーを追加。タブが非表示 → 表示になった時 (= 別 page から戻った時) に `loadSnapshot()` を 1 回呼ぶ。

`/snapshot` 内には #91 で `refreshStaleAlerts()` を仕込んだので、再 fetch すれば banner が自動的に最新状態に converge する。

## #88 polling 廃止との整合性

`setInterval` 周期 polling は復活させない。**タブ復帰時の 1 回だけ** の fetch であり、タブ active のまま放置すれば WS broadcast のみで更新される (= #64 の Worker request 削減効果は維持)。

`loadSnapshot()` 内には既に `if (document.hidden) return;` ガードがあるため、隠れ状態で event が誤発火しても no-op。

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 218 tests pass (status.test.ts に `visibilitychange` リスナー存在 + `setInterval(loadSnapshot` が無いことの assertion を追加)
- [ ] CI green → deploy → /releases から戻った時 banner が即更新されることを確認
- [ ] DevTools Network でタブ active 中に追加 fetch が走らないことを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_018WB3xu39LSQE8pymqE53e5)_