### PR TITLE
Add Security Inventory external tab to navigation

### DIFF
--- a/src/nav-tabs.ts
+++ b/src/nav-tabs.ts
@@ -9,7 +9,7 @@
 export type TabKey = "dashboard" | "issues" | "projects" | "releases" | "secret-gen";
 
 interface TabDef {
-  key: TabKey | "branch-protection" | "gcp-secrets";
+  key: TabKey | "branch-protection" | "gcp-secrets" | "security-inventory";
   href: string;
   label: string;
   // External tabs live on a different origin, so they open in a new tab and
@@ -41,6 +41,12 @@ const TABS: ReadonlyArray<TabDef> = [
     key: "gcp-secrets",
     href: `https://console.cloud.google.com/security/secret-manager?project=${encodeURIComponent(SECRETS_GCP_PROJECT)}`,
     label: "🗝️ GCP Secrets",
+    external: true,
+  },
+  {
+    key: "security-inventory",
+    href: "https://security-inventory.ippoan.org/",
+    label: "🔍 Security Inventory",
     external: true,
   },
 ];

--- a/test/nav-tabs.test.ts
+++ b/test/nav-tabs.test.ts
@@ -59,11 +59,21 @@ describe("renderTabs — external tabs", () => {
     );
   });
 
+  it("renders Security Inventory tab pointing at the secrets-inventory worker, opens in new tab", () => {
+    const html = renderTabs("dashboard");
+    expect(html).toContain('href="https://security-inventory.ippoan.org/"');
+    expect(html).toContain("🔍 Security Inventory");
+    expect(html).toMatch(
+      /href="https:\/\/security-inventory\.ippoan\.org\/"[^>]*target="_blank"[^>]*rel="noopener"/,
+    );
+  });
+
   it("never marks an external tab as active even if its key string is passed in (defensive)", () => {
     // Internal tabs are typed via TabKey, but a future contributor could
     // widen the type by mistake — make sure external tabs stay plain.
     const html = renderTabs("dashboard");
     expect(html).not.toMatch(/tab tab-active[^>]*>\s*🛡️ Branch Protection/);
     expect(html).not.toMatch(/tab tab-active[^>]*>\s*🗝️ GCP Secrets/);
+    expect(html).not.toMatch(/tab tab-active[^>]*>\s*🔍 Security Inventory/);
   });
 });


### PR DESCRIPTION
## 概要

Security Inventory タブを外部タブとしてナビゲーションに追加します。このタブは security-inventory.ippoan.org を指し、新しいタブで開きます。

## 関連 issue

Refs #

## 変更点

- `src/nav-tabs.ts`: 
  - `TabKey` 型に `"security-inventory"` を追加
  - `TABS` 配列に Security Inventory タブの定義を追加（🔍 Security Inventory ラベル、外部タブ）

- `test/nav-tabs.test.ts`:
  - Security Inventory タブが正しくレンダリングされることを確認するテストを追加
  - 外部タブが active マークされないことを確認するテストに Security Inventory を追加

## 動作確認

- [x] `npm test` — 新規テストを含むすべてのテストが成功
- [x] `npm run typecheck` — 型チェック成功

## メモ

外部タブの実装パターンに従い、既存の Branch Protection・GCP Secrets タブと同じ方式で実装しています。

https://claude.ai/code/session_013BpQgMWCvEw9KiVad8mS5E