### PR TITLE
infra: Set up staging environment for ci-dashboard Worker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,9 @@ jobs:
   ci:
     uses: ippoan/ci-workflows/.github/workflows/frontend-ci.yml@main
     with:
+      project_type: 'worker'
       install_command: 'npm install'
       typecheck_command: 'npx tsc --noEmit'
-      has_staging_deploy: false
+      deploy_staging_script: 'npx wrangler deploy --env staging'
       deploy_release_script: 'npx wrangler deploy'
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -84,15 +84,29 @@ npm run test:coverage
 npm run typecheck    # tsc --noEmit
 ```
 
+## 環境構成
+
+**staging が実運用環境**。本番リリースタグ (`v*`) は将来用に予約してあるが、
+当面は staging deploy だけを使う (secrets-inventory と同じ運用)。
+
+| env | name | trigger | route |
+|---|---|---|---|
+| staging (live) | `ci-dashboard-staging` | PR (non-draft) / main push | `workers.dev` |
+| production | `ci-dashboard` | `v*` tag push | (未割当) |
+
+PR を上げると `frontend-ci.yml` 経由で staging に auto-deploy される。
+
 ## デプロイ
 
 ```bash
-npm run deploy       # wrangler deploy
+npm run deploy                       # production (top-level, 予約) に手動 deploy
+npx wrangler deploy --env staging    # staging に手動 deploy
 ```
 
-GitHub PAT は wrangler secret に登録:
+GitHub PAT は wrangler secret に登録 (staging / production それぞれ):
 
 ```bash
+wrangler secret put GITHUB_TOKEN --env staging
 wrangler secret put GITHUB_TOKEN
 ```
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -34,5 +34,40 @@
       "tag": "v1",
       "new_sqlite_classes": ["CIDashboardHub"]
     }
-  ]
+  ],
+  // staging を実運用 env として扱う (secrets-inventory と同じパターン)。
+  // PR push 毎に `ci-dashboard-staging` Worker に auto-deploy され、`v*` tag の
+  // production (top-level `ci-dashboard`) は将来用に予約。top-level 設定は
+  // `wrangler dev` 用に残してある。
+  "env": {
+    "staging": {
+      "name": "ci-dashboard-staging",
+      "account_id": "24b45709d060d957340180e995f0d373",
+      "workers_dev": true,
+      "observability": { "enabled": true },
+      "vars": {
+        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp"
+      },
+      "kv_namespaces": [
+        {
+          "binding": "CI_STATUS",
+          "id": "ffb983ee8324499f915b11a0b8cf787b"
+        }
+      ],
+      "durable_objects": {
+        "bindings": [
+          {
+            "name": "CI_HUB",
+            "class_name": "CIDashboardHub"
+          }
+        ]
+      },
+      "migrations": [
+        {
+          "tag": "v1",
+          "new_sqlite_classes": ["CIDashboardHub"]
+        }
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## 概要

ci-dashboard Worker に staging 環境を追加し、PR push 時に自動デプロイされるよう設定。secrets-inventory と同じ運用パターンを採用し、staging を実運用環境として扱う。

## 関連 issue

Refs #

## 変更点

- **wrangler.jsonc**: staging 環境設定を追加
  - Worker 名: `ci-dashboard-staging`
  - KV namespace (`CI_STATUS`) と Durable Objects (`CIDashboardHub`) をバインド
  - SQLite migration (`v1`) を設定
  - 環境変数 `TAGLESS_REPOS` を定義

- **README.md**: 環境構成と デプロイ手順を文書化
  - staging (実運用) / production (将来用) の役割分担を明記
  - GitHub PAT 登録時に `--env staging` オプションが必要なことを記載

- **.github/workflows/test.yml**: CI/CD ワークフロー設定を更新
  - `project_type: 'worker'` を追加
  - `has_staging_deploy: false` → `deploy_staging_script: 'npx wrangler deploy --env staging'` に変更
  - PR push 時に staging への自動デプロイが実行されるよう設定

## 動作確認

- [x] `npm test`
- [x] `npm run typecheck`
- [ ] 手動確認: PR push 時に `frontend-ci.yml` 経由で staging への自動デプロイが実行されることを確認

## メモ

- production (top-level) は `v*` tag push 時のデプロイ用に予約。当面は staging deploy のみを使用
- secrets-inventory と同じ運用パターンを採用しているため、既存の secrets 管理フローに統一

https://claude.ai/code/session_012mxs3n5RqpNciymgudn3TR