### PR TITLE
feat(issues): exclude archived repos from /issues and list_org_issues

### DIFF
--- a/src/mcp/tools/issues.ts
+++ b/src/mcp/tools/issues.ts
@@ -414,12 +414,18 @@ export async function fetchOrgIssues(
   // the `org:` qualifier (the `repo:` already implies the owner). The
   // `validateOrg` allowlist check above still runs, so this is safe.
   const queryHasRepoFilter = !!query && /\brepo:/.test(query);
+  // Default-exclude archived repos so old projects like cf-secrets-mcp don't
+  // leak open issues into the dashboard. Caller can still opt back in (or
+  // request archived-only) by passing `archived:true` / `archived:false` in
+  // `query`.
+  const queryHasArchivedFilter = !!query && /\barchived:/.test(query);
 
   const parts: string[] = ["is:issue"];
   if (state !== "all") parts.push(`state:${state}`);
   if (!queryHasRepoFilter) {
     for (const o of orgs) parts.push(`org:${o}`);
   }
+  if (!queryHasArchivedFilter) parts.push("archived:false");
   if (labels) for (const l of labels) parts.push(`label:"${l}"`);
   if (assignee) parts.push(`assignee:${assignee}`);
   if (query) parts.push(query);

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -242,6 +242,12 @@ describe("GET /issues", () => {
     expect(yhonda!).toContain("repo:yhonda-ohishi/claude-hooks");
     expect(yhonda!).not.toContain("org:yhonda-ohishi");
 
+    // Both calls must exclude archived repos so old projects (e.g.
+    // ippoan/cf-secrets-mcp) don't leak open issues into the dashboard.
+    // Regression guard for issue #99.
+    expect(main!).toContain("archived:false");
+    expect(yhonda!).toContain("archived:false");
+
     for (const u of urls) expect(u).toContain("per_page=100");
   });
 

--- a/test/mcp/tools.test.ts
+++ b/test/mcp/tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { githubApi, githubApiRaw, parseRepo, validateOrg, GitHubApiError } from "../../src/github-api";
-import { buildUpdateIssuePayload } from "../../src/mcp/tools/issues";
+import { buildUpdateIssuePayload, fetchOrgIssues } from "../../src/mcp/tools/issues";
 
 // Test MCP tool logic by calling the same functions the tools use.
 // The MCP protocol layer (JSON-RPC, transport) is tested by the SDK itself.
@@ -559,6 +559,36 @@ describe("list_org_issues tool logic", () => {
     expect(() => {
       for (const o of ["ippoan", "evil-org"]) validateOrg(o);
     }).toThrow(GitHubApiError);
+  });
+
+  it("appends archived:false to the search q by default", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({ total_count: 0, incomplete_results: false, items: [] }),
+    );
+
+    await fetchOrgIssues("token", { orgs: ["ippoan"], state: "open" });
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    const decoded = decodeURIComponent(url.replace(/\+/g, " "));
+    expect(decoded).toContain("archived:false");
+  });
+
+  it("does not append archived:false when caller already passed archived: in query", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({ total_count: 0, incomplete_results: false, items: [] }),
+    );
+
+    await fetchOrgIssues("token", {
+      orgs: ["ippoan"],
+      state: "open",
+      query: "archived:true",
+    });
+
+    const url = fetchSpy.mock.calls[0]![0] as string;
+    const decoded = decodeURIComponent(url.replace(/\+/g, " "));
+    // Caller override must be the only `archived:` qualifier in the query.
+    expect(decoded).toContain("archived:true");
+    expect(decoded).not.toContain("archived:false");
   });
 });
 


### PR DESCRIPTION
## Summary

`fetchOrgIssues` now appends `archived:false` to the GitHub Search `q` by default, so archived repos (e.g. ippoan/cf-secrets-mcp) stop leaking open issues into the /issues page and the `list_org_issues` MCP tool.

- `src/mcp/tools/issues.ts`: append `archived:false` to query parts unless caller-supplied `query` already contains an `archived:` qualifier
- `test/issues-page.test.ts`: regression guard — both `/search/issues` calls (main orgs + yhonda-ohishi repo filter) include `archived:false`
- `test/mcp/tools.test.ts`: unit tests for default-on behavior and caller-override

Refs #99

## Test plan

- [x] `npm test` — 21 files / 220 tests passed
- [x] `npm run typecheck` — pass
- [ ] After merge: verify ippoan/cf-secrets-mcp#1 disappears from /issues

---
_Generated by [Claude Code](https://claude.ai/code/session_0112p7iHJ9JmgAVfaA2Jfz8E)_