### PR TITLE
feat(issues): show related open PRs on each issue row (Refs #107)

### DIFF
--- a/src/issue-prs.ts
+++ b/src/issue-prs.ts
@@ -1,0 +1,132 @@
+import { githubApi, validateOrg } from "./github-api";
+
+/** Lightweight PR descriptor used by the issues page to render "related PR"
+ *  chips. Body is intentionally not retained — it's only used to extract
+ *  issue refs and would balloon the KV-cached payload. */
+export interface IssuePrRef {
+  repo: string;
+  number: number;
+  title: string;
+  url: string;
+  draft: boolean;
+  updated_at: string;
+}
+
+// Matches "<keyword> [owner/repo]#N" where <keyword> is one of the GitHub
+// linking keywords. We also accept the non-closing forms from this repo's
+// CLAUDE.md convention (Refs / Related to / Part of). The optional
+// `owner/repo` prefix lets PR bodies reference issues in *other* repos.
+const ISSUE_REF_PATTERN =
+  /\b(?:refs?|closes?|closed|close[sd]?|fix(?:es|ed)?|resolves?|resolved|related\s+to|part\s+of)\b[:\s]+([\w.-]+\/[\w.-]+)?#(\d+)/gi;
+
+// Bare GitHub issue URL — matches "https://github.com/owner/repo/issues/N"
+// embedded anywhere in the PR body / title.
+const ISSUE_URL_PATTERN =
+  /https?:\/\/github\.com\/([\w.-]+\/[\w.-]+)\/issues\/(\d+)/gi;
+
+/** Extract every `owner/repo#N` issue ref mentioned in `text`. `prRepo` is the
+ *  repository the PR itself lives in — used to qualify bare `#N` refs (which
+ *  GitHub interprets as same-repo). */
+export function extractIssueRefs(prRepo: string, text: string): Set<string> {
+  const refs = new Set<string>();
+  for (const m of text.matchAll(ISSUE_REF_PATTERN)) {
+    const ownerRepo = m[1] || prRepo;
+    refs.add(`${ownerRepo}#${m[2]}`);
+  }
+  for (const m of text.matchAll(ISSUE_URL_PATTERN)) {
+    refs.add(`${m[1]}#${m[2]}`);
+  }
+  return refs;
+}
+
+interface SearchPrItem {
+  number: number;
+  title: string;
+  state: string;
+  body: string | null;
+  html_url: string;
+  repository_url: string;
+  draft?: boolean;
+  updated_at: string;
+  pull_request?: unknown;
+}
+
+interface SearchPrsResponse {
+  total_count: number;
+  incomplete_results: boolean;
+  items: SearchPrItem[];
+}
+
+/** Single GitHub search call for open PRs. Pass `orgs` for `org:` qualifiers
+ *  or `repos` for `repo:` qualifiers (mutually exclusive — GitHub silently
+ *  drops `repo:` when combined with `org:`, mirroring fetchOrgIssues). */
+export async function fetchOpenPrsByIssue(
+  token: string,
+  params: { orgs?: string[]; repos?: string[]; per_page?: number },
+): Promise<Map<string, IssuePrRef[]>> {
+  const { orgs = [], repos = [], per_page = 100 } = params;
+  for (const o of orgs) validateOrg(o);
+  for (const r of repos) validateOrg(r.split("/")[0]!);
+
+  const parts: string[] = ["is:pr", "state:open", "archived:false"];
+  if (repos.length > 0) {
+    for (const r of repos) parts.push(`repo:${r}`);
+  } else {
+    for (const o of orgs) parts.push(`org:${o}`);
+  }
+  const q = parts.join(" ");
+
+  const data = await githubApi<SearchPrsResponse>(
+    token, "GET", "/search/issues", undefined,
+    { q, per_page: String(per_page) },
+  );
+
+  const map = new Map<string, IssuePrRef[]>();
+  for (const pr of data.items) {
+    const repo = pr.repository_url.split("/").slice(-2).join("/");
+    const text = `${pr.title}\n${pr.body ?? ""}`;
+    const refs = extractIssueRefs(repo, text);
+    if (refs.size === 0) continue;
+    const ref: IssuePrRef = {
+      repo,
+      number: pr.number,
+      title: pr.title,
+      url: pr.html_url,
+      draft: pr.draft ?? false,
+      updated_at: pr.updated_at,
+    };
+    for (const key of refs) {
+      const existing = map.get(key);
+      if (existing) existing.push(ref);
+      else map.set(key, [ref]);
+    }
+  }
+  return map;
+}
+
+/** Fetch and merge open-PR → issue maps across the two search shapes the
+ *  issues page uses (main orgs + yhonda `repo:` filter). Mirrors the parallel
+ *  pattern in issues-page.ts so a partial failure aborts the whole call. */
+export async function fetchAllOpenPrsByIssue(
+  token: string,
+  mainOrgs: string[],
+  yhondaRepos: string[],
+): Promise<Map<string, IssuePrRef[]>> {
+  const [main, yhonda] = await Promise.all([
+    fetchOpenPrsByIssue(token, { orgs: mainOrgs }),
+    yhondaRepos.length > 0
+      ? fetchOpenPrsByIssue(token, { repos: yhondaRepos })
+      : Promise.resolve(new Map<string, IssuePrRef[]>()),
+  ]);
+  const merged = new Map<string, IssuePrRef[]>(main);
+  for (const [k, prs] of yhonda) {
+    const existing = merged.get(k);
+    if (existing) existing.push(...prs);
+    else merged.set(k, prs);
+  }
+  // Sort each list by recency so the most-recently-updated PR renders first.
+  for (const prs of merged.values()) {
+    prs.sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+  }
+  return merged;
+}

--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -1,5 +1,6 @@
 import { fetchOrgIssues, type OrgIssue } from "./mcp/tools/issues";
 import { fetchProjectIssueMap, type ProjectRef } from "./mcp/tools/projects";
+import { fetchAllOpenPrsByIssue, type IssuePrRef } from "./issue-prs";
 import { renderTabs, TAB_STYLES } from "./nav-tabs";
 import { PWA_HEAD_TAGS, PWA_REGISTER_SCRIPT } from "./pwa";
 
@@ -102,6 +103,53 @@ async function loadProjectMap(
   }
 }
 
+// PR map cache mirrors the project-map cache pattern. The freshness window is
+// shorter (2 min) because PR state churns faster than Project board edits — a
+// new PR opened minutes ago should appear without forcing a manual reload —
+// but the 24 h store window keeps a stale copy as fallback when GitHub search
+// rate-limits the worker.
+const PR_MAP_CACHE_KEY = "issues-page:pr-map";
+const PR_MAP_FRESH_SECONDS = 120;
+const PR_MAP_STORE_SECONDS = 86400;
+
+interface PrMapCacheEntry {
+  storedAt: number;
+  data: Record<string, IssuePrRef[]>;
+}
+
+interface PrMapResult {
+  map: Map<string, IssuePrRef[]>;
+  stale: boolean;
+  error: string | null;
+}
+
+async function loadPrMap(
+  kv: KVNamespace,
+  token: string,
+  mainOrgs: string[],
+  yhondaRepos: string[],
+): Promise<PrMapResult> {
+  const cached = await kv.get(PR_MAP_CACHE_KEY, "json") as PrMapCacheEntry | null;
+  const now = Date.now();
+  if (cached && now - cached.storedAt < PR_MAP_FRESH_SECONDS * 1000) {
+    return { map: new Map(Object.entries(cached.data)), stale: false, error: null };
+  }
+  try {
+    const fresh = await fetchAllOpenPrsByIssue(token, mainOrgs, yhondaRepos);
+    const entry: PrMapCacheEntry = { storedAt: now, data: Object.fromEntries(fresh) };
+    await kv.put(PR_MAP_CACHE_KEY, JSON.stringify(entry), {
+      expirationTtl: PR_MAP_STORE_SECONDS,
+    });
+    return { map: fresh, stale: false, error: null };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (cached) {
+      return { map: new Map(Object.entries(cached.data)), stale: true, error: message };
+    }
+    return { map: new Map(), stale: false, error: message };
+  }
+}
+
 export async function handleIssuesPage(
   env: { GITHUB_TOKEN: string; CI_STATUS: KVNamespace },
 ): Promise<Response> {
@@ -136,8 +184,12 @@ export async function handleIssuesPage(
     });
   }
 
-  const project = await loadProjectMap(env.CI_STATUS, env.GITHUB_TOKEN, PROJECT_ORGS);
+  const [project, prs] = await Promise.all([
+    loadProjectMap(env.CI_STATUS, env.GITHUB_TOKEN, PROJECT_ORGS),
+    loadPrMap(env.CI_STATUS, env.GITHUB_TOKEN, ORGS, YHONDA_REPOS),
+  ]);
   const projectMap = project.map;
+  const prMap = prs.map;
 
   // Split issues into "Project-tagged" (top aggregate section) and
   // "ungrouped per-repo" (bottom sections). An issue belongs to the project
@@ -167,7 +219,7 @@ export async function handleIssuesPage(
     ] as const);
 
   return new Response(
-    renderHtml(merged.total_count, merged.incomplete, projectTagged, repos, project),
+    renderHtml(merged.total_count, merged.incomplete, projectTagged, repos, project, prs),
     { headers: { "Content-Type": "text/html; charset=utf-8" } },
   );
 }
@@ -178,13 +230,14 @@ function renderHtml(
   projectTagged: ReadonlyArray<{ issue: OrgIssue; projects: ProjectRef[] }>,
   repos: ReadonlyArray<readonly [string, OrgIssue[]]>,
   project: ProjectMapResult,
+  prs: PrMapResult,
 ): string {
   const repoSections = repos
-    .map(([repo, items]) => renderRepoSection(repo, items))
+    .map(([repo, items]) => renderRepoSection(repo, items, prs.map))
     .join("\n");
 
   const projectSection = projectTagged.length > 0
-    ? renderProjectSection(projectTagged)
+    ? renderProjectSection(projectTagged, prs.map)
     : "";
 
   const incompleteBanner = incomplete
@@ -194,6 +247,11 @@ function renderHtml(
     ? `<div class="banner banner-info">📋 Project tags shown are from the last successful sync — fresh fetch failed (${escapeHtml(project.error ?? "")})</div>`
     : project.error
     ? `<div class="banner">⚠️ Project tags unavailable: ${escapeHtml(project.error)}</div>`
+    : "";
+  const prBanner = prs.stale
+    ? `<div class="banner banner-info">🔗 Related-PR links shown are from the last successful sync — fresh fetch failed (${escapeHtml(prs.error ?? "")})</div>`
+    : prs.error
+    ? `<div class="banner">⚠️ Related-PR links unavailable: ${escapeHtml(prs.error)}</div>`
     : "";
 
   return `<!DOCTYPE html>
@@ -334,6 +392,31 @@ function renderHtml(
       text-decoration: none;
     }
     .project-chip:hover { background: #1f6feb66; }
+    /* Related-PR chips: green palette so they read as "in-flight work" vs.
+       the blue project-chip's "belongs to a board" affordance. Draft PRs
+       desaturate to gray so the reader can tell at a glance whether the PR
+       is review-ready. */
+    .pr-chips { margin-top: 4px; }
+    .pr-chip {
+      display: inline-block;
+      font-size: 11px;
+      padding: 1px 8px;
+      border-radius: 10px;
+      background: #2ea04322;
+      color: #7ee787;
+      border: 1px solid #2ea04388;
+      margin-right: 4px;
+      margin-bottom: 2px;
+      text-decoration: none;
+      font-variant-numeric: tabular-nums;
+    }
+    .pr-chip:hover { background: #2ea04344; }
+    .pr-chip.draft {
+      background: #6e768122;
+      color: #8b949e;
+      border-color: #6e768188;
+    }
+    .pr-chip.draft:hover { background: #6e768144; }
     .empty {
       padding: 32px;
       text-align: center;
@@ -355,6 +438,7 @@ function renderHtml(
   </header>
   ${incompleteBanner}
   ${projectBanner}
+  ${prBanner}
   ${projectSection}
   ${repos.length === 0 && projectTagged.length === 0
     ? `<div class="empty">🎉 No open issues. Nice work.</div>`
@@ -366,8 +450,10 @@ function renderHtml(
 
 function renderProjectSection(
   items: ReadonlyArray<{ issue: OrgIssue; projects: ProjectRef[] }>,
+  prMap: ReadonlyMap<string, IssuePrRef[]>,
 ): string {
-  const rows = items.map(({ issue, projects }) => renderProjectRow(issue, projects)).join("\n");
+  const rows = items.map(({ issue, projects }) =>
+    renderProjectRow(issue, projects, prMap)).join("\n");
   return `<section class="projects">
   <h2>📋 Project 付き<span class="count">(${items.length})</span></h2>
   <table>
@@ -377,7 +463,11 @@ function renderProjectSection(
 </section>`;
 }
 
-function renderProjectRow(i: OrgIssue, projects: ReadonlyArray<ProjectRef>): string {
+function renderProjectRow(
+  i: OrgIssue,
+  projects: ReadonlyArray<ProjectRef>,
+  prMap: ReadonlyMap<string, IssuePrRef[]>,
+): string {
   const chips = projects.map((p) =>
     `<a class="project-chip" href="${escapeHtml(p.url)}" target="_blank" rel="noopener">${escapeHtml(p.title)}</a>`,
   ).join("");
@@ -388,15 +478,19 @@ function renderProjectRow(i: OrgIssue, projects: ReadonlyArray<ProjectRef>): str
   return `<tr>
     <td class="num"><a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">#${i.number}</a></td>
     <td class="repo"><a href="https://github.com/${escapeHtml(i.repo)}/issues" target="_blank" rel="noopener">${escapeHtml(i.repo)}</a></td>
-    <td class="title"><a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">${escapeHtml(i.title)}</a><div class="labels">${chips}</div>${labelChips}</td>
+    <td class="title"><a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">${escapeHtml(i.title)}</a><div class="labels">${chips}</div>${labelChips}${renderPrChips(i, prMap)}</td>
     <td class="author">@${escapeHtml(i.author)}</td>
     <td class="updated">${escapeHtml(i.updated_at.slice(0, 10))}</td>
     ${renderLaunchCell(i)}
   </tr>`;
 }
 
-function renderRepoSection(repo: string, items: OrgIssue[]): string {
-  const rows = items.map((i) => renderRow(i)).join("\n");
+function renderRepoSection(
+  repo: string,
+  items: OrgIssue[],
+  prMap: ReadonlyMap<string, IssuePrRef[]>,
+): string {
+  const rows = items.map((i) => renderRow(i, prMap)).join("\n");
   const repoUrl = `https://github.com/${repo}/issues`;
   return `<section class="repo">
   <h2><a href="${escapeHtml(repoUrl)}" target="_blank" rel="noopener">${escapeHtml(repo)}</a><span class="count">(${items.length})</span></h2>
@@ -407,18 +501,36 @@ function renderRepoSection(repo: string, items: OrgIssue[]): string {
 </section>`;
 }
 
-function renderRow(i: OrgIssue): string {
+function renderRow(
+  i: OrgIssue,
+  prMap: ReadonlyMap<string, IssuePrRef[]>,
+): string {
   const labelChips = i.labels.length > 0
     ? `<div class="labels">${i.labels.map((l) =>
         `<span class="label">${escapeHtml(l)}</span>`).join("")}</div>`
     : "";
   return `<tr>
     <td class="num"><a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">#${i.number}</a></td>
-    <td class="title"><a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">${escapeHtml(i.title)}</a>${labelChips}</td>
+    <td class="title"><a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">${escapeHtml(i.title)}</a>${labelChips}${renderPrChips(i, prMap)}</td>
     <td class="author">@${escapeHtml(i.author)}</td>
     <td class="updated">${escapeHtml(i.updated_at.slice(0, 10))}</td>
     ${renderLaunchCell(i)}
   </tr>`;
+}
+
+function renderPrChips(
+  i: OrgIssue,
+  prMap: ReadonlyMap<string, IssuePrRef[]>,
+): string {
+  const refs = prMap.get(`${i.repo}#${i.number}`);
+  if (!refs || refs.length === 0) return "";
+  const chips = refs.map((p) => {
+    const draft = p.draft ? " draft" : "";
+    const label = p.draft ? "Draft PR" : "PR";
+    const title = `${label} #${p.number}: ${p.title}${p.repo === i.repo ? "" : ` (${p.repo})`}`;
+    return `<a class="pr-chip${draft}" href="${escapeHtml(p.url)}" target="_blank" rel="noopener" title="${escapeHtml(title)}">🔗 #${p.number}${p.draft ? " (draft)" : ""}</a>`;
+  }).join("");
+  return `<div class="pr-chips">${chips}</div>`;
 }
 
 function renderLaunchCell(i: OrgIssue): string {

--- a/test/issue-prs.test.ts
+++ b/test/issue-prs.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { extractIssueRefs, fetchOpenPrsByIssue, fetchAllOpenPrsByIssue } from "../src/issue-prs";
+
+describe("extractIssueRefs()", () => {
+  it("extracts bare `#N` refs qualified with the PR's own repo", () => {
+    const refs = extractIssueRefs("ippoan/rust-alc-api", "Refs #123\nFixes #45");
+    expect([...refs]).toEqual(
+      expect.arrayContaining([
+        "ippoan/rust-alc-api#123",
+        "ippoan/rust-alc-api#45",
+      ]),
+    );
+  });
+
+  it("extracts cross-repo `owner/repo#N` refs", () => {
+    const refs = extractIssueRefs(
+      "ippoan/ci-dashboard",
+      "Part of ippoan/auth-worker#7",
+    );
+    expect(refs.has("ippoan/auth-worker#7")).toBe(true);
+  });
+
+  it("extracts GitHub issue URLs", () => {
+    const refs = extractIssueRefs(
+      "ippoan/foo",
+      "See https://github.com/ippoan/bar/issues/42 for context",
+    );
+    expect(refs.has("ippoan/bar#42")).toBe(true);
+  });
+
+  it("supports all the keywords from CLAUDE.md (Refs / Related to / Part of) and the closing keywords", () => {
+    const refs = extractIssueRefs(
+      "ippoan/x",
+      "Closes #1\nFixes #2\nResolves #3\nRefs #4\nRelated to #5\nPart of #6",
+    );
+    expect(refs.size).toBe(6);
+  });
+
+  it("returns empty when no refs are present", () => {
+    const refs = extractIssueRefs("ippoan/x", "This PR fixes a bug.");
+    expect(refs.size).toBe(0);
+  });
+
+  it("is case-insensitive on keywords", () => {
+    const refs = extractIssueRefs("ippoan/x", "REFS #99");
+    expect(refs.has("ippoan/x#99")).toBe(true);
+  });
+});
+
+describe("fetchOpenPrsByIssue()", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("queries /search/issues with `is:pr state:open` and parses refs from body", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        total_count: 2,
+        incomplete_results: false,
+        items: [
+          {
+            number: 10,
+            title: "feat",
+            state: "open",
+            body: "Refs #5",
+            html_url: "https://github.com/ippoan/foo/pull/10",
+            repository_url: "https://api.github.com/repos/ippoan/foo",
+            draft: false,
+            updated_at: "2026-05-11T00:00:00Z",
+            pull_request: {},
+          },
+          {
+            number: 11,
+            title: "chore: no refs",
+            state: "open",
+            body: "Just a cleanup",
+            html_url: "https://github.com/ippoan/foo/pull/11",
+            repository_url: "https://api.github.com/repos/ippoan/foo",
+            draft: false,
+            updated_at: "2026-05-11T00:00:00Z",
+            pull_request: {},
+          },
+        ],
+      }),
+    );
+
+    const map = await fetchOpenPrsByIssue("token", { orgs: ["ippoan"] });
+    expect(spy).toHaveBeenCalledTimes(1);
+    const url = String(spy.mock.calls[0]![0]);
+    const decoded = decodeURIComponent(url);
+    expect(decoded).toContain("is:pr");
+    expect(decoded).toContain("state:open");
+    expect(decoded).toContain("org:ippoan");
+
+    expect(map.size).toBe(1);
+    const refs = map.get("ippoan/foo#5");
+    expect(refs).toBeDefined();
+    expect(refs!).toHaveLength(1);
+    expect(refs![0]!.number).toBe(10);
+    expect(refs![0]!.draft).toBe(false);
+  });
+
+  it("uses repo: qualifiers (and omits org:) when `repos` is set", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({ total_count: 0, incomplete_results: false, items: [] }),
+    );
+    await fetchOpenPrsByIssue("token", {
+      repos: ["yhonda-ohishi/claude-skills", "yhonda-ohishi/claude-hooks"],
+    });
+    const url = String(spy.mock.calls[0]![0]);
+    const decoded = decodeURIComponent(url);
+    expect(decoded).toContain("repo:yhonda-ohishi/claude-skills");
+    expect(decoded).toContain("repo:yhonda-ohishi/claude-hooks");
+    expect(decoded).not.toContain("org:yhonda-ohishi");
+  });
+
+  it("rejects unknown orgs via validateOrg", async () => {
+    await expect(fetchOpenPrsByIssue("token", { orgs: ["evil-org"] }))
+      .rejects.toThrow(/Org not allowed/);
+  });
+});
+
+describe("fetchAllOpenPrsByIssue()", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("merges main-org and yhonda-repos PR maps, appending refs that share a key", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
+      const url = typeof req === "string" ? req : (req as Request).url;
+      const decoded = decodeURIComponent(url);
+      if (decoded.includes("repo:yhonda-ohishi/claude-skills")) {
+        return Response.json({
+          total_count: 1, incomplete_results: false,
+          items: [{
+            number: 99, title: "yhonda fix", state: "open",
+            body: "Refs ippoan/foo#5",
+            html_url: "https://github.com/yhonda-ohishi/claude-skills/pull/99",
+            repository_url: "https://api.github.com/repos/yhonda-ohishi/claude-skills",
+            draft: true,
+            updated_at: "2026-05-12T00:00:00Z",
+            pull_request: {},
+          }],
+        });
+      }
+      return Response.json({
+        total_count: 1, incomplete_results: false,
+        items: [{
+          number: 10, title: "ippoan fix", state: "open",
+          body: "Refs #5",
+          html_url: "https://github.com/ippoan/foo/pull/10",
+          repository_url: "https://api.github.com/repos/ippoan/foo",
+          draft: false,
+          updated_at: "2026-05-11T00:00:00Z",
+          pull_request: {},
+        }],
+      });
+    });
+
+    const map = await fetchAllOpenPrsByIssue(
+      "token", ["ippoan"], ["yhonda-ohishi/claude-skills"],
+    );
+    const refs = map.get("ippoan/foo#5");
+    expect(refs).toBeDefined();
+    expect(refs!).toHaveLength(2);
+    // Sorted by updated_at desc, so the yhonda PR (later) comes first.
+    expect(refs![0]!.number).toBe(99);
+    expect(refs![0]!.draft).toBe(true);
+    expect(refs![1]!.number).toBe(10);
+  });
+});

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -13,17 +13,20 @@ function testEnv(): Env {
   };
 }
 
-// Stub /search/issues + /graphql. The page fires three parallel calls:
-//   - /search/issues with main-org `q` (ippoan + ohishi-exp)
-//   - /search/issues with yhonda-ohishi `repo:` filter
+// Stub /search/issues + /graphql. The page fires parallel calls:
+//   - /search/issues `is:issue` × 2 (main orgs + yhonda repo: filter)
+//   - /search/issues `is:pr`    × 2 (main orgs + yhonda repo: filter,
+//     for the related-PR lookup)
 //   - /graphql for the per-org Projects v2 listing + per-project items
 // We branch on URL + (for GraphQL) on the request body so each call gets the
 // data its handler expects. By default the project map is empty so existing
 // assertions still see the per-repo grouping. Pass `withProjects` to seed a
 // project that maps to `ippoan/rust-alc-api#7` (i.e. the hostile-title issue),
-// which is what the project-section tests below rely on.
-function stubFetch(opts: { withProjects?: boolean } = {}) {
+// which is what the project-section tests below rely on. Pass `withPrs` to
+// seed a PR that references `ippoan/rust-alc-api#7` for the PR-chip tests.
+function stubFetch(opts: { withProjects?: boolean; withPrs?: boolean } = {}) {
   const withProjects = !!opts.withProjects;
+  const withPrs = !!opts.withPrs;
   return vi.spyOn(globalThis, "fetch").mockImplementation(async (req, init) => {
     const url = typeof req === "string" ? req : (req as Request).url;
     // `init.body` is set by `githubGraphQL`; a bare Request also exposes it.
@@ -70,6 +73,39 @@ function stubFetch(opts: { withProjects?: boolean } = {}) {
       return new Response("not stubbed: " + url, { status: 500 });
     }
     const decoded = decodeURIComponent(url);
+
+    // ---- PR search branch (is:pr) ----
+    if (decoded.includes("is:pr")) {
+      if (!withPrs) {
+        return Response.json({ total_count: 0, incomplete_results: false, items: [] });
+      }
+      if (decoded.includes("repo:yhonda-ohishi/claude-skills")) {
+        return Response.json({ total_count: 0, incomplete_results: false, items: [] });
+      }
+      return Response.json({
+        total_count: 1,
+        incomplete_results: false,
+        items: [
+          {
+            number: 42,
+            title: "feat: fix XSS in title rendering",
+            state: "open",
+            body: "Refs #7\n\nPart of the title-escape hardening pass.",
+            user: { login: "yhonda-ohishi" },
+            labels: [],
+            assignees: [],
+            comments: 0,
+            created_at: "2026-05-11T00:00:00Z",
+            updated_at: "2026-05-11T03:00:00Z",
+            html_url: "https://github.com/ippoan/rust-alc-api/pull/42",
+            repository_url: "https://api.github.com/repos/ippoan/rust-alc-api",
+            draft: false,
+            pull_request: { url: "https://api.github.com/..." },
+          },
+        ],
+      });
+    }
+
     if (decoded.includes("repo:yhonda-ohishi/claude-skills")) {
       return Response.json({
         total_count: 1,
@@ -152,6 +188,7 @@ describe("GET /issues", () => {
   // map from a no-project fixture happily masks any subsequent fetch).
   beforeEach(async () => {
     await env.CI_STATUS.delete("issues-page:project-map");
+    await env.CI_STATUS.delete("issues-page:pr-map");
   });
   afterEach(() => { vi.restoreAllMocks(); });
 
@@ -211,16 +248,19 @@ describe("GET /issues", () => {
     await worker.fetch(req, testEnv(), ctx);
     await waitOnExecutionContext(ctx);
 
-    // `/search/issues` is hit exactly twice; the extra `/graphql` calls for
-    // the Projects v2 map are ignored by this assertion.
+    // `/search/issues` is hit four times: 2 for `is:issue` (main orgs +
+    // yhonda repo: filter) + 2 for `is:pr` (related-PR map, same shape).
+    // The extra `/graphql` calls for the Projects v2 map are ignored here.
     const searchCalls = spy.mock.calls.filter((c) =>
       String(c[0]).includes("/search/issues"));
-    expect(searchCalls).toHaveLength(2);
+    expect(searchCalls).toHaveLength(4);
     const urls = searchCalls.map((c) => c[0] as string);
     const decoded = urls.map((u) => decodeURIComponent(u));
+    const issueDecoded = decoded.filter((d) => d.includes("is:issue"));
+    expect(issueDecoded).toHaveLength(2);
 
     // Main call: ippoan + ohishi-exp orgs without a repo: qualifier.
-    const main = decoded.find((d) => d.includes("org:ippoan"));
+    const main = issueDecoded.find((d) => d.includes("org:ippoan"));
     expect(main).toBeDefined();
     expect(main!).toContain("is:issue");
     expect(main!).toContain("state:open");
@@ -234,7 +274,7 @@ describe("GET /issues", () => {
     // to the entire org), so fetchOrgIssues must omit `org:` whenever the
     // caller-supplied query contains a `repo:` qualifier. Regression guard
     // for issue #53.
-    const yhonda = decoded.find((d) => d.includes("repo:yhonda-ohishi/claude-skills"));
+    const yhonda = issueDecoded.find((d) => d.includes("repo:yhonda-ohishi/claude-skills"));
     expect(yhonda).toBeDefined();
     expect(yhonda!).toContain("is:issue");
     expect(yhonda!).toContain("state:open");
@@ -284,6 +324,8 @@ describe("GET /issues", () => {
         }
         return Response.json({ data: { repositoryOwner: null } });
       }
+      // Both `is:issue` and `is:pr` shapes hit /search/issues and we want
+      // an empty result for both — the search response shape is identical.
       return Response.json({ total_count: 0, incomplete_results: false, items: [] });
     });
     const req = new Request("http://localhost/issues");
@@ -302,6 +344,7 @@ describe("GET /issues", () => {
 describe("GET /issues — Project section", () => {
   beforeEach(async () => {
     await env.CI_STATUS.delete("issues-page:project-map");
+    await env.CI_STATUS.delete("issues-page:pr-map");
   });
   afterEach(() => { vi.restoreAllMocks(); });
 
@@ -377,7 +420,12 @@ describe("GET /issues — Project section", () => {
         });
       }
       // Search responses — only the rust-alc-api#7 issue matters here.
-      if (decodeURIComponent(url).includes("repo:yhonda-ohishi/claude-skills")) {
+      const decoded = decodeURIComponent(url);
+      // PR search: return empty so the test focuses on project chips.
+      if (decoded.includes("is:pr")) {
+        return Response.json({ total_count: 0, incomplete_results: false, items: [] });
+      }
+      if (decoded.includes("repo:yhonda-ohishi/claude-skills")) {
         return Response.json({ total_count: 0, incomplete_results: false, items: [] });
       }
       return Response.json({
@@ -444,6 +492,7 @@ describe("buildClaudeCodeLaunchUrl()", () => {
 describe("GET /issues — Claude Code launch button", () => {
   beforeEach(async () => {
     await env.CI_STATUS.delete("issues-page:project-map");
+    await env.CI_STATUS.delete("issues-page:pr-map");
   });
   afterEach(() => { vi.restoreAllMocks(); });
 
@@ -484,6 +533,121 @@ describe("GET /issues — Claude Code launch button", () => {
     expect(projectSection![0]).toContain(
       escapeHtml(buildClaudeCodeLaunchUrl("ippoan/rust-alc-api", 7)),
     );
+  });
+});
+
+describe("GET /issues — Related-PR chips", () => {
+  beforeEach(async () => {
+    await env.CI_STATUS.delete("issues-page:project-map");
+    await env.CI_STATUS.delete("issues-page:pr-map");
+  });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("renders a pr-chip on issues that have an open PR referencing them via Refs #N", async () => {
+    stubFetch({ withPrs: true });
+    const req = new Request("http://localhost/issues");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    const html = await res.text();
+    // The seeded PR is rust-alc-api#42 referencing #7. We expect a pr-chip
+    // linking to that PR on issue #7's row, and no chip on the other rows.
+    expect(html).toContain('<a class="pr-chip"');
+    expect(html).toContain("https://github.com/ippoan/rust-alc-api/pull/42");
+    expect(html).toContain(">🔗 #42<");
+    // Issue #3 (ohishi-exp) and #1 (claude-skills) have no referencing PR.
+    const chipCount = (html.match(/class="pr-chip(?:\s|")/g) ?? []).length;
+    expect(chipCount).toBe(1);
+  });
+
+  it("marks draft PRs with the .draft class", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (req, init) => {
+      const url = typeof req === "string" ? req : (req as Request).url;
+      const body = (init?.body as string | undefined) ?? "";
+      if (url.includes("/graphql")) {
+        if (body.includes("projectsV2(first:")) {
+          return Response.json({
+            data: { repositoryOwner: { projectsV2: { nodes: [] } } },
+          });
+        }
+        return Response.json({ data: { repositoryOwner: null } });
+      }
+      const decoded = decodeURIComponent(url);
+      if (decoded.includes("is:pr")) {
+        if (decoded.includes("repo:yhonda-ohishi/claude-skills")) {
+          return Response.json({ total_count: 0, incomplete_results: false, items: [] });
+        }
+        return Response.json({
+          total_count: 1, incomplete_results: false,
+          items: [{
+            number: 88,
+            title: "WIP: draft fix",
+            state: "open",
+            body: "Closes #7",
+            user: { login: "yhonda-ohishi" },
+            labels: [], assignees: [], comments: 0,
+            created_at: "2026-05-11T00:00:00Z", updated_at: "2026-05-11T03:00:00Z",
+            html_url: "https://github.com/ippoan/rust-alc-api/pull/88",
+            repository_url: "https://api.github.com/repos/ippoan/rust-alc-api",
+            draft: true,
+            pull_request: { url: "..." },
+          }],
+        });
+      }
+      if (decoded.includes("repo:yhonda-ohishi/claude-skills")) {
+        return Response.json({ total_count: 0, incomplete_results: false, items: [] });
+      }
+      return Response.json({
+        total_count: 1, incomplete_results: false,
+        items: [{
+          number: 7, title: "the issue", state: "open",
+          user: { login: "yhonda-ohishi" }, labels: [], assignees: [], comments: 0,
+          created_at: "2026-05-10T00:00:00Z", updated_at: "2026-05-10T03:00:00Z",
+          html_url: "https://github.com/ippoan/rust-alc-api/issues/7",
+          repository_url: "https://api.github.com/repos/ippoan/rust-alc-api",
+        }],
+      });
+    });
+    const req = new Request("http://localhost/issues");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    const html = await res.text();
+    expect(html).toContain('class="pr-chip draft"');
+    expect(html).toContain("(draft)");
+  });
+
+  it("does not blank the page when the PR search call fails — shows a banner instead", async () => {
+    // Issue calls succeed but PR search rejects with 403. The issues page
+    // should still render with a stale/error banner for the related-PR map,
+    // not return 502.
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (req, init) => {
+      const url = typeof req === "string" ? req : (req as Request).url;
+      const body = (init?.body as string | undefined) ?? "";
+      if (url.includes("/graphql")) {
+        if (body.includes("projectsV2(first:")) {
+          return Response.json({
+            data: { repositoryOwner: { projectsV2: { nodes: [] } } },
+          });
+        }
+        return Response.json({ data: { repositoryOwner: null } });
+      }
+      const decoded = decodeURIComponent(url);
+      if (decoded.includes("is:pr")) {
+        return new Response("rate limited", { status: 403 });
+      }
+      return Response.json({ total_count: 0, incomplete_results: false, items: [] });
+    });
+    const req = new Request("http://localhost/issues");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Related-PR links unavailable");
   });
 });
 


### PR DESCRIPTION
## Summary

- `/issues` の各 issue 行に紐付く **open PR の chip** を表示
- `Refs` / `Closes` / `Fixes` / `Resolves` / `Related to` / `Part of` の 6 keyword + GitHub issue URL を PR title + body から逆引き
- Project 付きセクション・per-repo セクション両方で表示
- Draft PR は gray chip で区別
- cross-repo ref (`owner/repo` 形式) もサポート

## 設計メモ

- `src/issue-prs.ts`: search REST (`is:pr state:open`) で PR を取得し、本文を parse して `owner/repo#N → IssuePrRef[]` map を返す
- `src/issues-page.ts`: project-map と同じ KV cache パターン (fresh 2 min / store 24 h)。`Promise.all` で project-map と並列取得
- PR 取得失敗時は banner で fail を伝え、issue 本体は blank にしない (項目 #94 follow-up と同じスタンス)
- GraphQL `closingIssuesReferences` ではなく本文 parse を選んだのは、CLAUDE.md の `Refs` 規約 (auto-close されない) を拾える唯一の方法だから

## Test plan

- [x] `npm run typecheck` 緑
- [x] `npm test` 248 件 pass (新規 9 件 + 既存テストの search count 期待値更新)
- [x] `test/issue-prs.test.ts`: ref 抽出 / 6 keyword / cross-repo / URL / case-insensitive / org allowlist
- [x] `test/issues-page.test.ts`: pr-chip 描画 / draft クラス / PR fetch 失敗時の banner
- [ ] deploy 後 `https://ci-dashboard.ippoan.org/issues` で実データを確認

Refs #107

---
旧 PR #108 (`claude/jolly-newton-ex3Gt` branch) を CLAUDE.md の命名規則に合わせ `107-feat-related-prs` で作り直し。内容は同一 (origin/main へ rebase 済み)。</body>

---
_Generated by [Claude Code](https://claude.ai/code/session_011tv9EzE376k1dGcpqaMyph)_