### PR TITLE
fix(hub,issues): harden GitHub API fetches against cache + rate limit (Refs #94)

### DIFF
--- a/src/hub.ts
+++ b/src/hub.ts
@@ -483,18 +483,25 @@ export class CIDashboardHub extends DurableObject<Env> {
 
   // Direct GitHub fetch that bypasses every cache layer:
   //   - KV `cachedIssue` (60 s TTL): we don't call it
-  //   - Cloudflare Worker outbound fetch cache: `cache: "no-store"` is the
-  //     officially-supported escape hatch
-  //     (https://developers.cloudflare.com/workers/runtime-apis/fetch/).
-  //     The Worker types lib doesn't expose `cache` on RequestInit, so we
-  //     widen via a cast — the runtime does honor it.
+  //   - Cloudflare Worker outbound fetch cache, defense in depth:
+  //       1. `cache: "no-store"` (officially-supported escape hatch —
+  //          https://developers.cloudflare.com/workers/runtime-apis/fetch/).
+  //          The Worker types lib doesn't expose `cache` on RequestInit, so we
+  //          widen via a cast — the runtime does honor it.
+  //       2. Per-call cache-buster query (`?_=${Date.now()}`) so the cache
+  //          key (full URL) misses on every request even if (1) is ignored.
+  //          GitHub ignores unknown query params on /issues/N.
+  //       3. `Cache-Control: no-cache, no-store, must-revalidate` + `Pragma:
+  //          no-cache` request headers to ask the intermediate layer not to
+  //          serve a cached response.
   //
   // Only used by refreshStaleAlerts; for any page-render path stick with
   // `cachedIssue` which is fine.
   //
-  // Refs #94: without `cache: "no-store"`, the Worker's implicit fetch
-  // cache held a stale `state: "open"` response for #64 across hours of
-  // /snapshot calls — refreshStaleAlerts never saw the close.
+  // Refs #94: without (1), the Worker's implicit fetch cache held a stale
+  // `state: "open"` response for #64 across hours of /snapshot calls. After
+  // shipping (1) alone the bug recurred — the cache only cleared when an
+  // operator manually purged it. (2)+(3) defend against that recurrence.
   private async fetchLiveIssueState(owner: string, name: string, n: number): Promise<string> {
     const init: RequestInit & { cache?: string } = {
       method: "GET",
@@ -504,9 +511,12 @@ export class CIDashboardHub extends DurableObject<Env> {
         Accept: "application/vnd.github+json",
         "User-Agent": "ci-dashboard-mcp",
         "X-GitHub-Api-Version": "2022-11-28",
+        "Cache-Control": "no-cache, no-store, must-revalidate",
+        Pragma: "no-cache",
       },
     };
-    const res = await fetch(`https://api.github.com/repos/${owner}/${name}/issues/${n}`, init as RequestInit);
+    const url = `https://api.github.com/repos/${owner}/${name}/issues/${n}?_=${Date.now()}`;
+    const res = await fetch(url, init as RequestInit);
     if (!res.ok) {
       throw new Error(`GitHub /issues/${n} returned ${res.status}`);
     }

--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -17,15 +17,62 @@ const YHONDA_REPOS = ["yhonda-ohishi/claude-skills", "yhonda-ohishi/claude-hooks
 // board, even though only a subset of their repos surface as issues here.
 const PROJECT_ORGS = ["ippoan", "ohishi-exp", "yhonda-ohishi"];
 
-export async function handleIssuesPage(env: { GITHUB_TOKEN: string }): Promise<Response> {
-  let merged;
-  let projectMap: Map<string, ProjectRef[]>;
+// KV cache for the cross-org Project v2 → issue map. GraphQL fan-out is
+// expensive (one call per open project × per org) and its 5000 points/h budget
+// is easy to exhaust when the dashboard's MCP tools share the same token. A
+// short fresh window (5 min) is plenty for the issues page — Project boards
+// don't churn second-by-second — and a long store window (24 h) keeps a stale
+// copy around so a temporary rate-limit hit doesn't blank the page.
+const PROJECT_MAP_CACHE_KEY = "issues-page:project-map";
+const PROJECT_MAP_FRESH_SECONDS = 300;
+const PROJECT_MAP_STORE_SECONDS = 86400;
+
+interface ProjectMapCacheEntry {
+  storedAt: number;
+  data: Record<string, ProjectRef[]>;
+}
+
+interface ProjectMapResult {
+  map: Map<string, ProjectRef[]>;
+  stale: boolean;
+  error: string | null;
+}
+
+async function loadProjectMap(
+  kv: KVNamespace,
+  token: string,
+  orgs: string[],
+): Promise<ProjectMapResult> {
+  const cached = await kv.get(PROJECT_MAP_CACHE_KEY, "json") as ProjectMapCacheEntry | null;
+  const now = Date.now();
+  if (cached && now - cached.storedAt < PROJECT_MAP_FRESH_SECONDS * 1000) {
+    return { map: new Map(Object.entries(cached.data)), stale: false, error: null };
+  }
   try {
-    // Three parallel fetches: main-org search, yhonda repo-pinned search, and
-    // the cross-org project→issue map. Errors from any one of them are
-    // surfaced via the friendly error page — partial results aren't worth
-    // the extra ambiguity in the UI.
-    const [main, yhonda, pm] = await Promise.all([
+    const fresh = await fetchProjectIssueMap(token, { orgs });
+    const entry: ProjectMapCacheEntry = { storedAt: now, data: Object.fromEntries(fresh) };
+    await kv.put(PROJECT_MAP_CACHE_KEY, JSON.stringify(entry), {
+      expirationTtl: PROJECT_MAP_STORE_SECONDS,
+    });
+    return { map: fresh, stale: false, error: null };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (cached) {
+      return { map: new Map(Object.entries(cached.data)), stale: true, error: message };
+    }
+    return { map: new Map(), stale: false, error: message };
+  }
+}
+
+export async function handleIssuesPage(
+  env: { GITHUB_TOKEN: string; CI_STATUS: KVNamespace },
+): Promise<Response> {
+  // Search REST gives us the issues themselves; this is the only fetch that
+  // can fail the page outright. Project map is loaded separately below so a
+  // GraphQL rate-limit doesn't blank the page (Refs #94 follow-up).
+  let merged;
+  try {
+    const [main, yhonda] = await Promise.all([
       fetchOrgIssues(env.GITHUB_TOKEN, {
         orgs: ORGS,
         state: "open",
@@ -37,14 +84,12 @@ export async function handleIssuesPage(env: { GITHUB_TOKEN: string }): Promise<R
         per_page: 100,
         query: YHONDA_REPOS.map((r) => `repo:${r}`).join(" "),
       }),
-      fetchProjectIssueMap(env.GITHUB_TOKEN, { orgs: PROJECT_ORGS }),
     ]);
     merged = {
       total_count: main.total_count + yhonda.total_count,
       incomplete: main.incomplete || yhonda.incomplete,
       items: [...main.items, ...yhonda.items],
     };
-    projectMap = pm;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return new Response(renderError(msg), {
@@ -52,6 +97,9 @@ export async function handleIssuesPage(env: { GITHUB_TOKEN: string }): Promise<R
       headers: { "Content-Type": "text/html; charset=utf-8" },
     });
   }
+
+  const project = await loadProjectMap(env.CI_STATUS, env.GITHUB_TOKEN, PROJECT_ORGS);
+  const projectMap = project.map;
 
   // Split issues into "Project-tagged" (top aggregate section) and
   // "ungrouped per-repo" (bottom sections). An issue belongs to the project
@@ -81,7 +129,7 @@ export async function handleIssuesPage(env: { GITHUB_TOKEN: string }): Promise<R
     ] as const);
 
   return new Response(
-    renderHtml(merged.total_count, merged.incomplete, projectTagged, repos),
+    renderHtml(merged.total_count, merged.incomplete, projectTagged, repos, project),
     { headers: { "Content-Type": "text/html; charset=utf-8" } },
   );
 }
@@ -91,6 +139,7 @@ function renderHtml(
   incomplete: boolean,
   projectTagged: ReadonlyArray<{ issue: OrgIssue; projects: ProjectRef[] }>,
   repos: ReadonlyArray<readonly [string, OrgIssue[]]>,
+  project: ProjectMapResult,
 ): string {
   const repoSections = repos
     .map(([repo, items]) => renderRepoSection(repo, items))
@@ -102,6 +151,11 @@ function renderHtml(
 
   const incompleteBanner = incomplete
     ? `<div class="banner">⚠️ Result was truncated by GitHub search. Showing ${total} issues but more may exist.</div>`
+    : "";
+  const projectBanner = project.stale
+    ? `<div class="banner banner-info">📋 Project tags shown are from the last successful sync — fresh fetch failed (${escapeHtml(project.error ?? "")})</div>`
+    : project.error
+    ? `<div class="banner">⚠️ Project tags unavailable: ${escapeHtml(project.error)}</div>`
     : "";
 
   return `<!DOCTYPE html>
@@ -132,6 +186,11 @@ function renderHtml(
       padding: 10px 14px;
       font-size: 13px;
       margin-bottom: 16px;
+    }
+    .banner-info {
+      background: #1c2433;
+      border-color: #1f6feb88;
+      color: #a5d6ff;
     }
     section.repo, section.projects {
       background: #161b22;
@@ -245,6 +304,7 @@ function renderHtml(
     </div>
   </header>
   ${incompleteBanner}
+  ${projectBanner}
   ${projectSection}
   ${repos.length === 0 && projectTagged.length === 0
     ? `<div class="empty">🎉 No open issues. Nice work.</div>`

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -1,5 +1,5 @@
 import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import worker from "../src/index";
 import type { Env } from "../src/index";
 import { escapeHtml } from "../src/issues-page";
@@ -147,6 +147,12 @@ function stubSearchIssues() {
 }
 
 describe("GET /issues", () => {
+  // The project map is KV-cached for 5 min. Without per-test cache eviction
+  // the second test in a file reuses the first test's response (and an empty
+  // map from a no-project fixture happily masks any subsequent fetch).
+  beforeEach(async () => {
+    await env.CI_STATUS.delete("issues-page:project-map");
+  });
   afterEach(() => { vi.restoreAllMocks(); });
 
   it("renders an HTML page with repo-grouped tables", async () => {
@@ -288,6 +294,9 @@ describe("GET /issues", () => {
 });
 
 describe("GET /issues — Project section", () => {
+  beforeEach(async () => {
+    await env.CI_STATUS.delete("issues-page:project-map");
+  });
   afterEach(() => { vi.restoreAllMocks(); });
 
   it("renders a 'Project 付き' section with project chips and excludes those issues from their repo section", async () => {


### PR DESCRIPTION
## Summary

Two follow-ups after the v0.0.67 deploy:

### 1. `fetchLiveIssueState` cache bypass — defense in depth

`cache: "no-store"` was not enough in practice — the Worker outbound
fetch cache kept serving the stale `state: "open"` response for #64
until an operator manually purged it. Stack a per-call cache-buster
query (`?_=${Date.now()}`) plus `Cache-Control: no-cache, no-store,
must-revalidate` + `Pragma: no-cache` request headers so the cache key
changes on every call and the intermediate layer is asked to revalidate.

### 2. `/issues` page resilience against GraphQL rate limit

Reported in-session:

> `Failed to fetch issues: GitHub GraphQL error: API rate limit already exceeded for user ID 87104778.`

The Projects v2 fan-out (one GraphQL call per open project × per org)
was sharing the same `Promise.all` + outer try with the search-issues
REST calls, so a GraphQL rate-limit exhaustion blanked the whole page.

- Search REST stays in the fatal block (no issues = no useful page)
- Project map moves to a dedicated loader with KV cache (5 min fresh /
  24 h stale fallback)
- On a rate-limited refresh we serve the last cached map and surface a
  blue info banner; with no cache at all we render the page without
  project chips and a red error banner
- Test suite gets a `beforeEach` to evict the new KV cache key between
  cases (cloudflare:test KV persists across cases otherwise)

Refs #94

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 218/218 pass
- [ ] Post-deploy: `/snapshot` recomputes after the next minute or two
  even without manual cache purge (cache-buster carries through)
- [ ] Post-deploy: `/issues` stays usable when the GraphQL quota is
  exhausted (blue info banner appears, project chips come from cache)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1r9CWncmPSFjWp4Ja9z2H)_