### PR TITLE
feat(projects): add /projects SSR page (Projects v2 read)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { cors } from "hono/cors";
 import { handleWebhook } from "./webhook";
 import { handleDashboard } from "./dashboard";
 import { handleIssuesPage } from "./issues-page";
+import { handleProjectsPage } from "./projects-page";
 import { handleReleasesPage } from "./releases-page";
 import { handleReleaseClose } from "./release-close";
 import { handleReleaseCloseBatch } from "./release-close-batch";
@@ -43,6 +44,9 @@ app.get("/", () => handleDashboard());
 
 // Open issues (SSR, cross-org)
 app.get("/issues", (c) => handleIssuesPage(c.env));
+
+// Projects v2 read-only listing (SSR, cross-org). Refs #72.
+app.get("/projects", (c) => handleProjectsPage(c.env));
 
 // Cryptographically-strong random value generator (client-side, no server-side
 // state). Operators paste the output into Cloudflare Secrets Store / wrangler

--- a/src/mcp/tools/projects.ts
+++ b/src/mcp/tools/projects.ts
@@ -266,6 +266,85 @@ export async function fetchProjectIssueMap(
   return map;
 }
 
+export interface ProjectItemSummary {
+  item_id: string;
+  item_type: string;
+  content:
+    | { type: "issue" | "pull_request"; repo: string; number: number; title: string; state: string; url: string }
+    | { type: "draft_issue"; title: string }
+    | { type: "unknown" };
+  fields: Record<string, unknown>;
+}
+
+/**
+ * Fetch the cards on a single Projects v2 board, with each item's field values
+ * flattened (Status / Priority / Iteration title / etc.) into a `fields` map
+ * keyed by field name. Shared by the `list_project_items` MCP tool and the
+ * SSR `/projects` page in `src/projects-page.ts`.
+ *
+ * `repositoryOwner(login:$login)` is used (rather than `node(id:$id)` like
+ * `fetchProjectIssueMap`) so callers can pass `org` + `number` directly — the
+ * same surface as the MCP tool.
+ */
+export async function fetchProjectItems(
+  token: string,
+  org: string,
+  number: number,
+  first = 50,
+): Promise<ProjectItemSummary[]> {
+  validateOrg(org);
+  const data = await githubGraphQL<{
+    repositoryOwner: { projectV2?: { items: { nodes: ProjectItemNode[] } } | null } | null;
+  }>(
+    token,
+    `query($login:String!,$number:Int!,$first:Int!){
+      repositoryOwner(login:$login){
+        ... ProjectItems
+      }
+    }
+    fragment ProjectItems on ProjectV2Owner {
+      projectV2(number:$number){
+        items(first:$first){
+          nodes{
+            id
+            type
+            content{
+              __typename
+              ... on Issue { number title url state repository{ nameWithOwner } }
+              ... on PullRequest { number title url state repository{ nameWithOwner } }
+              ... on DraftIssue { title }
+            }
+            fieldValues(first:30){
+              nodes{
+                __typename
+                ... on ProjectV2ItemFieldTextValue {
+                  text field{ ... on ProjectV2FieldCommon { name } }
+                }
+                ... on ProjectV2ItemFieldNumberValue {
+                  number field{ ... on ProjectV2FieldCommon { name } }
+                }
+                ... on ProjectV2ItemFieldDateValue {
+                  date field{ ... on ProjectV2FieldCommon { name } }
+                }
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name optionId field{ ... on ProjectV2FieldCommon { name } }
+                }
+                ... on ProjectV2ItemFieldIterationValue {
+                  title iterationId
+                  field{ ... on ProjectV2FieldCommon { name } }
+                }
+              }
+            }
+          }
+        }
+      }
+    }`,
+    { login: org, number, first },
+  );
+  const nodes = data.repositoryOwner?.projectV2?.items.nodes ?? [];
+  return nodes.map(formatItem);
+}
+
 export function registerProjectsTools(server: McpServer, token: string): void {
   // --------------------------------------------------------------------
   // Read tools
@@ -394,57 +473,7 @@ export function registerProjectsTools(server: McpServer, token: string): void {
       annotations: { readOnlyHint: true },
     },
     async ({ org, number, first }) => {
-      validateOrg(org);
-      const data = await githubGraphQL<{
-        repositoryOwner: { projectV2?: { items: { nodes: ProjectItemNode[] } } | null } | null;
-      }>(
-        token,
-        `query($login:String!,$number:Int!,$first:Int!){
-          repositoryOwner(login:$login){
-            ... ProjectItems
-          }
-        }
-        fragment ProjectItems on ProjectV2Owner {
-          projectV2(number:$number){
-            items(first:$first){
-              nodes{
-                id
-                type
-                content{
-                  __typename
-                  ... on Issue { number title url state repository{ nameWithOwner } }
-                  ... on PullRequest { number title url state repository{ nameWithOwner } }
-                  ... on DraftIssue { title }
-                }
-                fieldValues(first:30){
-                  nodes{
-                    __typename
-                    ... on ProjectV2ItemFieldTextValue {
-                      text field{ ... on ProjectV2FieldCommon { name } }
-                    }
-                    ... on ProjectV2ItemFieldNumberValue {
-                      number field{ ... on ProjectV2FieldCommon { name } }
-                    }
-                    ... on ProjectV2ItemFieldDateValue {
-                      date field{ ... on ProjectV2FieldCommon { name } }
-                    }
-                    ... on ProjectV2ItemFieldSingleSelectValue {
-                      name optionId field{ ... on ProjectV2FieldCommon { name } }
-                    }
-                    ... on ProjectV2ItemFieldIterationValue {
-                      title iterationId
-                      field{ ... on ProjectV2FieldCommon { name } }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }`,
-        { login: org, number, first },
-      );
-      const nodes = data.repositoryOwner?.projectV2?.items.nodes ?? [];
-      const result = nodes.map(formatItem);
+      const result = await fetchProjectItems(token, org, number, first);
       return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
     },
   );
@@ -848,9 +877,9 @@ type ProjectFieldValueNode =
   | { __typename: "ProjectV2ItemFieldIterationValue"; title: string; iterationId: string; field: { name?: string } }
   | { __typename: string };
 
-function formatItem(node: ProjectItemNode) {
+function formatItem(node: ProjectItemNode): ProjectItemSummary {
   const content = node.content;
-  let contentSummary: Record<string, unknown> = { type: "unknown" };
+  let contentSummary: ProjectItemSummary["content"] = { type: "unknown" };
   if (content) {
     if (content.__typename === "Issue" || content.__typename === "PullRequest") {
       contentSummary = {

--- a/src/nav-tabs.ts
+++ b/src/nav-tabs.ts
@@ -6,7 +6,7 @@
 // pages self-contained (no external stylesheet to fetch) and avoid the
 // CSS-classname coupling problem if pages grow apart later.
 
-export type TabKey = "dashboard" | "issues" | "releases" | "secret-gen";
+export type TabKey = "dashboard" | "issues" | "projects" | "releases" | "secret-gen";
 
 interface TabDef {
   key: TabKey | "branch-protection" | "gcp-secrets";
@@ -28,6 +28,7 @@ const SECRETS_GCP_PROJECT = "cloudsql-sv";
 const TABS: ReadonlyArray<TabDef> = [
   { key: "dashboard",  href: "/",           label: "📊 Dashboard" },
   { key: "issues",     href: "/issues",     label: "📋 Open Issues" },
+  { key: "projects",   href: "/projects",   label: "🗂️ Projects" },
   { key: "releases",   href: "/releases",   label: "🏷️ Releases" },
   { key: "secret-gen", href: "/secret-gen", label: "🔐 Secret Generator" },
   {

--- a/src/projects-page.ts
+++ b/src/projects-page.ts
@@ -1,0 +1,399 @@
+import {
+  fetchOrgProjects,
+  fetchProjectItems,
+  type OrgProject,
+  type ProjectItemSummary,
+} from "./mcp/tools/projects";
+import { renderTabs, TAB_STYLES } from "./nav-tabs";
+import { PWA_HEAD_TAGS, PWA_REGISTER_SCRIPT } from "./pwa";
+import { escapeHtml } from "./issues-page";
+
+// Same set of orgs as the `/issues` Projects-aggregate section. Three orgs ×
+// ~10 open projects each is well under the GraphQL rate-limit budget for one
+// page load; cross-page caching is a follow-up if items() queries grow.
+const PROJECT_ORGS = ["ippoan", "ohishi-exp", "yhonda-ohishi"];
+
+interface ProjectWithItems {
+  project: OrgProject;
+  items: ProjectItemSummary[] | null; // null on per-project fetch failure
+  error: string | null;
+}
+
+interface OrgSection {
+  org: string;
+  projects: ProjectWithItems[];
+}
+
+export async function handleProjectsPage(
+  env: { GITHUB_TOKEN: string },
+): Promise<Response> {
+  let perOrg;
+  try {
+    perOrg = await fetchOrgProjects(env.GITHUB_TOKEN, { orgs: PROJECT_ORGS });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return new Response(renderError(msg), {
+      status: 502,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  }
+
+  // Fan-out: one items() GraphQL call per (org, project). `allSettled` so a
+  // single project that errors out (e.g. permission, deleted between list and
+  // fetch) doesn't blank the whole page — that project surfaces an inline
+  // error in its <details> block instead.
+  const flat = perOrg.flatMap(({ org, projects }) =>
+    projects.map((p) => ({ org, project: p })),
+  );
+  const itemResults = await Promise.allSettled(
+    flat.map(({ org, project }) =>
+      fetchProjectItems(env.GITHUB_TOKEN, org, project.number),
+    ),
+  );
+
+  // Re-fold into org → projects[] structure preserving the order from
+  // `fetchOrgProjects` (which is NUMBER DESC per org → newest first).
+  const itemsByKey = new Map<string, ProjectWithItems>();
+  flat.forEach(({ org, project }, idx) => {
+    const r = itemResults[idx]!;
+    const key = `${org}/${project.number}`;
+    if (r.status === "fulfilled") {
+      itemsByKey.set(key, { project, items: r.value, error: null });
+    } else {
+      const msg = r.reason instanceof Error ? r.reason.message : String(r.reason);
+      itemsByKey.set(key, { project, items: null, error: msg });
+    }
+  });
+
+  const sections: OrgSection[] = perOrg.map(({ org, projects }) => ({
+    org,
+    projects: projects.map((p) => itemsByKey.get(`${org}/${p.number}`)!),
+  }));
+
+  const totalProjects = sections.reduce((sum, s) => sum + s.projects.length, 0);
+
+  return new Response(renderHtml(sections, totalProjects), {
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+function renderHtml(sections: OrgSection[], totalProjects: number): string {
+  const orgBlocks = sections
+    .map((s) => renderOrgSection(s))
+    .join("\n");
+
+  const empty = totalProjects === 0
+    ? `<div class="empty">No open Projects v2 across ${PROJECT_ORGS.map((o) => escapeHtml(o)).join(", ")}.</div>`
+    : "";
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Projects — CI Dashboard</title>${PWA_HEAD_TAGS}
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #0d1117;
+      color: #c9d1d9;
+      padding: 24px;
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+    header { margin-bottom: 24px; }
+    ${TAB_STYLES}
+    h1 { font-size: 20px; color: #58a6ff; }
+    .summary { font-size: 13px; color: #8b949e; margin-top: 4px; }
+    section.org {
+      margin-bottom: 24px;
+    }
+    section.org > h2 {
+      font-size: 14px;
+      font-weight: 600;
+      color: #8b949e;
+      padding: 4px 0;
+      margin-bottom: 8px;
+      letter-spacing: 0.3px;
+    }
+    section.org > h2 .count {
+      color: #6b7280;
+      font-weight: 400;
+      margin-left: 6px;
+    }
+    details.project {
+      background: #161b22;
+      border: 1px solid #30363d;
+      border-radius: 8px;
+      margin-bottom: 8px;
+      overflow: hidden;
+    }
+    details.project[open] {
+      border-color: #1f6feb55;
+    }
+    details.project > summary {
+      cursor: pointer;
+      list-style: none;
+      padding: 10px 14px;
+      background: #1f2630;
+      border-bottom: 1px solid transparent;
+      display: flex;
+      gap: 10px;
+      align-items: baseline;
+      font-size: 13px;
+    }
+    details.project > summary::-webkit-details-marker { display: none; }
+    details.project > summary::before {
+      content: "▸";
+      color: #8b949e;
+      font-size: 11px;
+      width: 10px;
+      display: inline-block;
+    }
+    details.project[open] > summary::before { content: "▾"; }
+    details.project[open] > summary {
+      border-bottom-color: #30363d;
+      background: #1c2433;
+    }
+    summary .num {
+      color: #8b949e;
+      font-variant-numeric: tabular-nums;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 12px;
+    }
+    summary .title {
+      color: #c9d1d9;
+      font-weight: 500;
+      flex-grow: 1;
+    }
+    summary .title a {
+      color: inherit;
+      text-decoration: none;
+    }
+    summary .title a:hover { color: #58a6ff; text-decoration: underline; }
+    summary .desc {
+      color: #8b949e;
+      font-size: 12px;
+      font-weight: 400;
+    }
+    summary .item-count {
+      color: #8b949e;
+      font-size: 12px;
+      font-variant-numeric: tabular-nums;
+      white-space: nowrap;
+    }
+    summary .closed-tag {
+      display: inline-block;
+      font-size: 11px;
+      padding: 1px 6px;
+      border-radius: 10px;
+      background: #8b949e22;
+      color: #8b949e;
+      margin-left: 6px;
+    }
+    .items {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+    .items tbody tr { border-top: 1px solid #21262d; }
+    .items tbody tr:hover { background: #1c2129; }
+    .items th, .items td {
+      padding: 8px 14px;
+      text-align: left;
+      vertical-align: top;
+    }
+    .items th {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: #8b949e;
+      background: #0d1117;
+    }
+    .items td.type {
+      width: 90px;
+      color: #8b949e;
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    .items td.repo {
+      width: 220px;
+      font-size: 12px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      color: #8b949e;
+      white-space: nowrap;
+    }
+    .items td.repo a { color: #58a6ff; text-decoration: none; }
+    .items td.repo a:hover { text-decoration: underline; }
+    .items td.title a { color: #c9d1d9; text-decoration: none; font-weight: 500; }
+    .items td.title a:hover { color: #58a6ff; text-decoration: underline; }
+    .items td.state {
+      width: 80px;
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: #8b949e;
+    }
+    .items .state-open { color: #3fb950; }
+    .items .state-closed { color: #f85149; }
+    .items .state-merged { color: #a371f7; }
+    .fields { margin-top: 4px; }
+    .field-chip {
+      display: inline-block;
+      font-size: 11px;
+      padding: 1px 8px;
+      border-radius: 10px;
+      background: #1f6feb22;
+      color: #79c0ff;
+      margin-right: 4px;
+      margin-bottom: 2px;
+    }
+    .field-chip .field-name {
+      color: #58a6ff99;
+      margin-right: 4px;
+    }
+    .err {
+      padding: 12px 14px;
+      color: #ffa198;
+      background: #341a1f;
+      font-size: 12px;
+    }
+    .no-items {
+      padding: 12px 14px;
+      color: #8b949e;
+      font-size: 13px;
+      font-style: italic;
+    }
+    .empty {
+      padding: 32px;
+      text-align: center;
+      color: #8b949e;
+      font-size: 14px;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    ${renderTabs("projects")}
+    <h1>🗂️ Projects</h1>
+    <div class="summary">
+      ${escapeHtml(String(totalProjects))} open project${totalProjects === 1 ? "" : "s"} across
+      ${PROJECT_ORGS.map((o) => escapeHtml(o)).join(", ")}
+    </div>
+  </header>
+  ${orgBlocks}
+  ${empty}
+  ${PWA_REGISTER_SCRIPT}
+</body>
+</html>`;
+}
+
+function renderOrgSection(s: OrgSection): string {
+  if (s.projects.length === 0) {
+    // Skip empty orgs to avoid visual noise (closed/empty user accounts).
+    return "";
+  }
+  const items = s.projects.map((pw) => renderProject(pw)).join("\n");
+  return `<section class="org">
+  <h2>${escapeHtml(s.org)}<span class="count">(${s.projects.length})</span></h2>
+  ${items}
+</section>`;
+}
+
+function renderProject(pw: ProjectWithItems): string {
+  const { project, items, error } = pw;
+  const itemCount = items?.length ?? 0;
+  const closedTag = project.closed ? `<span class="closed-tag">closed</span>` : "";
+  const desc = project.shortDescription
+    ? `<span class="desc">— ${escapeHtml(project.shortDescription)}</span>`
+    : "";
+  const countLabel = error
+    ? `<span class="item-count">error</span>`
+    : `<span class="item-count">${itemCount} item${itemCount === 1 ? "" : "s"}</span>`;
+  const body = error
+    ? `<div class="err">Failed to load items: ${escapeHtml(error)}</div>`
+    : !items || items.length === 0
+    ? `<div class="no-items">No items.</div>`
+    : renderItemsTable(items);
+
+  return `<details class="project">
+  <summary>
+    <span class="num">#${project.number}</span>
+    <span class="title"><a href="${escapeHtml(project.url)}" target="_blank" rel="noopener">${escapeHtml(project.title)}</a>${closedTag}</span>
+    ${desc}
+    ${countLabel}
+  </summary>
+  ${body}
+</details>`;
+}
+
+function renderItemsTable(items: ReadonlyArray<ProjectItemSummary>): string {
+  const rows = items.map((i) => renderItemRow(i)).join("\n");
+  return `<table class="items">
+  <thead><tr><th>Type</th><th>Repo</th><th>Title</th><th>State</th></tr></thead>
+  <tbody>${rows}</tbody>
+</table>`;
+}
+
+function renderItemRow(item: ProjectItemSummary): string {
+  const fieldChips = renderFieldChips(item.fields);
+  const c = item.content;
+  if (c.type === "issue" || c.type === "pull_request") {
+    const stateCls = stateClass(c.state);
+    return `<tr>
+    <td class="type">${c.type === "issue" ? "Issue" : "PR"}</td>
+    <td class="repo"><a href="https://github.com/${escapeHtml(c.repo)}" target="_blank" rel="noopener">${escapeHtml(c.repo)}</a>#${c.number}</td>
+    <td class="title"><a href="${escapeHtml(c.url)}" target="_blank" rel="noopener">${escapeHtml(c.title)}</a>${fieldChips}</td>
+    <td class="state ${stateCls}">${escapeHtml(c.state.toLowerCase())}</td>
+  </tr>`;
+  }
+  if (c.type === "draft_issue") {
+    return `<tr>
+    <td class="type">Draft</td>
+    <td class="repo">—</td>
+    <td class="title">${escapeHtml(c.title)}${fieldChips}</td>
+    <td class="state">draft</td>
+  </tr>`;
+  }
+  return `<tr>
+    <td class="type">?</td>
+    <td class="repo">—</td>
+    <td class="title">(redacted item)${fieldChips}</td>
+    <td class="state">—</td>
+  </tr>`;
+}
+
+function renderFieldChips(fields: Record<string, unknown>): string {
+  const names = Object.keys(fields);
+  if (names.length === 0) return "";
+  const chips = names.map((name) => {
+    const v = fields[name];
+    const display = v === null || v === undefined ? "" : String(v);
+    return `<span class="field-chip"><span class="field-name">${escapeHtml(name)}:</span>${escapeHtml(display)}</span>`;
+  }).join("");
+  return `<div class="fields">${chips}</div>`;
+}
+
+function stateClass(state: string): string {
+  const lower = state.toLowerCase();
+  if (lower === "open") return "state-open";
+  if (lower === "closed") return "state-closed";
+  if (lower === "merged") return "state-merged";
+  return "";
+}
+
+function renderError(msg: string): string {
+  return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><title>Projects — Error</title>
+<style>body { font-family: sans-serif; background: #0d1117; color: #c9d1d9; padding: 24px; }
+.err { background: #341a1f; border: 1px solid #f85149; color: #ffa198;
+       padding: 12px 16px; border-radius: 6px; max-width: 720px; }</style>
+</head><body>
+<h1>🗂️ Projects</h1>
+<div class="err">Failed to fetch projects: ${escapeHtml(msg)}</div>
+<p style="margin-top: 12px;"><a href="/" style="color:#58a6ff">← CI Dashboard</a></p>
+</body></html>`;
+}

--- a/test/nav-tabs.test.ts
+++ b/test/nav-tabs.test.ts
@@ -18,6 +18,19 @@ describe("renderTabs — internal tabs", () => {
     expect(html).toContain('href="/secret-gen"');
     expect(html).toContain("🔐 Secret Generator");
   });
+
+  it("renders the Projects tab pointing at /projects", () => {
+    const html = renderTabs("dashboard");
+    expect(html).toContain('href="/projects"');
+    expect(html).toContain("🗂️ Projects");
+  });
+
+  it("marks the Projects tab active when key='projects'", () => {
+    const html = renderTabs("projects");
+    expect(html).toMatch(/tab tab-active[^>]*>\s*🗂️ Projects/);
+    // sibling tabs stay plain
+    expect(html).toMatch(/class="tab"[^>]*>\s*📋 Open Issues/);
+  });
 });
 
 describe("renderTabs — external tabs", () => {

--- a/test/projects-page.test.ts
+++ b/test/projects-page.test.ts
@@ -1,0 +1,229 @@
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import worker from "../src/index";
+import type { Env } from "../src/index";
+
+function testEnv(): Env {
+  return {
+    CI_STATUS: env.CI_STATUS,
+    WEBHOOK_SECRET: "test-secret",
+    GITHUB_TOKEN: "test-token",
+    CI_HUB: {
+      idFromName: () => ({}),
+      get: () => ({ fetch: async () => new Response("OK") }),
+    } as unknown as DurableObjectNamespace,
+  };
+}
+
+// Stub /graphql for the projects page. Two GraphQL shapes are issued:
+//   - `projectsV2(first:` — one per org (3 calls: ippoan, ohishi-exp, yhonda-ohishi)
+//   - `items(first:` (with `$number`) — one per (org, project) pair
+// `failItemFetchFor` lets a test simulate a per-project failure to verify the
+// page still renders the rest of the board grid.
+function stubGraphQL(opts: { failItemsFor?: string } = {}) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (req, init) => {
+    const url = typeof req === "string" ? req : (req as Request).url;
+    const body = (init?.body as string | undefined)
+      ?? (typeof req === "string" ? "" : await (req as Request).clone().text());
+
+    if (!url.includes("/graphql")) {
+      return new Response("not stubbed: " + url, { status: 500 });
+    }
+
+    // Per-org project list. Match on the org login that appears in `variables`.
+    if (body.includes("projectsV2(first:") && !body.includes("items(first:")) {
+      if (body.includes('"ippoan"')) {
+        return Response.json({
+          data: { repositoryOwner: { projectsV2: { nodes: [
+            { id: "PVT_1", number: 1, title: "Camera Monitoring",
+              url: "https://github.com/orgs/ippoan/projects/1",
+              closed: false, shortDescription: "device health" },
+          ] } } },
+        });
+      }
+      if (body.includes('"yhonda-ohishi"')) {
+        return Response.json({
+          data: { repositoryOwner: { projectsV2: { nodes: [
+            { id: "PVT_2", number: 2, title: "Personal Board",
+              url: "https://github.com/users/yhonda-ohishi/projects/2",
+              closed: false, shortDescription: null },
+          ] } } },
+        });
+      }
+      // ohishi-exp returns empty
+      return Response.json({
+        data: { repositoryOwner: { projectsV2: { nodes: [] } } },
+      });
+    }
+
+    // Per-project items.
+    if (body.includes("items(first:") && body.includes("ProjectItems")) {
+      // Optional failure injection — used to verify the page survives a
+      // single project's items() call failing.
+      if (opts.failItemsFor && body.includes(`"${opts.failItemsFor}"`)) {
+        return new Response("Internal Server Error", { status: 500 });
+      }
+      if (body.includes('"ippoan"')) {
+        return Response.json({
+          data: { repositoryOwner: { projectV2: { items: { nodes: [
+            {
+              id: "ITEM_1",
+              type: "ISSUE",
+              content: {
+                __typename: "Issue",
+                number: 7,
+                title: "<script>alert('xss')</script>",
+                url: "https://github.com/ippoan/rust-alc-api/issues/7",
+                state: "OPEN",
+                repository: { nameWithOwner: "ippoan/rust-alc-api" },
+              },
+              fieldValues: { nodes: [
+                {
+                  __typename: "ProjectV2ItemFieldSingleSelectValue",
+                  name: "In Progress",
+                  optionId: "opt_inp",
+                  field: { name: "Status" },
+                },
+                {
+                  __typename: "ProjectV2ItemFieldTextValue",
+                  text: "P1",
+                  field: { name: "Priority" },
+                },
+              ] },
+            },
+            {
+              id: "ITEM_2",
+              type: "DRAFT_ISSUE",
+              content: { __typename: "DraftIssue", title: "TBD" },
+              fieldValues: { nodes: [] },
+            },
+          ] } } } },
+        });
+      }
+      if (body.includes('"yhonda-ohishi"')) {
+        return Response.json({
+          data: { repositoryOwner: { projectV2: { items: { nodes: [] } } } },
+        });
+      }
+    }
+
+    return Response.json({ data: { repositoryOwner: null } });
+  });
+}
+
+describe("GET /projects", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("renders an HTML page with the Projects tab active and 🗂️ Projects header", async () => {
+    stubGraphQL();
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request("http://localhost/projects"), testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/html; charset=utf-8");
+    const html = await res.text();
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html).toContain("🗂️ Projects");
+    expect(html).toMatch(/tab tab-active[^>]*>\s*🗂️ Projects/);
+  });
+
+  it("groups projects by org and renders <details> per project with item table", async () => {
+    stubGraphQL();
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request("http://localhost/projects"), testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    const html = await res.text();
+    // Two org sections rendered (ippoan + yhonda-ohishi); ohishi-exp is empty
+    // and skipped to avoid noise.
+    expect(html).toContain('<section class="org">');
+    expect(html).toMatch(/<h2>ippoan<span class="count">\(1\)<\/span>/);
+    expect(html).toMatch(/<h2>yhonda-ohishi<span class="count">\(1\)<\/span>/);
+    // ohishi-exp appears in the header summary line but must NOT get its own
+    // <section> (empty orgs are skipped).
+    expect(html).not.toMatch(/<h2>ohishi-exp<span/);
+
+    // Per-project <details> with item count in summary.
+    expect(html).toContain('<details class="project">');
+    expect(html).toContain("#1");
+    expect(html).toContain("Camera Monitoring");
+    expect(html).toContain("device health");
+    expect(html).toContain("2 items"); // 1 issue + 1 draft
+
+    // yhonda-ohishi's project shows "No items.".
+    expect(html).toContain("No items.");
+  });
+
+  it("escapes content titles to prevent XSS", async () => {
+    stubGraphQL();
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request("http://localhost/projects"), testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    const html = await res.text();
+    expect(html).not.toContain("<script>alert");
+    expect(html).toContain("&lt;script&gt;alert");
+  });
+
+  it("renders field chips for Status and Priority", async () => {
+    stubGraphQL();
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request("http://localhost/projects"), testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    const html = await res.text();
+    expect(html).toContain('class="field-chip"');
+    expect(html).toContain("Status:");
+    expect(html).toContain("In Progress");
+    expect(html).toContain("Priority:");
+    expect(html).toContain("P1");
+  });
+
+  it("links Issue repo + url, and tags PR/Issue type explicitly", async () => {
+    stubGraphQL();
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request("http://localhost/projects"), testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    const html = await res.text();
+    // Issue row links out to the github issue URL
+    expect(html).toContain('href="https://github.com/ippoan/rust-alc-api/issues/7"');
+    // Repo cell shows owner/repo#number
+    expect(html).toContain("ippoan/rust-alc-api</a>#7");
+    // Type column distinguishes Issue from Draft
+    expect(html).toContain("<td class=\"type\">Issue</td>");
+    expect(html).toContain("<td class=\"type\">Draft</td>");
+  });
+
+  it("survives a per-project items() failure with an inline error block", async () => {
+    // ippoan's items() call fails. The page should still render yhonda-ohishi's
+    // project and show ippoan's failure inline rather than 502'ing the page.
+    stubGraphQL({ failItemsFor: "ippoan" });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request("http://localhost/projects"), testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Camera Monitoring");
+    expect(html).toContain("Failed to load items:");
+    // yhonda-ohishi's section still renders fine.
+    expect(html).toContain("Personal Board");
+  });
+
+  it("returns 502 when the per-org project list fetch fails outright", async () => {
+    // Make every /graphql call fail. The page can't recover without the
+    // project list, so it should respond with the error page (502).
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("Service Unavailable", { status: 503 }),
+    );
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request("http://localhost/projects"), testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(502);
+    const html = await res.text();
+    expect(html).toContain("Failed to fetch projects");
+  });
+});


### PR DESCRIPTION
## 概要

`/projects` ページを新設し、3 org (`ippoan` / `ohishi-exp` / `yhonda-ohishi`) の open な Projects v2 ボードと、各ボードの items 一覧をブラウザから一覧できるようにする。 read only、書き込み (Status 変更 / card 追加削除) は未対応。

## 関連 issue

Refs #72

## 変更点

### `src/projects-page.ts` (新規)

- `fetchOrgProjects` を 3 org に並列で叩いて open projects を取得
- 各 project に対して `fetchProjectItems` を `Promise.allSettled` で並列実行 — 1 project の `items()` が失敗しても他はレンダリングされ、当該 project は `<details>` 内にインラインの error block を出す
- 全 org list 自体の失敗時のみページ全体を 502 に倒す
- 各 project は CSS-only `<details>` (JS 不要、初版はサーバ側で全部 fetch して inline 展開) で開閉
- items テーブル: Type / Repo#Number / Title / State + 各 item の `fields` (Status / Priority / Iteration title 等) を chip 表示
- 空の org はセクションごとスキップして視覚ノイズを排除
- XSS 対策は `src/issues-page.ts` の `escapeHtml` を再利用

### `src/mcp/tools/projects.ts`

`list_project_items` ハンドラのインライン GraphQL を抜き出して純粋関数として export、UI からも呼べるようにする (`issues.ts` の `fetchOrgIssues` パターンに揃える):

```ts
export interface ProjectItemSummary { item_id, item_type, content, fields }
export async function fetchProjectItems(
  token: string, org: string, number: number, first?: number,
): Promise<ProjectItemSummary[]>
```

`list_project_items` ハンドラはこれを呼んで `JSON.stringify` するだけにリファクタ。**MCP ツールの on-wire shape は不変** (`formatItem` の戻り型を `ProjectItemSummary` で明示しただけ)。

### `src/index.ts` / `src/nav-tabs.ts`

- `app.get("/projects", (c) => handleProjectsPage(c.env))` を登録
- `TabKey` に `"projects"`、TABS に `🗂️ Projects` エントリ追加

## 動作確認

- [x] `npm test` — 229/229 passed (+9 new)
- [x] `npm run typecheck` — clean
- [ ] デプロイ後 `/projects` を開き、`ippoan/projects/2 (監視カメラ死活管理)` 等が org グループの下に `<details>` で並ぶこと
- [ ] 1 つの project の items 取得が permission 等で失敗してもページ全体が落ちず、当該 project だけが赤い error block になること

## メモ

- KV キャッシュは未導入 — 現状の org / project 数では `items()` の fan-out は GraphQL rate-limit 5000 pt/h の budget に対して充分余裕がある。`/issues` ページのような hardening が必要になったら follow-up issue で
- スコープ外 (issue 本文の通り): 遅延ローディング (現在は全部サーバ側 inline)、書き込み系 UI、Project 単位ページ
- new file の `test/projects-page.test.ts` は `test/issues-page.test.ts` の `stubFetch` パターンを踏襲。`failItemsFor` オプションで per-project 失敗パスもカバー

https://claude.ai/code/session_01WZFWDo4bmeYTgCLMTC1Pck

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZFWDo4bmeYTgCLMTC1Pck)_