### PR TITLE
infra: add ci-dashboard itself to TAGLESS_REPOS

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,7 +13,7 @@
     // mini-release: it scans the merged PR for `Refs #N` and surfaces any still-
     // open issues on the dashboard banner + /releases synthetic blocks. Repos
     // not listed here keep the original tag-driven flow.
-    "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp"
+    "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard"
   },
   "kv_namespaces": [
     {
@@ -57,7 +57,7 @@
         }
       ],
       "vars": {
-        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp"
+        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard"
       },
       "kv_namespaces": [
         {


### PR DESCRIPTION
## 概要

PR #105 / #106 で ci-dashboard を staging-only 運用に切替え、`v*` tag を将来用に予約状態とした (= 当面 tag を切らない)。これに伴い、ダッシュボードが自分の PR merge を mini-release として扱えるよう、`ippoan/ci-dashboard` を `TAGLESS_REPOS` env var に追加する。

## 変更点

- `wrangler.jsonc` top-level / `env.staging` 両方の `TAGLESS_REPOS` に `ippoan/ci-dashboard` を追加

## 動作確認

- [x] dry-run で binding が解決されること
- [ ] CI deploy 後、ダッシュボード上で ci-dashboard の release セクションが tagless 表示 (PR merge 単位) に切り替わること

Refs #109


---
_Generated by [Claude Code](https://claude.ai/code/session_012mxs3n5RqpNciymgudn3TR)_