### PR TITLE
infra: point ci-dashboard.ippoan.org custom domain at staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ npm run typecheck    # tsc --noEmit
 
 | env | name | trigger | route |
 |---|---|---|---|
-| staging (live) | `ci-dashboard-staging` | PR (non-draft) / main push | `workers.dev` |
+| staging (live) | `ci-dashboard-staging` | PR (non-draft) / main push | `ci-dashboard.ippoan.org` (Custom Domain) + `workers.dev` |
 | production | `ci-dashboard` | `v*` tag push | (未割当) |
 
 PR を上げると `frontend-ci.yml` 経由で staging に auto-deploy される。

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -45,6 +45,17 @@
       "account_id": "24b45709d060d957340180e995f0d373",
       "workers_dev": true,
       "observability": { "enabled": true },
+      // `ci-dashboard.ippoan.org` を staging 側に向ける。元々 production
+      // Worker (`ci-dashboard`) に Custom Domain として付いていたが、本 repo
+      // は staging-only 運用に切替えたため staging 側にバインドする。初回
+      // deploy 時は既存 production binding と衝突するので、事前に Cloudflare
+      // dashboard で production 側から hostname を外しておくこと。
+      "routes": [
+        {
+          "pattern": "ci-dashboard.ippoan.org",
+          "custom_domain": true
+        }
+      ],
       "vars": {
         "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp"
       },


### PR DESCRIPTION
## 概要

PR #105 で staging-only 運用に切り替えた続き。Custom Domain `ci-dashboard.ippoan.org` を staging Worker (`ci-dashboard-staging`) にバインドする。

前段で旧 production Worker `ci-dashboard` は手動で削除済みなので、衝突なく付け替わる想定。

## 変更点

- `wrangler.jsonc`: `env.staging.routes` に `ci-dashboard.ippoan.org` を Custom Domain として追加
- `README.md`: 環境表の staging route 欄を更新

## 動作確認

- [ ] CI Deploy Staging で route assign が log に出る
- [ ] `curl https://ci-dashboard.ippoan.org/` が CF Access へリダイレクトする (元 production と同じ)

Refs #


---
_Generated by [Claude Code](https://claude.ai/code/session_012mxs3n5RqpNciymgudn3TR)_