### PR TITLE
chore(wrangler): register secrets-inventory{,-gcp} as TAGLESS_REPOS

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,7 +13,7 @@
     // mini-release: it scans the merged PR for `Refs #N` and surfaces any still-
     // open issues on the dashboard banner + /releases synthetic blocks. Repos
     // not listed here keep the original tag-driven flow.
-    "TAGLESS_REPOS": ""
+    "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp"
   },
   "kv_namespaces": [
     {


### PR DESCRIPTION
## 概要

`/releases` ランディングページに `ippoan/secrets-inventory` / `ippoan/secrets-inventory-gcp` のカードが出るよう、`wrangler.jsonc` の `vars.TAGLESS_REPOS` に 2 repo を追加する。

## 関連 issue

Refs #97

## 変更点

- `wrangler.jsonc`: `TAGLESS_REPOS` を `""` → `"ippoan/secrets-inventory,ippoan/secrets-inventory-gcp"` に更新

## 背景

`/releases` の watched 集合 (`src/releases-page.ts` 内 `handleIndexPage`) は以下 3 ソースの和集合:

1. Hub status cache (CI runs を発射した repo)
2. direct-push-OK allowlist (`yhonda-ohishi/claude-skills/wt-direct-push/config/direct-push-ok.txt`)
3. `TAGLESS_REPOS` wrangler var

secrets-inventory 系 2 repo は tagless 運用 (PR merge = release) なので、`TAGLESS_REPOS` に明示登録する経路が想定パス。webhook 側 (`/release-alert-detect-pr`) は既に対応済み (`test/webhook.test.ts` でも `ippoan/secrets-inventory-gcp` がサンプル repo として登場)。

## 動作確認

- [ ] `npm test` (wrangler.jsonc 単体変更なので影響なし想定)
- [ ] `npm run typecheck`
- [ ] deploy 後に `https://ci-dashboard.ippoan.org/releases` で 2 repo のカードが表示されることを目視確認

## メモ

- `loadSyntheticBlock` は default branch の直近 100 commit を `Refs #N` で走査して open issue を残す。commit に `Refs #N` を含む直近実績が無い repo はこの PR だけでは表示されないので、対象 repo 側で `Refs #N` を仕込む慣習を合わせて整備する必要がある。


---
_Generated by [Claude Code](https://claude.ai/code/session_01QteJG9s3kpA3HCuLM3Mkfm)_