### PR TITLE
fix(hub): refreshStaleAlerts must bypass Cloudflare Worker fetch cache

### DIFF
--- a/src/hub.ts
+++ b/src/hub.ts
@@ -8,7 +8,7 @@ import {
   computeReleaseAlertForPr,
 } from "./release-alert";
 import { parseRepo } from "./github-api";
-import { cachedIssue } from "./release-cache";
+import { invalidateIssue } from "./release-cache";
 
 // WebSocket message envelope. All broadcasts now share `{ type, data }` so
 // the dashboard JS can dispatch by type. Two channels currently:
@@ -410,21 +410,36 @@ export class CIDashboardHub extends DurableObject<Env> {
   }
 
   // For each in-memory alert, re-verify its openIssues against current GitHub
-  // state (via `cachedIssue` 60 s KV TTL). Drop issues now reported closed; if
-  // the alert ends up with no openIssues, delete the alert entirely so the
-  // banner disappears.
+  // state. Drop issues now reported closed; if the alert ends up with no
+  // openIssues, delete the alert entirely so the banner disappears.
   //
-  // The KV cache layer keeps the cost bounded: the first /snapshot after an
-  // issue close pays N GitHub `/issues/N` fetches, subsequent /snapshot calls
-  // within 60 s hit KV. No GitHub fetches when alerts.size === 0.
+  // We deliberately bypass `cachedIssue` (60 s KV TTL) AND Cloudflare's
+  // outbound fetch cache (`cache: "no-store"`). The reason: an issue
+  // referenced by an alert is, by definition, one we already think is open.
+  // The whole point of refreshing here is to detect the open→closed flip.
+  // Reading any cached state runs the risk of returning the stale "open"
+  // value that originally triggered the alert — defeating the refresh.
   //
-  // Best-effort: any per-issue fetch error leaves that issue in place (we'd
-  // rather show a banner stale by 60 s than fail the whole /snapshot path on
-  // a transient GitHub 5xx).
+  // Side effect: invalidate the cachedIssue KV entry after a state change so
+  // /releases (which uses cachedIssue) reflects the fresh state on its next
+  // load instead of waiting out the 60 s TTL.
+  //
+  // Cost: N raw GitHub `/issues/N` fetches per /snapshot call where N is the
+  // total openIssues count across all alerts. Typical N is 1-5. /snapshot is
+  // called on dashboard load + visibilitychange (Refs #92) — no periodic
+  // polling. No GitHub fetches when `alerts.size === 0`.
+  //
+  // Best-effort: any per-issue fetch error keeps that issue in place
+  // (transient GitHub 5xx shouldn't silently hide an alert that may still be
+  // legitimate).
+  //
+  // Refs #94 (the previous cachedIssue-based version saw stale "open" data
+  // and never dropped a known-closed issue).
   private async refreshStaleAlerts(): Promise<void> {
     if (this.alerts.size === 0) return;
     const entries = [...this.alerts.entries()];
     let anyChanged = false;
+    const invalidations: Array<Promise<void>> = [];
     await Promise.all(entries.map(async ([kvKey, alert]) => {
       let owner: string;
       let name: string;
@@ -435,8 +450,8 @@ export class CIDashboardHub extends DurableObject<Env> {
       }
       const statuses = await Promise.all(alert.openIssues.map(async (i) => {
         try {
-          const fresh = await cachedIssue(this.env.GITHUB_TOKEN, this.env.CI_STATUS, owner, name, i.number);
-          return { issue: i, state: fresh.state };
+          const state = await this.fetchLiveIssueState(owner, name, i.number);
+          return { issue: i, state };
         } catch {
           // Keep the issue on transient failure (treat as "still open" so the
           // banner doesn't quietly disappear because of GitHub rate limits).
@@ -448,13 +463,55 @@ export class CIDashboardHub extends DurableObject<Env> {
         .map((s) => s.issue);
       if (stillOpen.length === alert.openIssues.length) return;
       anyChanged = true;
+      // Wipe the cachedIssue entry for each now-closed issue so /releases
+      // also picks up the fresh "closed" on its next render rather than
+      // serving the same stale "open" we just routed around.
+      for (const s of statuses) {
+        if (s.state === "closed") {
+          invalidations.push(invalidateIssue(this.env.CI_STATUS, owner, name, s.issue.number));
+        }
+      }
       if (stillOpen.length === 0) {
         this.persistAlertAtKey(kvKey, null);
       } else {
         this.persistAlertAtKey(kvKey, { ...alert, openIssues: stillOpen });
       }
     }));
+    if (invalidations.length > 0) this.ctx.waitUntil(Promise.all(invalidations).then(() => undefined));
     if (anyChanged) this.broadcastAlerts();
+  }
+
+  // Direct GitHub fetch that bypasses every cache layer:
+  //   - KV `cachedIssue` (60 s TTL): we don't call it
+  //   - Cloudflare Worker outbound fetch cache: `cache: "no-store"` is the
+  //     officially-supported escape hatch
+  //     (https://developers.cloudflare.com/workers/runtime-apis/fetch/).
+  //     The Worker types lib doesn't expose `cache` on RequestInit, so we
+  //     widen via a cast — the runtime does honor it.
+  //
+  // Only used by refreshStaleAlerts; for any page-render path stick with
+  // `cachedIssue` which is fine.
+  //
+  // Refs #94: without `cache: "no-store"`, the Worker's implicit fetch
+  // cache held a stale `state: "open"` response for #64 across hours of
+  // /snapshot calls — refreshStaleAlerts never saw the close.
+  private async fetchLiveIssueState(owner: string, name: string, n: number): Promise<string> {
+    const init: RequestInit & { cache?: string } = {
+      method: "GET",
+      cache: "no-store",
+      headers: {
+        Authorization: `Bearer ${this.env.GITHUB_TOKEN}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": "ci-dashboard-mcp",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    };
+    const res = await fetch(`https://api.github.com/repos/${owner}/${name}/issues/${n}`, init as RequestInit);
+    if (!res.ok) {
+      throw new Error(`GitHub /issues/${n} returned ${res.status}`);
+    }
+    const body = await res.json() as { state?: string };
+    return body.state ?? "open";
   }
 
   private broadcastFromCache(): void {


### PR DESCRIPTION
Refs #94

## Summary

`#91` で `/snapshot` に `refreshStaleAlerts()` を仕込んだが本番では closed 済 issue が消えなかった。原因は **Cloudflare Worker の implicit outbound fetch cache** (Durable Object 内の `fetch()` も対象)。

## Web search 由来の根拠

> "When a Worker calls fetch(), the request passes through Cloudflare's cache and Tiered Cache (if enabled). fetch() will always write back to cache after a miss, meaning responses are implicitly cached by default."
> 
> "Workers only support the no-store and no-cache mode for controlling the cache. When no-store is supplied the cache is bypassed on the way to the origin and the request is not cacheable."
> 
> — [Cloudflare Workers Fetch docs](https://developers.cloudflare.com/workers/runtime-apis/fetch/)

GitHub API は `cache-control: private, max-age=60` を返すため、Worker 内 `fetch()` は閉じる前の "open" レスポンスを CDN cache に保持し続け、KV TTL が切れて kvCached が再 fetch しても **Cloudflare 経由で同じ "open" が返り続けた**。

## 実環境での再現

ブラウザ console 検証 (本セッションで取得):

```
fetch("/snapshot") → openIssues に #64 残存 (detectedAt = v0.0.63 リリース時のオリジナル時刻)
fetch("https://api.github.com/repos/ippoan/ci-dashboard/issues/64") → state: "closed"
```

つまり GitHub は closed と返してるのに、worker 内 fetch だと cache 経由で "open" が返り続けていた。

## 修正

`Hub.refreshStaleAlerts` 内で:

1. `cachedIssue` を経由せず `fetchLiveIssueState()` 新メソッドで GitHub API 直叩き
2. fetch options に `cache: "no-store"` を付与 (Worker の implicit cache を bypass する公式 escape hatch)
3. closed 検出時に既存の `cachedIssue` KV entry も `invalidateIssue` で wipe → /releases ページも次回 render で fresh state を見る

`@cloudflare/workers-types` の `RequestInit` が `cache` field を expose していないので type cast で widen。Runtime は honor する。

## コスト

- `/snapshot` 1 回 = N GitHub fetch (N = 全 alert の openIssues 合計、典型 1-5)
- `/snapshot` はダッシュボード load + visibilitychange (#92) のみ。polling 無し
- alerts.size === 0 → 0 fetch

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 218 tests pass (既存テストは `fetch` を stub していて新コード経路に届かないため新規 test は無し)
- [ ] CI green → tag release → deploy
- [ ] deploy 後 `https://ci-dashboard.ippoan.org/` で banner (v0.0.63 #64) が消えることを確認
- [ ] ブラウザ console で `fetch("/snapshot").then(r=>r.json()).then(d=>console.log(d.alerts))` が `[]` を返すことを確認

Sources:
- [Cloudflare Workers Fetch docs](https://developers.cloudflare.com/workers/runtime-apis/fetch/)
- [How the Cache works · Cloudflare Workers docs](https://developers.cloudflare.com/workers/reference/how-the-cache-works/)

---
_Generated by [Claude Code](https://claude.ai/code/session_018WB3xu39LSQE8pymqE53e5)_