### PR TITLE
Add Claude Code launch button to issues page

### DIFF
--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -17,6 +17,44 @@ const YHONDA_REPOS = ["yhonda-ohishi/claude-skills", "yhonda-ohishi/claude-hooks
 // board, even though only a subset of their repos surface as issues here.
 const PROJECT_ORGS = ["ippoan", "ohishi-exp", "yhonda-ohishi"];
 
+// Repos pre-attached when launching a Claude Code on Web session from an
+// issue row's 🚀 button. Mirrors the GitHub MCP scope a typical web session
+// runs with (cross-repo tasks routinely need consumers / shared hooks beyond
+// the issue's own repo — see open-multirepo skill "Default repo set").
+// Update in sync with the session install template if the scope changes.
+export const CLAUDE_CODE_LAUNCH_REPOS = [
+  "ippoan/auth-worker",
+  "ippoan/mcp-relay-rs",
+  "ippoan/ref-files-worker",
+  "ippoan/cc-relay",
+  "ippoan/ci-workflows",
+  "ippoan/claude-md",
+  "ippoan/ci-dashboard",
+  "ippoan/secrets-inventory",
+  "ippoan/secrets-inventory-gcp",
+  "yhonda-ohishi/claude-skills",
+  "yhonda-ohishi/claude-hooks",
+];
+
+// Build a claude.ai/code launch URL pre-attached with the standard repo set
+// and a minimal `<owner>/<repo>#<N> を read して処理` prompt. Spec lives in
+// the issue body — the prompt only carries the ref (open-multirepo "prompt
+// body MUST stay minimal" rule).
+export function buildClaudeCodeLaunchUrl(repo: string, issueNumber: number): string {
+  const prompt = `${repo}#${issueNumber} を read して処理`;
+  // encodeURIComponent leaves `!*'()` per RFC3986. They're harmless inside
+  // an HTML href attribute, but encoding them keeps the URL safe if it's
+  // ever copy-pasted into Markdown (where `)` would terminate a link).
+  const encoded = encodeURIComponent(prompt)
+    .replace(/!/g, "%21")
+    .replace(/\*/g, "%2A")
+    .replace(/'/g, "%27")
+    .replace(/\(/g, "%28")
+    .replace(/\)/g, "%29");
+  // claude.ai/code accepts raw `,` between repos — do NOT URL-encode commas.
+  return `https://claude.ai/code?repositories=${CLAUDE_CODE_LAUNCH_REPOS.join(",")}&prompt=${encoded}`;
+}
+
 // KV cache for the cross-org Project v2 → issue map. GraphQL fan-out is
 // expensive (one call per open project × per org) and its 5000 points/h budget
 // is easy to exhaust when the dashboard's MCP tools share the same token. A
@@ -259,6 +297,18 @@ function renderHtml(
       font-variant-numeric: tabular-nums;
       white-space: nowrap;
     }
+    td.launch { width: 44px; text-align: center; }
+    .cc-launch {
+      display: inline-block;
+      text-decoration: none;
+      font-size: 15px;
+      line-height: 1;
+      padding: 4px 6px;
+      border-radius: 6px;
+      opacity: 0.55;
+      transition: opacity 0.15s, background 0.15s;
+    }
+    .cc-launch:hover { opacity: 1; background: #1f6feb33; }
     .labels { margin-top: 4px; }
     .label {
       display: inline-block;
@@ -321,7 +371,7 @@ function renderProjectSection(
   return `<section class="projects">
   <h2>📋 Project 付き<span class="count">(${items.length})</span></h2>
   <table>
-    <thead><tr><th>#</th><th>Repo</th><th>Title</th><th>Author</th><th>Updated</th></tr></thead>
+    <thead><tr><th>#</th><th>Repo</th><th>Title</th><th>Author</th><th>Updated</th><th></th></tr></thead>
     <tbody>${rows}</tbody>
   </table>
 </section>`;
@@ -341,6 +391,7 @@ function renderProjectRow(i: OrgIssue, projects: ReadonlyArray<ProjectRef>): str
     <td class="title"><a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">${escapeHtml(i.title)}</a><div class="labels">${chips}</div>${labelChips}</td>
     <td class="author">@${escapeHtml(i.author)}</td>
     <td class="updated">${escapeHtml(i.updated_at.slice(0, 10))}</td>
+    ${renderLaunchCell(i)}
   </tr>`;
 }
 
@@ -350,7 +401,7 @@ function renderRepoSection(repo: string, items: OrgIssue[]): string {
   return `<section class="repo">
   <h2><a href="${escapeHtml(repoUrl)}" target="_blank" rel="noopener">${escapeHtml(repo)}</a><span class="count">(${items.length})</span></h2>
   <table>
-    <thead><tr><th>#</th><th>Title</th><th>Author</th><th>Updated</th></tr></thead>
+    <thead><tr><th>#</th><th>Title</th><th>Author</th><th>Updated</th><th></th></tr></thead>
     <tbody>${rows}</tbody>
   </table>
 </section>`;
@@ -366,7 +417,13 @@ function renderRow(i: OrgIssue): string {
     <td class="title"><a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">${escapeHtml(i.title)}</a>${labelChips}</td>
     <td class="author">@${escapeHtml(i.author)}</td>
     <td class="updated">${escapeHtml(i.updated_at.slice(0, 10))}</td>
+    ${renderLaunchCell(i)}
   </tr>`;
+}
+
+function renderLaunchCell(i: OrgIssue): string {
+  const url = buildClaudeCodeLaunchUrl(i.repo, i.number);
+  return `<td class="launch"><a class="cc-launch" href="${escapeHtml(url)}" target="_blank" rel="noopener" title="Claude Code で起動 (${escapeHtml(i.repo)}#${i.number})">🚀</a></td>`;
 }
 
 function renderError(msg: string): string {

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -2,7 +2,7 @@ import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import worker from "../src/index";
 import type { Env } from "../src/index";
-import { escapeHtml } from "../src/issues-page";
+import { escapeHtml, buildClaudeCodeLaunchUrl, CLAUDE_CODE_LAUNCH_REPOS } from "../src/issues-page";
 
 function testEnv(): Env {
   return {
@@ -409,6 +409,81 @@ describe("GET /issues — Project section", () => {
     expect(sec).toContain("Board B");
     const chipMatches = sec.match(/project-chip/g) ?? [];
     expect(chipMatches.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("buildClaudeCodeLaunchUrl()", () => {
+  it("returns claude.ai/code URL pre-attached with the standard repo set and an issue-ref prompt", () => {
+    const url = buildClaudeCodeLaunchUrl("ippoan/auth-worker", 130);
+    expect(url.startsWith("https://claude.ai/code?")).toBe(true);
+    // repositories= must be raw comma-separated (claude.ai/code accepts `,`)
+    expect(url).toContain(`repositories=${CLAUDE_CODE_LAUNCH_REPOS.join(",")}`);
+    // prompt is URL-encoded; decode and verify it references the issue.
+    const params = new URL(url).searchParams;
+    expect(params.get("prompt")).toBe("ippoan/auth-worker#130 を read して処理");
+  });
+
+  it("encodes `()'!*` so the URL is safe in Markdown link syntax", () => {
+    // We rely on `encodeURIComponent` for most chars; the helper adds an
+    // extra pass for `!*'()` which encodeURIComponent leaves untouched.
+    // Use a number — parens come from the prompt's static text, not the
+    // arguments, so we verify by injecting via the repo string.
+    const url = buildClaudeCodeLaunchUrl("ippoan/foo(bar)", 1);
+    expect(url).not.toMatch(/[()'!*]/);
+    expect(url).toContain("foo%28bar%29");
+  });
+
+  it("preserves commas between repositories (not URL-encoded)", () => {
+    const url = buildClaudeCodeLaunchUrl("ippoan/ci-dashboard", 42);
+    const reposPart = url.split("repositories=")[1]!.split("&")[0]!;
+    expect(reposPart.includes(",")).toBe(true);
+    expect(reposPart).not.toContain("%2C");
+  });
+});
+
+describe("GET /issues — Claude Code launch button", () => {
+  beforeEach(async () => {
+    await env.CI_STATUS.delete("issues-page:project-map");
+  });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("renders a 🚀 launch link per issue row pointing at claude.ai/code", async () => {
+    stubFetch();
+    const req = new Request("http://localhost/issues");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    const html = await res.text();
+    // Each rendered issue gets one cc-launch anchor. With the default stub
+    // we have 3 issues total (#7, #3, and the claude-skills #1), all in
+    // per-repo sections (no project map seeded).
+    const launchAnchors = html.match(/<a class="cc-launch"/g) ?? [];
+    expect(launchAnchors.length).toBe(3);
+    // URL contains the expected issue-specific prompt.
+    expect(html).toContain(
+      `href="${escapeHtml(buildClaudeCodeLaunchUrl("ippoan/rust-alc-api", 7))}"`,
+    );
+    // Opens in a new tab.
+    expect(html).toContain('target="_blank"');
+  });
+
+  it("renders a launch link in the Project section too", async () => {
+    stubFetch({ withProjects: true });
+    const req = new Request("http://localhost/issues");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    const html = await res.text();
+    const projectSection = html.match(
+      /<section class="projects">[\s\S]*?<\/section>/,
+    );
+    expect(projectSection).not.toBeNull();
+    expect(projectSection![0]).toContain('<a class="cc-launch"');
+    expect(projectSection![0]).toContain(
+      escapeHtml(buildClaudeCodeLaunchUrl("ippoan/rust-alc-api", 7)),
+    );
   });
 });
 


### PR DESCRIPTION
## 概要

Issues ページの各 issue 行に 🚀 ボタンを追加し、Claude Code on Web を起動できるようにしました。ボタンをクリックすると、標準リポジトリセットが事前アタッチされた claude.ai/code が開きます。

## 関連 issue

Refs #

## 変更点

- `buildClaudeCodeLaunchUrl()` 関数を追加：リポジトリと issue 番号から claude.ai/code の起動 URL を生成
- `CLAUDE_CODE_LAUNCH_REPOS` 定数を追加：Claude Code セッションで事前アタッチするリポジトリリスト（GitHub MCP スコープと同期）
- issue 行に `renderLaunchCell()` で 🚀 ボタンを追加（Project セクション、リポジトリセクション両対応）
- URL エンコーディング：Markdown リンク構文で安全なように `!*'()` を追加エンコード
- CSS スタイル追加：`.cc-launch` ボタンのホバーエフェクト、レイアウト調整

## 動作確認

- [x] `npm test` — 新規テスト 3 つ追加（`buildClaudeCodeLaunchUrl()` の URL 生成、エンコーディング、Markdown 安全性）、既存テスト 2 つ追加（Project セクション、リポジトリセクションでのボタン表示確認）
- [x] `npm run typecheck`

## メモ

- `CLAUDE_CODE_LAUNCH_REPOS` はセッションインストールテンプレートと同期が必要
- prompt は `<owner>/<repo>#<N> を read して処理` の最小形式（詳細は issue body に記載）
- URL の commas は URL エンコードしない（claude.ai/code の仕様）

https://claude.ai/code/session_01VEuFutJQLGPvkyc2YyHbsA