### PR TITLE
refactor(auth): swap PAT for GitHub App installation token across all call sites (Refs #112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,13 @@ npm run deploy                       # production (top-level, 予約) に手動 
 npx wrangler deploy --env staging    # staging に手動 deploy
 ```
 
-### GitHub 認証 (PAT → GitHub App 移行中: #112)
+### GitHub 認証 (GitHub App — #112 で PAT 廃止済み)
 
-`refactor(auth): replace PAT with GitHub App installation token (3-org)` の
-移行作業中。新規セットアップは GitHub App、既存の PAT 設定は段階的に廃止する。
+PAT (`GITHUB_TOKEN`) は完全廃止。Worker は GitHub App installation token
+(per-org、1 h TTL、KV cache ~55 min) を `src/github-app-auth.ts` 経由で
+発行・更新する。手動 rotation は不要。
 
-#### GitHub App セットアップ (推奨、最終形)
+#### GitHub App セットアップ
 
 1. **App 作成** (Settings → Developer settings → GitHub Apps → New GitHub App)
    - Homepage URL: `https://ci-dashboard.ippoan.org`
@@ -138,15 +139,16 @@ npx wrangler deploy --env staging    # staging に手動 deploy
 5. installation token は worker 内で JWT 経由で交換し、KV (`gh-app:token:<installation_id>`) に
    ~55 min キャッシュされる。手動 rotation 不要。
 
-#### PAT (旧、廃止予定)
+#### 移行作業の最終ステップ
+
+旧 PAT secret は #112 で全 code path から外したので、デプロイ後に各 worker
+(`ci-dashboard-staging` / `ci-dashboard`) から `GITHUB_TOKEN` secret を
+削除すること:
 
 ```bash
-wrangler secret put GITHUB_TOKEN --env staging
-wrangler secret put GITHUB_TOKEN
+npx wrangler secret delete GITHUB_TOKEN --env staging
+npx wrangler secret delete GITHUB_TOKEN
 ```
-
-`repo` / `workflow` スコープ + Projects v2 用に `project` (write) または `read:project` を追加。
-**#112 完了後にこの secret は不要になるので削除すること。**
 
 ## 開発ルール
 

--- a/src/direct-push-allowlist.ts
+++ b/src/direct-push-allowlist.ts
@@ -10,7 +10,8 @@
 // set so the rest of the page still renders — direct-push UI just silently
 // won't appear until the fetch recovers.
 
-import { githubApi, GitHubApiError } from "./github-api";
+import { githubApi, GitHubApiError, tokenForOrg } from "./github-api";
+import type { GitHubAppEnv } from "./github-app-auth";
 
 export const ALLOWLIST_REPO = "yhonda-ohishi/claude-skills";
 export const ALLOWLIST_PATH = "wt-direct-push/config/direct-push-ok.txt";
@@ -29,9 +30,10 @@ interface CachedAllowlist {
 
 // Returns the parsed allowlist as a Set so callers do O(1) membership checks.
 // `kv` is optional so unit tests can exercise the pure-fetch path without
-// stubbing a KV namespace; production passes `env.CI_STATUS`.
+// stubbing a KV namespace; production passes `env.CI_STATUS`. The token is
+// resolved against `yhonda-ohishi` (owner of ALLOWLIST_REPO).
 export async function loadDirectPushAllowlist(
-  token: string,
+  env: GitHubAppEnv,
   kv?: KVNamespace,
 ): Promise<Set<string>> {
   if (kv) {
@@ -41,6 +43,7 @@ export async function loadDirectPushAllowlist(
     }
   }
 
+  const token = await tokenForOrg(env, "yhonda-ohishi");
   const repos = await fetchAllowlistFromGitHub(token);
 
   if (kv && repos.length > 0) {

--- a/src/github-api.ts
+++ b/src/github-api.ts
@@ -1,3 +1,5 @@
+import { getInstallationToken, type GitHubAppEnv } from "./github-app-auth";
+
 const GITHUB_API = "https://api.github.com";
 const ALLOWED_ORGS = ["ippoan", "ohishi-exp", "yhonda-ohishi"];
 const DEFAULT_ORG = "ippoan";
@@ -14,6 +16,14 @@ export function validateOrg(owner: string): void {
   if (!ALLOWED_ORGS.includes(owner)) {
     throw new GitHubApiError(403, `Org not allowed: ${owner}`);
   }
+}
+
+/** Resolve a GitHub App installation token for the given org. Combines the
+ *  allowlist check (`validateOrg`) with the per-org token mint so the common
+ *  3-line pattern at call sites collapses to one. */
+export async function tokenForOrg(env: GitHubAppEnv, owner: string): Promise<string> {
+  validateOrg(owner);
+  return getInstallationToken(env, owner);
 }
 
 export class GitHubApiError extends Error {

--- a/src/hub.ts
+++ b/src/hub.ts
@@ -7,7 +7,7 @@ import {
   computeReleaseAlert,
   computeReleaseAlertForPr,
 } from "./release-alert";
-import { parseRepo } from "./github-api";
+import { parseRepo, tokenForOrg } from "./github-api";
 import { invalidateIssue } from "./release-cache";
 
 // WebSocket message envelope. All broadcasts now share `{ type, data }` so
@@ -173,7 +173,7 @@ export class CIDashboardHub extends DurableObject<Env> {
       await this.ensureAlerts();
       try {
         const alert = await computeReleaseAlert(
-          this.env.GITHUB_TOKEN, repo, tag, this.env.CI_STATUS,
+          this.env, repo, tag, this.env.CI_STATUS,
         );
         this.persistAlertAtKey(tagAlertKey(repo), alert);
         this.broadcastAlerts();
@@ -198,7 +198,7 @@ export class CIDashboardHub extends DurableObject<Env> {
       await this.ensureAlerts();
       try {
         const alert = await computeReleaseAlertForPr(
-          this.env.GITHUB_TOKEN, repo, prNumber, mergeSha, defaultBranch, this.env.CI_STATUS,
+          this.env, repo, prNumber, mergeSha, defaultBranch, this.env.CI_STATUS,
         );
         this.persistAlertAtKey(prAlertKey(repo, prNumber), alert);
         this.broadcastAlerts();
@@ -227,13 +227,13 @@ export class CIDashboardHub extends DurableObject<Env> {
         try {
           const fresh = existing.prNumber !== undefined
             ? await computeReleaseAlertForPr(
-                this.env.GITHUB_TOKEN, repo, existing.prNumber,
+                this.env, repo, existing.prNumber,
                 /* mergeSha */ null,
                 /* defaultBranch */ existing.tag.split("@")[0] ?? "main",
                 this.env.CI_STATUS,
               )
             : await recomputeAlert(
-                this.env.GITHUB_TOKEN, repo, existing.tag, this.env.CI_STATUS,
+                this.env, repo, existing.tag, this.env.CI_STATUS,
               );
           this.persistAlertAtKey(kvKey, fresh);
           changed = true;
@@ -503,11 +503,12 @@ export class CIDashboardHub extends DurableObject<Env> {
   // shipping (1) alone the bug recurred — the cache only cleared when an
   // operator manually purged it. (2)+(3) defend against that recurrence.
   private async fetchLiveIssueState(owner: string, name: string, n: number): Promise<string> {
+    const token = await tokenForOrg(this.env, owner);
     const init: RequestInit & { cache?: string } = {
       method: "GET",
       cache: "no-store",
       headers: {
-        Authorization: `Bearer ${this.env.GITHUB_TOKEN}`,
+        Authorization: `Bearer ${token}`,
         Accept: "application/vnd.github+json",
         "User-Agent": "ci-dashboard-mcp",
         "X-GitHub-Api-Version": "2022-11-28",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,8 +22,13 @@ export { CIDashboardHub } from "./hub";
 export interface Env {
   CI_STATUS: KVNamespace;
   WEBHOOK_SECRET: string;
-  GITHUB_TOKEN: string;
   CI_HUB: DurableObjectNamespace;
+  // GitHub App credentials. Replaces the classic-PAT `GITHUB_TOKEN` secret;
+  // each Worker request mints (or reads from KV cache) per-org installation
+  // tokens via src/github-app-auth.ts. Refs #112.
+  GITHUB_APP_ID: string;
+  GITHUB_APP_PRIVATE_KEY: string;
+  GITHUB_APP_INSTALLATIONS: string;
   // Comma-separated `owner/name` list of repos that don't cut tags. PR merges
   // into the default branch are treated as releases for these. See
   // wrangler.jsonc and src/tagless-repos.ts.
@@ -134,6 +139,6 @@ app.get("/sw.js", () => handlePwaServiceWorker());
 app.get("/icons/:file", (c) => handlePwaIcon("/icons/" + c.req.param("file")));
 
 // MCP endpoint (Streamable HTTP)
-app.all("/mcp", (c) => handleMcpRequest(c.req.raw, c.env.GITHUB_TOKEN));
+app.all("/mcp", (c) => handleMcpRequest(c.req.raw, c.env));
 
 export default app;

--- a/src/issue-prs.ts
+++ b/src/issue-prs.ts
@@ -1,4 +1,5 @@
 import { githubApi, validateOrg } from "./github-api";
+import { getInstallationToken, type GitHubAppEnv } from "./github-app-auth";
 
 /** Lightweight PR descriptor used by the issues page to render "related PR"
  *  chips. Body is intentionally not retained — it's only used to extract
@@ -57,16 +58,25 @@ interface SearchPrsResponse {
   items: SearchPrItem[];
 }
 
-/** Single GitHub search call for open PRs. Pass `orgs` for `org:` qualifiers
- *  or `repos` for `repo:` qualifiers (mutually exclusive — GitHub silently
- *  drops `repo:` when combined with `org:`, mirroring fetchOrgIssues). */
+/** Single GitHub search call for open PRs. Pass either `orgs` (for `org:`
+ *  qualifiers) or `repos` (for `repo:` qualifiers) — mutually exclusive.
+ *  Either way the call is run with a single installation token, so the
+ *  caller must guarantee that all orgs/repos belong to one owner (typically
+ *  the same App installation). Cross-org fan-out lives in
+ *  `fetchAllOpenPrsByIssue`. */
 export async function fetchOpenPrsByIssue(
-  token: string,
+  env: GitHubAppEnv,
   params: { orgs?: string[]; repos?: string[]; per_page?: number },
 ): Promise<Map<string, IssuePrRef[]>> {
   const { orgs = [], repos = [], per_page = 100 } = params;
   for (const o of orgs) validateOrg(o);
   for (const r of repos) validateOrg(r.split("/")[0]!);
+
+  // Resolve a single owner for the installation token. `repos` win because
+  // we know the explicit owner; otherwise `orgs[0]` (callers either pass one
+  // org per call after fan-out, or a same-owner repos list).
+  const owner = repos.length > 0 ? repos[0]!.split("/")[0]! : orgs[0]!;
+  const token = await getInstallationToken(env, owner);
 
   const parts: string[] = ["is:pr", "state:open", "archived:false"];
   if (repos.length > 0) {
@@ -108,21 +118,28 @@ export async function fetchOpenPrsByIssue(
  *  issues page uses (main orgs + yhonda `repo:` filter). Mirrors the parallel
  *  pattern in issues-page.ts so a partial failure aborts the whole call. */
 export async function fetchAllOpenPrsByIssue(
-  token: string,
+  env: GitHubAppEnv,
   mainOrgs: string[],
   yhondaRepos: string[],
 ): Promise<Map<string, IssuePrRef[]>> {
-  const [main, yhonda] = await Promise.all([
-    fetchOpenPrsByIssue(token, { orgs: mainOrgs }),
-    yhondaRepos.length > 0
-      ? fetchOpenPrsByIssue(token, { repos: yhondaRepos })
-      : Promise.resolve(new Map<string, IssuePrRef[]>()),
-  ]);
-  const merged = new Map<string, IssuePrRef[]>(main);
-  for (const [k, prs] of yhonda) {
-    const existing = merged.get(k);
-    if (existing) existing.push(...prs);
-    else merged.set(k, prs);
+  // Per-org fan-out: GitHub App installation tokens are per-org so a single
+  // `org:ippoan org:ohishi-exp` search can't be served by one token. Mirror
+  // the same fan-out used by fetchOrgIssues — one search call per org.
+  const tasks: Array<Promise<Map<string, IssuePrRef[]>>> = mainOrgs.map((org) =>
+    fetchOpenPrsByIssue(env, { orgs: [org] }),
+  );
+  if (yhondaRepos.length > 0) {
+    tasks.push(fetchOpenPrsByIssue(env, { repos: yhondaRepos }));
+  }
+  const results = await Promise.all(tasks);
+
+  const merged = new Map<string, IssuePrRef[]>();
+  for (const m of results) {
+    for (const [k, prs] of m) {
+      const existing = merged.get(k);
+      if (existing) existing.push(...prs);
+      else merged.set(k, prs.slice());
+    }
   }
   // Sort each list by recency so the most-recently-updated PR renders first.
   for (const prs of merged.values()) {

--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -1,6 +1,7 @@
 import { fetchOrgIssues, type OrgIssue } from "./mcp/tools/issues";
 import { fetchProjectIssueMap, type ProjectRef } from "./mcp/tools/projects";
 import { fetchAllOpenPrsByIssue, type IssuePrRef } from "./issue-prs";
+import type { GitHubAppEnv } from "./github-app-auth";
 import { renderTabs, TAB_STYLES } from "./nav-tabs";
 import { PWA_HEAD_TAGS, PWA_REGISTER_SCRIPT } from "./pwa";
 
@@ -78,17 +79,17 @@ interface ProjectMapResult {
 }
 
 async function loadProjectMap(
-  kv: KVNamespace,
-  token: string,
+  env: GitHubAppEnv,
   orgs: string[],
 ): Promise<ProjectMapResult> {
+  const kv = env.CI_STATUS;
   const cached = await kv.get(PROJECT_MAP_CACHE_KEY, "json") as ProjectMapCacheEntry | null;
   const now = Date.now();
   if (cached && now - cached.storedAt < PROJECT_MAP_FRESH_SECONDS * 1000) {
     return { map: new Map(Object.entries(cached.data)), stale: false, error: null };
   }
   try {
-    const fresh = await fetchProjectIssueMap(token, { orgs });
+    const fresh = await fetchProjectIssueMap(env, { orgs });
     const entry: ProjectMapCacheEntry = { storedAt: now, data: Object.fromEntries(fresh) };
     await kv.put(PROJECT_MAP_CACHE_KEY, JSON.stringify(entry), {
       expirationTtl: PROJECT_MAP_STORE_SECONDS,
@@ -124,18 +125,18 @@ interface PrMapResult {
 }
 
 async function loadPrMap(
-  kv: KVNamespace,
-  token: string,
+  env: GitHubAppEnv,
   mainOrgs: string[],
   yhondaRepos: string[],
 ): Promise<PrMapResult> {
+  const kv = env.CI_STATUS;
   const cached = await kv.get(PR_MAP_CACHE_KEY, "json") as PrMapCacheEntry | null;
   const now = Date.now();
   if (cached && now - cached.storedAt < PR_MAP_FRESH_SECONDS * 1000) {
     return { map: new Map(Object.entries(cached.data)), stale: false, error: null };
   }
   try {
-    const fresh = await fetchAllOpenPrsByIssue(token, mainOrgs, yhondaRepos);
+    const fresh = await fetchAllOpenPrsByIssue(env, mainOrgs, yhondaRepos);
     const entry: PrMapCacheEntry = { storedAt: now, data: Object.fromEntries(fresh) };
     await kv.put(PR_MAP_CACHE_KEY, JSON.stringify(entry), {
       expirationTtl: PR_MAP_STORE_SECONDS,
@@ -150,21 +151,19 @@ async function loadPrMap(
   }
 }
 
-export async function handleIssuesPage(
-  env: { GITHUB_TOKEN: string; CI_STATUS: KVNamespace },
-): Promise<Response> {
+export async function handleIssuesPage(env: GitHubAppEnv): Promise<Response> {
   // Search REST gives us the issues themselves; this is the only fetch that
   // can fail the page outright. Project map is loaded separately below so a
   // GraphQL rate-limit doesn't blank the page (Refs #94 follow-up).
   let merged;
   try {
     const [main, yhonda] = await Promise.all([
-      fetchOrgIssues(env.GITHUB_TOKEN, {
+      fetchOrgIssues(env, {
         orgs: ORGS,
         state: "open",
         per_page: 100,
       }),
-      fetchOrgIssues(env.GITHUB_TOKEN, {
+      fetchOrgIssues(env, {
         orgs: ["yhonda-ohishi"],
         state: "open",
         per_page: 100,
@@ -185,8 +184,8 @@ export async function handleIssuesPage(
   }
 
   const [project, prs] = await Promise.all([
-    loadProjectMap(env.CI_STATUS, env.GITHUB_TOKEN, PROJECT_ORGS),
-    loadPrMap(env.CI_STATUS, env.GITHUB_TOKEN, ORGS, YHONDA_REPOS),
+    loadProjectMap(env, PROJECT_ORGS),
+    loadPrMap(env, ORGS, YHONDA_REPOS),
   ]);
   const projectMap = project.map;
   const prMap = prs.map;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import type { GitHubAppEnv } from "../github-app-auth";
 import { registerActionsTools } from "./tools/actions";
 import { registerPullsTools } from "./tools/pulls";
 import { registerReleasesTools } from "./tools/releases";
@@ -9,26 +10,26 @@ import { registerCommitsTools } from "./tools/commits";
 import { registerIssuesTools } from "./tools/issues";
 import { registerProjectsTools } from "./tools/projects";
 
-function createMcpServer(token: string): McpServer {
+function createMcpServer(env: GitHubAppEnv): McpServer {
   const server = new McpServer({
     name: "ci-dashboard",
     version: "1.0.0",
   });
 
-  registerActionsTools(server, token);
-  registerPullsTools(server, token);
-  registerReleasesTools(server, token);
-  registerLogsTools(server, token);
-  registerRepositoryTools(server, token);
-  registerCommitsTools(server, token);
-  registerIssuesTools(server, token);
-  registerProjectsTools(server, token);
+  registerActionsTools(server, env);
+  registerPullsTools(server, env);
+  registerReleasesTools(server, env);
+  registerLogsTools(server, env);
+  registerRepositoryTools(server, env);
+  registerCommitsTools(server, env);
+  registerIssuesTools(server, env);
+  registerProjectsTools(server, env);
 
   return server;
 }
 
-export async function handleMcpRequest(request: Request, token: string): Promise<Response> {
-  const server = createMcpServer(token);
+export async function handleMcpRequest(request: Request, env: GitHubAppEnv): Promise<Response> {
+  const server = createMcpServer(env);
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator: undefined, // stateless
     enableJsonResponse: true,

--- a/src/mcp/tools/actions.ts
+++ b/src/mcp/tools/actions.ts
@@ -1,8 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { githubApi, parseRepo, validateOrg } from "../../github-api";
+import { githubApi, parseRepo, tokenForOrg } from "../../github-api";
+import type { GitHubAppEnv } from "../../github-app-auth";
 
-export function registerActionsTools(server: McpServer, token: string): void {
+export function registerActionsTools(server: McpServer, env: GitHubAppEnv): void {
   server.registerTool(
     "list_workflow_runs",
     {
@@ -16,7 +17,7 @@ export function registerActionsTools(server: McpServer, token: string): void {
     },
     async ({ repo, status, per_page }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
       const params: Record<string, string> = { per_page: String(per_page) };
       if (status) params.status = status;
 
@@ -52,7 +53,7 @@ export function registerActionsTools(server: McpServer, token: string): void {
     },
     async ({ repo, run_id }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const run = await githubApi<WorkflowRun>(
         token, "GET", `/repos/${owner}/${name}/actions/runs/${run_id}`,
@@ -90,7 +91,7 @@ export function registerActionsTools(server: McpServer, token: string): void {
     },
     async ({ repo, run_id }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const data = await githubApi<{ jobs: WorkflowJob[] }>(
         token, "GET", `/repos/${owner}/${name}/actions/runs/${run_id}/jobs`,
@@ -122,7 +123,7 @@ export function registerActionsTools(server: McpServer, token: string): void {
     },
     async ({ repo, run_id }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
       await githubApi(token, "POST", `/repos/${owner}/${name}/actions/runs/${run_id}/rerun`);
       return { content: [{ type: "text" as const, text: `Rerun triggered for run ${run_id}` }] };
     },
@@ -140,7 +141,7 @@ export function registerActionsTools(server: McpServer, token: string): void {
     },
     async ({ repo, run_id }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
       await githubApi(token, "POST", `/repos/${owner}/${name}/actions/runs/${run_id}/rerun-failed-jobs`);
       return { content: [{ type: "text" as const, text: `Rerun of failed jobs triggered for run ${run_id}` }] };
     },
@@ -158,7 +159,7 @@ export function registerActionsTools(server: McpServer, token: string): void {
     },
     async ({ repo, run_id }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
       await githubApi(token, "POST", `/repos/${owner}/${name}/actions/runs/${run_id}/cancel`);
       return { content: [{ type: "text" as const, text: `Cancelled run ${run_id}` }] };
     },

--- a/src/mcp/tools/commits.ts
+++ b/src/mcp/tools/commits.ts
@@ -1,8 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { githubApi, parseRepo, validateOrg } from "../../github-api";
+import { githubApi, parseRepo, tokenForOrg } from "../../github-api";
+import type { GitHubAppEnv } from "../../github-app-auth";
 
-export function registerCommitsTools(server: McpServer, token: string): void {
+export function registerCommitsTools(server: McpServer, env: GitHubAppEnv): void {
   server.registerTool(
     "list_commits",
     {
@@ -17,7 +18,7 @@ export function registerCommitsTools(server: McpServer, token: string): void {
     },
     async ({ repo, sha, path, per_page }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const params: Record<string, string> = {
         sha,
@@ -52,7 +53,7 @@ export function registerCommitsTools(server: McpServer, token: string): void {
     },
     async ({ repo, sha }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const commit = await githubApi<CommitDetail>(
         token, "GET", `/repos/${owner}/${name}/commits/${sha}`,

--- a/src/mcp/tools/issues.ts
+++ b/src/mcp/tools/issues.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { githubApi, parseRepo, validateOrg } from "../../github-api";
+import { githubApi, parseRepo, tokenForOrg, validateOrg } from "../../github-api";
+import { getInstallationToken, type GitHubAppEnv } from "../../github-app-auth";
 
 /** Build the PATCH body for `update_issue` from optional fields. Strips
  *  fields the caller did not provide (= `undefined`); preserves empty
@@ -28,7 +29,7 @@ export function buildUpdateIssuePayload(input: {
   return payload;
 }
 
-export function registerIssuesTools(server: McpServer, token: string): void {
+export function registerIssuesTools(server: McpServer, env: GitHubAppEnv): void {
   server.registerTool(
     "list_issues",
     {
@@ -43,7 +44,7 @@ export function registerIssuesTools(server: McpServer, token: string): void {
     },
     async ({ repo, state, labels, per_page }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const params: Record<string, string> = {
         state,
@@ -86,7 +87,7 @@ export function registerIssuesTools(server: McpServer, token: string): void {
     },
     async ({ repo, issue_number }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const [issue, comments] = await Promise.all([
         githubApi<Issue>(token, "GET", `/repos/${owner}/${name}/issues/${issue_number}`),
@@ -129,7 +130,7 @@ export function registerIssuesTools(server: McpServer, token: string): void {
     },
     async ({ repo, title, body, labels, assignees }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const payload: Record<string, unknown> = { title };
       if (body) payload.body = body;
@@ -173,7 +174,7 @@ export function registerIssuesTools(server: McpServer, token: string): void {
     },
     async ({ repo, issue_number, title, body, labels, assignees, milestone }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const payload = buildUpdateIssuePayload({ title, body, labels, assignees, milestone });
 
@@ -206,7 +207,7 @@ export function registerIssuesTools(server: McpServer, token: string): void {
     },
     async ({ repo, issue_number, body }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const created = await githubApi<{ id: number; html_url: string; created_at: string }>(
         token, "POST", `/repos/${owner}/${name}/issues/${issue_number}/comments`, { body },
@@ -235,7 +236,7 @@ export function registerIssuesTools(server: McpServer, token: string): void {
     },
     async ({ repo, issue_number, labels }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const updated = await githubApi<Array<{ name: string }>>(
         token, "POST", `/repos/${owner}/${name}/issues/${issue_number}/labels`, { labels },
@@ -259,7 +260,7 @@ export function registerIssuesTools(server: McpServer, token: string): void {
     },
     async ({ repo, issue_number, label }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const remaining = await githubApi<Array<{ name: string }>>(
         token, "DELETE",
@@ -285,7 +286,7 @@ export function registerIssuesTools(server: McpServer, token: string): void {
     },
     async ({ repo, issue_number, state_reason }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const payload: Record<string, unknown> = { state: "closed" };
       payload.state_reason = state_reason ?? "completed";
@@ -317,7 +318,7 @@ export function registerIssuesTools(server: McpServer, token: string): void {
     },
     async ({ repo, issue_number }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const updated = await githubApi<Issue>(
         token, "PATCH", `/repos/${owner}/${name}/issues/${issue_number}`,
@@ -358,7 +359,7 @@ export function registerIssuesTools(server: McpServer, token: string): void {
       annotations: { readOnlyHint: true },
     },
     async ({ orgs, state, labels, assignee, query, per_page }) => {
-      const result = await fetchOrgIssues(token, {
+      const result = await fetchOrgIssues(env, {
         orgs, state, labels, assignee, query, per_page,
       });
       return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
@@ -400,20 +401,59 @@ export interface FetchOrgIssuesResult {
   items: OrgIssue[];
 }
 
+/** Cross-org issue search.
+ *
+ * GitHub App installation tokens are scoped per-org, so we cannot run
+ * `org:ippoan org:ohishi-exp` in a single search call: that token would
+ * only return results from its own installation. We fan out: one search
+ * per org with that org's installation token, then merge the rows.
+ *
+ * The special case is when `params.query` pins a specific `repo:owner/...`.
+ * In that case all repos belong to a single owner, so a single search call
+ * with that owner's token is correct (and required, because GitHub silently
+ * drops `repo:` when combined with `org:`, so we never want to add `org:`
+ * in that branch). */
 export async function fetchOrgIssues(
+  env: GitHubAppEnv,
+  params: FetchOrgIssuesParams,
+): Promise<FetchOrgIssuesResult> {
+  const { orgs, query } = params;
+  for (const o of orgs) validateOrg(o);
+
+  const queryHasRepoFilter = !!query && /\brepo:/.test(query);
+
+  if (queryHasRepoFilter) {
+    // All repos in the query must share an owner (else we couldn't pick one
+    // installation token). Extract the first owner and use that.
+    const m = query!.match(/\brepo:([\w.-]+)\//);
+    if (!m) throw new Error("fetchOrgIssues: query has repo: qualifier but owner could not be parsed");
+    const owner = m[1]!;
+    const token = await tokenForOrg(env, owner);
+    return runIssueSearch(token, params, /*omitOrgQualifier*/ true);
+  }
+
+  // Per-org fan-out.
+  const results = await Promise.all(
+    orgs.map(async (org) => {
+      const token = await getInstallationToken(env, org);
+      return runIssueSearch(token, { ...params, orgs: [org] }, /*omitOrgQualifier*/ false);
+    }),
+  );
+
+  return {
+    total_count: results.reduce((s, r) => s + r.total_count, 0),
+    incomplete: results.some((r) => r.incomplete),
+    items: results.flatMap((r) => r.items),
+  };
+}
+
+async function runIssueSearch(
   token: string,
   params: FetchOrgIssuesParams,
+  omitOrgQualifier: boolean,
 ): Promise<FetchOrgIssuesResult> {
   const { orgs, state = "open", labels, assignee, query, per_page = 30 } = params;
 
-  for (const o of orgs) validateOrg(o);
-
-  // GitHub Search silently drops `repo:` qualifiers when `org:` is also
-  // present in the same query — the result widens to the entire org. When
-  // the caller-supplied `query` already pins specific repos via `repo:`, omit
-  // the `org:` qualifier (the `repo:` already implies the owner). The
-  // `validateOrg` allowlist check above still runs, so this is safe.
-  const queryHasRepoFilter = !!query && /\brepo:/.test(query);
   // Default-exclude archived repos so old projects like cf-secrets-mcp don't
   // leak open issues into the dashboard. Caller can still opt back in (or
   // request archived-only) by passing `archived:true` / `archived:false` in
@@ -422,7 +462,7 @@ export async function fetchOrgIssues(
 
   const parts: string[] = ["is:issue"];
   if (state !== "all") parts.push(`state:${state}`);
-  if (!queryHasRepoFilter) {
+  if (!omitOrgQualifier) {
     for (const o of orgs) parts.push(`org:${o}`);
   }
   if (!queryHasArchivedFilter) parts.push("archived:false");

--- a/src/mcp/tools/logs.ts
+++ b/src/mcp/tools/logs.ts
@@ -1,8 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { githubApiRaw, parseRepo, validateOrg } from "../../github-api";
+import { githubApiRaw, parseRepo, tokenForOrg } from "../../github-api";
+import type { GitHubAppEnv } from "../../github-app-auth";
 
-export function registerLogsTools(server: McpServer, token: string): void {
+export function registerLogsTools(server: McpServer, env: GitHubAppEnv): void {
   server.registerTool(
     "get_job_logs",
     {
@@ -18,7 +19,7 @@ export function registerLogsTools(server: McpServer, token: string): void {
     },
     async ({ repo, job_id, tail_lines, start_line, end_line }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const raw = await githubApiRaw(
         token, "GET", `/repos/${owner}/${name}/actions/jobs/${job_id}/logs`,
@@ -72,7 +73,7 @@ export function registerLogsTools(server: McpServer, token: string): void {
     },
     async ({ repo, job_id, pattern, context_lines }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const raw = await githubApiRaw(
         token, "GET", `/repos/${owner}/${name}/actions/jobs/${job_id}/logs`,

--- a/src/mcp/tools/projects.ts
+++ b/src/mcp/tools/projects.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { githubGraphQL, parseRepo, validateOrg, GitHubApiError } from "../../github-api";
+import { githubGraphQL, parseRepo, tokenForOrg, validateOrg, GitHubApiError } from "../../github-api";
+import { getInstallationToken, type GitHubAppEnv } from "../../github-app-auth";
 
 // --------------------------------------------------------------------------
 // GitHub Projects v2 tooling.
@@ -157,12 +158,13 @@ export interface OrgProjectsResult {
  * `validateOrg` is enforced for every org before any network call.
  */
 export async function fetchOrgProjects(
-  token: string,
+  env: GitHubAppEnv,
   params: { orgs: string[]; first?: number; include_closed?: boolean },
 ): Promise<OrgProjectsResult[]> {
   const { orgs, first = 50, include_closed = false } = params;
   for (const o of orgs) validateOrg(o);
   return Promise.all(orgs.map(async (org) => {
+    const token = await getInstallationToken(env, org);
     const data = await githubGraphQL<{
       repositoryOwner: {
         projectsV2?: { nodes: OrgProject[] };
@@ -209,16 +211,17 @@ export interface ProjectRef {
  * each well under 1 point of the 5000/h rate-limit budget.
  */
 export async function fetchProjectIssueMap(
-  token: string,
+  env: GitHubAppEnv,
   params: { orgs: string[]; first?: number },
 ): Promise<Map<string, ProjectRef[]>> {
   const { orgs, first = 100 } = params;
-  const orgsProjects = await fetchOrgProjects(token, { orgs, include_closed: false });
+  const orgsProjects = await fetchOrgProjects(env, { orgs, include_closed: false });
 
   const map = new Map<string, ProjectRef[]>();
   await Promise.all(
     orgsProjects.flatMap(({ org, projects }) =>
       projects.map(async (p) => {
+        const token = await getInstallationToken(env, org);
         const data = await githubGraphQL<{
           node: {
             items: { nodes: Array<{
@@ -287,12 +290,12 @@ export interface ProjectItemSummary {
  * same surface as the MCP tool.
  */
 export async function fetchProjectItems(
-  token: string,
+  env: GitHubAppEnv,
   org: string,
   number: number,
   first = 50,
 ): Promise<ProjectItemSummary[]> {
-  validateOrg(org);
+  const token = await tokenForOrg(env, org);
   const data = await githubGraphQL<{
     repositoryOwner: { projectV2?: { items: { nodes: ProjectItemNode[] } } | null } | null;
   }>(
@@ -345,7 +348,7 @@ export async function fetchProjectItems(
   return nodes.map(formatItem);
 }
 
-export function registerProjectsTools(server: McpServer, token: string): void {
+export function registerProjectsTools(server: McpServer, env: GitHubAppEnv): void {
   // --------------------------------------------------------------------
   // Read tools
   // --------------------------------------------------------------------
@@ -370,7 +373,7 @@ export function registerProjectsTools(server: McpServer, token: string): void {
       annotations: { readOnlyHint: true },
     },
     async ({ orgs, first, include_closed }) => {
-      const perOrg = await fetchOrgProjects(token, { orgs, first, include_closed });
+      const perOrg = await fetchOrgProjects(env, { orgs, first, include_closed });
       // Tool shape stays the same (number/title/url/closed/shortDescription)
       // — the `id` is internal-only and dropped here.
       const result = perOrg.map(({ org, projects }) => ({
@@ -403,7 +406,7 @@ export function registerProjectsTools(server: McpServer, token: string): void {
       annotations: { readOnlyHint: true },
     },
     async ({ org, number }) => {
-      validateOrg(org);
+      const token = await tokenForOrg(env, org);
       // Named fragment on `ProjectV2Owner` so the big field-list block only
       // lives once and the inline-fragment spread covers both User and
       // Organization owners.
@@ -473,7 +476,8 @@ export function registerProjectsTools(server: McpServer, token: string): void {
       annotations: { readOnlyHint: true },
     },
     async ({ org, number, first }) => {
-      const result = await fetchProjectItems(token, org, number, first);
+      validateOrg(org);
+      const result = await fetchProjectItems(env, org, number, first);
       return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
     },
   );
@@ -501,8 +505,13 @@ export function registerProjectsTools(server: McpServer, token: string): void {
       annotations: { destructiveHint: true },
     },
     async ({ org, project_number, repo, issue_number }) => {
-      validateOrg(org);
+      const token = await tokenForOrg(env, org);
       const { owner, repo: name } = parseRepo(repo);
+      // The issue/PR may live in a different org from the project — but
+      // GitHub App installation tokens are per-org. We use the project
+      // owner's token here: the `contentId` resolution only needs the
+      // issue's *node id*, which Issues GraphQL exposes to any installation
+      // that can see the repo (public repos are visible to all our installs).
       validateOrg(owner);
       const [projectId, contentId] = await Promise.all([
         resolveProjectId(token, org, project_number),
@@ -545,6 +554,7 @@ export function registerProjectsTools(server: McpServer, token: string): void {
       annotations: { destructiveHint: true },
     },
     async ({ org, project_number, item_id }) => {
+      const token = await tokenForOrg(env, org);
       const projectId = await resolveProjectId(token, org, project_number);
       const data = await githubGraphQL<{
         deleteProjectV2Item: { deletedItemId: string };
@@ -585,6 +595,7 @@ export function registerProjectsTools(server: McpServer, token: string): void {
       annotations: { destructiveHint: true },
     },
     async ({ org, project_number, item_id, field_name, value }) => {
+      const token = await tokenForOrg(env, org);
       const projectId = await resolveProjectId(token, org, project_number);
       const fields = await getProjectFields(token, projectId);
       const field = fields.find((f) => f.name === field_name);
@@ -712,6 +723,7 @@ export function registerProjectsTools(server: McpServer, token: string): void {
       annotations: { destructiveHint: true },
     },
     async ({ org, project_number, name, data_type, single_select_options }) => {
+      const token = await tokenForOrg(env, org);
       const projectId = await resolveProjectId(token, org, project_number);
 
       const dataTypeMap = {
@@ -780,7 +792,7 @@ export function registerProjectsTools(server: McpServer, token: string): void {
       annotations: { destructiveHint: true },
     },
     async ({ org, title, short_description }) => {
-      validateOrg(org);
+      const token = await tokenForOrg(env, org);
 
       // Step 1: resolve the owner's GraphQL node ID (needed as ownerId).
       // `repositoryOwner` handles both User and Organization logins.

--- a/src/mcp/tools/pulls.ts
+++ b/src/mcp/tools/pulls.ts
@@ -1,8 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { githubApi, parseRepo, validateOrg } from "../../github-api";
+import { githubApi, parseRepo, tokenForOrg } from "../../github-api";
+import type { GitHubAppEnv } from "../../github-app-auth";
 
-export function registerPullsTools(server: McpServer, token: string): void {
+export function registerPullsTools(server: McpServer, env: GitHubAppEnv): void {
   server.registerTool(
     "list_pull_requests",
     {
@@ -16,7 +17,7 @@ export function registerPullsTools(server: McpServer, token: string): void {
     },
     async ({ repo, state, per_page }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const prs = await githubApi<PullRequest[]>(
         token, "GET", `/repos/${owner}/${name}/pulls`, undefined,
@@ -53,7 +54,7 @@ export function registerPullsTools(server: McpServer, token: string): void {
     },
     async ({ repo, pull_number }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const pr = await githubApi<PullRequest>(
         token, "GET", `/repos/${owner}/${name}/pulls/${pull_number}`,
@@ -103,7 +104,7 @@ export function registerPullsTools(server: McpServer, token: string): void {
     },
     async ({ repo, pull_number, commit_title }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const body: Record<string, unknown> = { merge_method: "squash" };
       if (commit_title) body.commit_title = commit_title;

--- a/src/mcp/tools/releases.ts
+++ b/src/mcp/tools/releases.ts
@@ -1,8 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { githubApi, parseRepo, validateOrg } from "../../github-api";
+import { githubApi, parseRepo, tokenForOrg } from "../../github-api";
+import type { GitHubAppEnv } from "../../github-app-auth";
 
-export function registerReleasesTools(server: McpServer, token: string): void {
+export function registerReleasesTools(server: McpServer, env: GitHubAppEnv): void {
   server.registerTool(
     "list_tags",
     {
@@ -15,7 +16,7 @@ export function registerReleasesTools(server: McpServer, token: string): void {
     },
     async ({ repo, per_page }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const tags = await githubApi<Tag[]>(
         token, "GET", `/repos/${owner}/${name}/tags`, undefined,
@@ -42,7 +43,7 @@ export function registerReleasesTools(server: McpServer, token: string): void {
     },
     async ({ repo }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const release = await githubApi<Release>(
         token, "GET", `/repos/${owner}/${name}/releases/latest`,
@@ -74,7 +75,7 @@ export function registerReleasesTools(server: McpServer, token: string): void {
     },
     async ({ repo }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       await githubApi(
         token, "POST",

--- a/src/mcp/tools/repository.ts
+++ b/src/mcp/tools/repository.ts
@@ -1,8 +1,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { githubApi, parseRepo, validateOrg } from "../../github-api";
+import { githubApi, parseRepo, tokenForOrg } from "../../github-api";
+import type { GitHubAppEnv } from "../../github-app-auth";
 
-export function registerRepositoryTools(server: McpServer, token: string): void {
+export function registerRepositoryTools(server: McpServer, env: GitHubAppEnv): void {
   server.registerTool(
     "get_file_tree",
     {
@@ -16,7 +17,7 @@ export function registerRepositoryTools(server: McpServer, token: string): void 
     },
     async ({ repo, ref, path }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const data = await githubApi<GitTree>(
         token, "GET", `/repos/${owner}/${name}/git/trees/${ref}`, undefined,
@@ -61,7 +62,7 @@ export function registerRepositoryTools(server: McpServer, token: string): void 
     },
     async ({ repo, path, ref, start_line, end_line }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const params: Record<string, string> = {};
       if (ref) params.ref = ref;
@@ -129,7 +130,7 @@ export function registerRepositoryTools(server: McpServer, token: string): void 
     },
     async ({ repo, query, path, extension, per_page }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       let q = `${query} repo:${owner}/${name}`;
       if (path) q += ` path:${path}`;
@@ -169,7 +170,7 @@ export function registerRepositoryTools(server: McpServer, token: string): void 
     },
     async ({ repo, symbol, kind, language, per_page }) => {
       const { owner, repo: name } = parseRepo(repo);
-      validateOrg(owner);
+      const token = await tokenForOrg(env, owner);
 
       const keyword = kind ? symbolKeyword(kind, language) : "";
       const quotedSymbol = keyword ? `"${keyword} ${symbol}"` : `"${symbol}"`;

--- a/src/projects-page.ts
+++ b/src/projects-page.ts
@@ -4,6 +4,7 @@ import {
   type OrgProject,
   type ProjectItemSummary,
 } from "./mcp/tools/projects";
+import type { GitHubAppEnv } from "./github-app-auth";
 import { renderTabs, TAB_STYLES } from "./nav-tabs";
 import { PWA_HEAD_TAGS, PWA_REGISTER_SCRIPT } from "./pwa";
 import { escapeHtml } from "./issues-page";
@@ -24,12 +25,10 @@ interface OrgSection {
   projects: ProjectWithItems[];
 }
 
-export async function handleProjectsPage(
-  env: { GITHUB_TOKEN: string },
-): Promise<Response> {
+export async function handleProjectsPage(env: GitHubAppEnv): Promise<Response> {
   let perOrg;
   try {
-    perOrg = await fetchOrgProjects(env.GITHUB_TOKEN, { orgs: PROJECT_ORGS });
+    perOrg = await fetchOrgProjects(env, { orgs: PROJECT_ORGS });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return new Response(renderError(msg), {
@@ -47,7 +46,7 @@ export async function handleProjectsPage(
   );
   const itemResults = await Promise.allSettled(
     flat.map(({ org, project }) =>
-      fetchProjectItems(env.GITHUB_TOKEN, org, project.number),
+      fetchProjectItems(env, org, project.number),
     ),
   );
 

--- a/src/recheck.ts
+++ b/src/recheck.ts
@@ -1,4 +1,5 @@
 import type { Env } from "./index";
+import { tokenForOrg } from "./github-api";
 
 interface GitHubRun {
   id: number;
@@ -32,13 +33,23 @@ export async function handleRecheck(
     repo: string;
   }>();
 
-  const allowedOrgs = ["ippoan/", "ohishi-exp/"];
-  if (!repo || !allowedOrgs.some((org) => repo.startsWith(org))) {
-    return Response.json({ error: "Org not allowed" }, { status: 403 });
+  if (!repo) {
+    return Response.json({ error: "Missing repo" }, { status: 400 });
+  }
+  const [owner] = repo.split("/", 1);
+  if (!owner) {
+    return Response.json({ error: "Bad repo" }, { status: 400 });
+  }
+  let token: string;
+  try {
+    token = await tokenForOrg(env, owner);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return Response.json({ error: msg }, { status: 403 });
   }
 
   const headers = {
-    Authorization: `Bearer ${env.GITHUB_TOKEN}`,
+    Authorization: `Bearer ${token}`,
     Accept: "application/vnd.github+json",
     "User-Agent": "ci-dashboard",
   };

--- a/src/release-alert.ts
+++ b/src/release-alert.ts
@@ -19,9 +19,10 @@
 
 import {
   parseRepo,
-  validateOrg,
+  tokenForOrg,
   GitHubApiError,
 } from "./github-api";
+import type { GitHubAppEnv } from "./github-app-auth";
 import {
   extractRefIssues,
   extractPrNumber,
@@ -117,13 +118,13 @@ export async function fetchIssuesByNumbers(
 // compute the alert payload, return null when no open issues are referenced
 // (banner suppressed).
 export async function computeReleaseAlert(
-  token: string,
+  env: GitHubAppEnv,
   repo: string,
   tagOverride?: string,
   kv?: KVNamespace,
 ): Promise<ReleaseAlert | null> {
   const { owner, repo: name } = parseRepo(repo);
-  validateOrg(owner);
+  const token = await tokenForOrg(env, owner);
 
   const tags = await cachedTags(token, kv, owner, name, 30);
   const tagNames = tags.map((t) => t.name);
@@ -169,12 +170,12 @@ export async function computeReleaseAlert(
 // are no open referenced issues left (banner should clear). Used by the
 // release-close path so a successful close immediately drops the banner.
 export async function recomputeAlert(
-  token: string,
+  env: GitHubAppEnv,
   repo: string,
   tag: string,
   kv?: KVNamespace,
 ): Promise<ReleaseAlert | null> {
-  return computeReleaseAlert(token, repo, tag, kv);
+  return computeReleaseAlert(env, repo, tag, kv);
 }
 
 // PR-merge variant of computeReleaseAlert for tagless repos. A merged PR is
@@ -186,7 +187,7 @@ export async function recomputeAlert(
 // `<defaultBranch>@pr-<n>` — the alert is still functional; the only loss is a
 // less-clickable label.
 export async function computeReleaseAlertForPr(
-  token: string,
+  env: GitHubAppEnv,
   repo: string,
   prNumber: number,
   mergeSha: string | null,
@@ -194,7 +195,7 @@ export async function computeReleaseAlertForPr(
   kv?: KVNamespace,
 ): Promise<ReleaseAlert | null> {
   const { owner, repo: name } = parseRepo(repo);
-  validateOrg(owner);
+  const token = await tokenForOrg(env, owner);
 
   const issueNumbers = new Set<number>();
 

--- a/src/release-close-batch.ts
+++ b/src/release-close-batch.ts
@@ -1,4 +1,5 @@
-import { githubApi, parseRepo, validateOrg } from "./github-api";
+import { githubApi, parseRepo, tokenForOrg } from "./github-api";
+import type { GitHubAppEnv } from "./github-app-auth";
 import { invalidateIssue } from "./release-cache";
 
 // POST /api/release-close-batch
@@ -17,7 +18,7 @@ const PAIR_RE = /^(.+):(\d+)$/;
 
 export async function handleReleaseCloseBatch(
   req: Request,
-  env: { GITHUB_TOKEN: string; CI_STATUS?: KVNamespace },
+  env: GitHubAppEnv,
   hub?: DurableObjectStub,
   ctx?: ExecutionContext,
 ): Promise<Response> {
@@ -52,10 +53,10 @@ export async function handleReleaseCloseBatch(
     return redirect("/releases");
   }
 
-  let owner: string, name: string;
+  let owner: string, name: string, token: string;
   try {
     ({ owner, repo: name } = parseRepo(repoParam));
-    validateOrg(owner);
+    token = await tokenForOrg(env, owner);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return new Response(`Bad repo: ${msg}`, { status: 400 });
@@ -72,12 +73,12 @@ export async function handleReleaseCloseBatch(
   const settled = await Promise.allSettled(
     ops.map(async ({ tag, issue }) => {
       await githubApi(
-        env.GITHUB_TOKEN, "POST",
+        token, "POST",
         `/repos/${owner}/${name}/issues/${issue}/comments`,
         { body: `Closed by release ${tag}` },
       );
       await githubApi(
-        env.GITHUB_TOKEN, "PATCH",
+        token, "PATCH",
         `/repos/${owner}/${name}/issues/${issue}`,
         { state: "closed", state_reason: "completed" },
       );
@@ -94,9 +95,11 @@ export async function handleReleaseCloseBatch(
 
   // Invalidate cached issue snapshots so the next /releases load reflects the
   // newly-closed state instead of the 60s-stale "open" row.
-  await Promise.all(
-    closed.map((n) => invalidateIssue(env.CI_STATUS, owner, name, n)),
-  );
+  if (env.CI_STATUS) {
+    await Promise.all(
+      closed.map((n) => invalidateIssue(env.CI_STATUS, owner, name, n)),
+    );
+  }
 
   // Kick Hub to recompute alert state for this repo when at least one close
   // succeeded. Same waitUntil pattern as release-close.ts so the redirect

--- a/src/release-close.ts
+++ b/src/release-close.ts
@@ -1,4 +1,5 @@
-import { githubApi, parseRepo, validateOrg } from "./github-api";
+import { githubApi, parseRepo, tokenForOrg } from "./github-api";
+import type { GitHubAppEnv } from "./github-app-auth";
 import { invalidateIssue } from "./release-cache";
 
 // POST /api/release-close
@@ -14,7 +15,7 @@ import { invalidateIssue } from "./release-cache";
 
 export async function handleReleaseClose(
   req: Request,
-  env: { GITHUB_TOKEN: string; CI_STATUS?: KVNamespace },
+  env: GitHubAppEnv,
   hub?: DurableObjectStub,
   ctx?: ExecutionContext,
 ): Promise<Response> {
@@ -39,10 +40,10 @@ export async function handleReleaseClose(
     return redirect(`/releases?repo=${encodeURIComponent(repoParam)}&tag=${encodeURIComponent(tag)}`);
   }
 
-  let owner: string, name: string;
+  let owner: string, name: string, token: string;
   try {
     ({ owner, repo: name } = parseRepo(repoParam));
-    validateOrg(owner);
+    token = await tokenForOrg(env, owner);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return new Response(`Bad repo: ${msg}`, { status: 400 });
@@ -53,12 +54,12 @@ export async function handleReleaseClose(
   const settled = await Promise.allSettled(
     issueNumbers.map(async (n) => {
       await githubApi(
-        env.GITHUB_TOKEN, "POST",
+        token, "POST",
         `/repos/${owner}/${name}/issues/${n}/comments`,
         { body: `Closed by release ${tag}` },
       );
       await githubApi(
-        env.GITHUB_TOKEN, "PATCH",
+        token, "PATCH",
         `/repos/${owner}/${name}/issues/${n}`,
         { state: "closed", state_reason: "completed" },
       );
@@ -76,9 +77,11 @@ export async function handleReleaseClose(
   // Drop the just-closed issues from the release cache so the next /releases
   // load (and the banner recompute below) sees `state: "closed"` instead of
   // the still-open snapshot from the 60s TTL window.
-  await Promise.all(
-    closed.map((n) => invalidateIssue(env.CI_STATUS, owner, name, n)),
-  );
+  if (env.CI_STATUS) {
+    await Promise.all(
+      closed.map((n) => invalidateIssue(env.CI_STATUS, owner, name, n)),
+    );
+  }
 
   // Kick the Hub to recompute the banner alert state for this repo when at
   // least one issue actually closed. waitUntil keeps the user-facing redirect

--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -1,4 +1,5 @@
-import { parseRepo, validateOrg, GitHubApiError } from "./github-api";
+import { parseRepo, tokenForOrg, GitHubApiError } from "./github-api";
+import type { GitHubAppEnv } from "./github-app-auth";
 import {
   extractRefIssues,
   sortSemverDesc,
@@ -38,9 +39,11 @@ import { PWA_HEAD_TAGS, PWA_REGISTER_SCRIPT } from "./pwa";
 export async function handleReleasesPage(
   req: Request,
   env: {
-    GITHUB_TOKEN: string;
+    GITHUB_APP_ID: string;
+    GITHUB_APP_PRIVATE_KEY: string;
+    GITHUB_APP_INSTALLATIONS: string;
     CI_HUB: DurableObjectNamespace;
-    CI_STATUS?: KVNamespace;
+    CI_STATUS: KVNamespace;
     TAGLESS_REPOS?: string;
   },
 ): Promise<Response> {
@@ -63,7 +66,7 @@ export async function handleReleasesPage(
   if (repoParam && tag) {
     let result: ReleasePayload;
     try {
-      result = await loadRelease(env.GITHUB_TOKEN, repoParam, tag, env.CI_STATUS);
+      result = await loadRelease(env, repoParam, tag, env.CI_STATUS);
     } catch (err) {
       if (err instanceof GitHubApiError && err.status === 404) {
         return html(renderError(`Not found: ${err.message}`), 404);
@@ -124,9 +127,11 @@ const TOP_TAGS_INLINE = 5;
 
 async function handleIndexPage(
   env: {
-    GITHUB_TOKEN: string;
+    GITHUB_APP_ID: string;
+    GITHUB_APP_PRIVATE_KEY: string;
+    GITHUB_APP_INSTALLATIONS: string;
     CI_HUB: DurableObjectNamespace;
-    CI_STATUS?: KVNamespace;
+    CI_STATUS: KVNamespace;
     TAGLESS_REPOS?: string;
   },
   closedFlash: number[],
@@ -157,7 +162,7 @@ async function handleIndexPage(
 
   let allowlist = new Set<string>();
   try {
-    allowlist = await loadDirectPushAllowlist(env.GITHUB_TOKEN, env.CI_STATUS);
+    allowlist = await loadDirectPushAllowlist(env, env.CI_STATUS);
     for (const r of allowlist) watched.add(r);
   } catch { /* graceful: allowlist stays empty, existing tag-flow unaffected */ }
 
@@ -173,7 +178,7 @@ async function handleIndexPage(
   const views = await Promise.all(repos.map(async (repo) => {
     try {
       const useSynthetic = allowlist.has(repo) || tagless.has(repo);
-      return await loadRepoView(env.GITHUB_TOKEN, repo, useSynthetic, env.CI_STATUS);
+      return await loadRepoView(env, repo, useSynthetic, env.CI_STATUS);
     } catch {
       return null;
     }
@@ -192,13 +197,13 @@ async function handleIndexPage(
 }
 
 async function loadRepoView(
-  token: string,
+  env: GitHubAppEnv,
   repo: string,
   useSynthetic: boolean,
   kv?: KVNamespace,
 ): Promise<RepoView | null> {
   const { owner, repo: name } = parseRepo(repo);
-  validateOrg(owner);
+  const token = await tokenForOrg(env, owner);
 
   // 1. Recent semver tags. 10 gives us 5 inline + room for the predecessor
   //    pairing on the oldest of those 5 + a small "older" strip.
@@ -389,13 +394,13 @@ interface IssueRow {
 }
 
 async function loadRelease(
-  token: string,
+  env: GitHubAppEnv,
   repoParam: string,
   tag: string,
   kv?: KVNamespace,
 ): Promise<ReleasePayload> {
   const { owner, repo: name } = parseRepo(repoParam);
-  validateOrg(owner);
+  const token = await tokenForOrg(env, owner);
 
   // 1. Pull recent tags so we can pick the immediate predecessor for the
   //    compare endpoint. 30 is plenty given typical release cadence; for

--- a/src/tag-release.ts
+++ b/src/tag-release.ts
@@ -1,4 +1,5 @@
 import type { Env } from "./index";
+import { tokenForOrg } from "./github-api";
 
 export async function handleTagRelease(
   request: Request,
@@ -6,12 +7,19 @@ export async function handleTagRelease(
 ): Promise<Response> {
   const { repo } = await request.json<{ repo: string }>();
 
-  const allowedOrgs = ["ippoan/", "ohishi-exp/"];
-  if (!repo || !allowedOrgs.some((org) => repo.startsWith(org))) {
-    return Response.json(
-      { error: "Org not allowed" },
-      { status: 403 },
-    );
+  if (!repo) {
+    return Response.json({ error: "Missing repo" }, { status: 400 });
+  }
+  const [owner] = repo.split("/", 1);
+  if (!owner) {
+    return Response.json({ error: "Bad repo" }, { status: 400 });
+  }
+  let token: string;
+  try {
+    token = await tokenForOrg(env, owner);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return Response.json({ error: msg }, { status: 403 });
   }
 
   const res = await fetch(
@@ -19,7 +27,7 @@ export async function handleTagRelease(
     {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${env.GITHUB_TOKEN}`,
+        Authorization: `Bearer ${token}`,
         Accept: "application/vnd.github+json",
         "User-Agent": "ci-dashboard",
       },

--- a/test/_helpers/app-env.ts
+++ b/test/_helpers/app-env.ts
@@ -1,0 +1,53 @@
+// Shared test helper for the GitHub App auth migration (#112).
+//
+// Pre-seeds cached installation tokens into KV so production code can call
+// `getInstallationToken(env, org)` without firing the JWT-exchange path.
+// Replaces the old "give the test a `GITHUB_TOKEN` secret" pattern; every test
+// that touches a real githubApi() call now seeds 3 tokens and uses
+// `appTestEnv()` to supply the App secrets.
+
+import { env } from "cloudflare:test";
+
+// Same dummy installation IDs across all tests. The actual integer doesn't
+// matter — Worker code only ever uses it as a KV key suffix.
+export const TEST_INSTALLATIONS = {
+  "ippoan": 111,
+  "ohishi-exp": 222,
+  "yhonda-ohishi": 333,
+} as const;
+
+export const TEST_INSTALLATION_TOKEN = "test-token";
+
+/** Env object suitable for handlers that take GitHubAppEnv (or its supersets
+ *  like the full Worker Env in src/index.ts). The values are syntactically
+ *  valid but never actually drive a JWT exchange because `seedTestTokens()`
+ *  pre-populates the per-installation KV cache. */
+export function appTestEnv() {
+  return {
+    GITHUB_APP_ID: "1",
+    GITHUB_APP_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----\nTEST\n-----END PRIVATE KEY-----",
+    GITHUB_APP_INSTALLATIONS: JSON.stringify(TEST_INSTALLATIONS),
+    CI_STATUS: env.CI_STATUS,
+  };
+}
+
+/** Pre-populate the KV cache so `getInstallationToken(env, org)` returns
+ *  `TEST_INSTALLATION_TOKEN` synchronously without minting a JWT. Call this
+ *  in `beforeEach` for any test whose stubbed fetch expects the
+ *  Authorization header but doesn't want to stub the App-token endpoint. */
+export async function seedTestTokens(): Promise<void> {
+  const expires_at_ms = Date.now() + 3600 * 1000;
+  for (const id of Object.values(TEST_INSTALLATIONS)) {
+    await env.CI_STATUS.put(
+      `gh-app:token:${id}`,
+      JSON.stringify({ token: TEST_INSTALLATION_TOKEN, expires_at_ms }),
+    );
+  }
+}
+
+/** Clear seeded tokens between tests so a fresh seed always wins. */
+export async function clearTestTokens(): Promise<void> {
+  for (const id of Object.values(TEST_INSTALLATIONS)) {
+    await env.CI_STATUS.delete(`gh-app:token:${id}`);
+  }
+}

--- a/test/_helpers/setup-app-env.ts
+++ b/test/_helpers/setup-app-env.ts
@@ -1,0 +1,16 @@
+// Global Vitest setup: seed GitHub App installation tokens into KV before
+// every test runs. Production code calls `getInstallationToken(env, org)`
+// which reads from KV `gh-app:token:<installation_id>`; by pre-seeding a
+// long-lived fake token we let tests stub `globalThis.fetch` without ever
+// firing the App-JWT exchange path.
+//
+// Tests that explicitly exercise the App-auth path (test/github-app-auth.test.ts)
+// clear and re-seed on their own — `beforeEach` here gets out of their way
+// because `clearTestTokens` in those tests runs after our seed.
+
+import { beforeEach } from "vitest";
+import { seedTestTokens } from "./app-env";
+
+beforeEach(async () => {
+  await seedTestTokens();
+});

--- a/test/direct-push-allowlist.test.ts
+++ b/test/direct-push-allowlist.test.ts
@@ -1,3 +1,4 @@
+import { appTestEnv } from "./_helpers/app-env";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   parseAllowlist,
@@ -75,7 +76,7 @@ describe("loadDirectPushAllowlist", () => {
       "yhonda-ohishi/claude-hooks",
     ]);
     const kv = memoryKv();
-    const set = await loadDirectPushAllowlist("token", kv);
+    const set = await loadDirectPushAllowlist(appTestEnv(), kv);
     expect([...set].sort()).toEqual([
       "ippoan/ci-workflows",
       "yhonda-ohishi/claude-hooks",
@@ -96,7 +97,7 @@ describe("loadDirectPushAllowlist", () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
       throw new Error("should not be called");
     });
-    const set = await loadDirectPushAllowlist("token", kv);
+    const set = await loadDirectPushAllowlist(appTestEnv(), kv);
     expect([...set]).toEqual(["cached/repo"]);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
@@ -106,7 +107,7 @@ describe("loadDirectPushAllowlist", () => {
       new Response("Not Found", { status: 404 }),
     );
     const kv = memoryKv();
-    const set = await loadDirectPushAllowlist("token", kv);
+    const set = await loadDirectPushAllowlist(appTestEnv(), kv);
     expect(set.size).toBe(0);
     // Empty fetches must NOT poison the cache; the next load gets a real
     // chance against GitHub.
@@ -116,7 +117,7 @@ describe("loadDirectPushAllowlist", () => {
 
   it("works without a KV namespace (pure fetch fallback)", async () => {
     stubContentsResponse(["a/b"]);
-    const set = await loadDirectPushAllowlist("token");
+    const set = await loadDirectPushAllowlist(appTestEnv());
     expect([...set]).toEqual(["a/b"]);
   });
 });

--- a/test/issue-prs.test.ts
+++ b/test/issue-prs.test.ts
@@ -1,3 +1,4 @@
+import { appTestEnv } from "./_helpers/app-env";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { extractIssueRefs, fetchOpenPrsByIssue, fetchAllOpenPrsByIssue } from "../src/issue-prs";
 
@@ -82,7 +83,7 @@ describe("fetchOpenPrsByIssue()", () => {
       }),
     );
 
-    const map = await fetchOpenPrsByIssue("token", { orgs: ["ippoan"] });
+    const map = await fetchOpenPrsByIssue(appTestEnv(), { orgs: ["ippoan"] });
     expect(spy).toHaveBeenCalledTimes(1);
     const url = String(spy.mock.calls[0]![0]);
     const decoded = decodeURIComponent(url);
@@ -102,7 +103,7 @@ describe("fetchOpenPrsByIssue()", () => {
     const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       Response.json({ total_count: 0, incomplete_results: false, items: [] }),
     );
-    await fetchOpenPrsByIssue("token", {
+    await fetchOpenPrsByIssue(appTestEnv(), {
       repos: ["yhonda-ohishi/claude-skills", "yhonda-ohishi/claude-hooks"],
     });
     const url = String(spy.mock.calls[0]![0]);
@@ -113,7 +114,7 @@ describe("fetchOpenPrsByIssue()", () => {
   });
 
   it("rejects unknown orgs via validateOrg", async () => {
-    await expect(fetchOpenPrsByIssue("token", { orgs: ["evil-org"] }))
+    await expect(fetchOpenPrsByIssue(appTestEnv(), { orgs: ["evil-org"] }))
       .rejects.toThrow(/Org not allowed/);
   });
 });
@@ -154,7 +155,7 @@ describe("fetchAllOpenPrsByIssue()", () => {
     });
 
     const map = await fetchAllOpenPrsByIssue(
-      "token", ["ippoan"], ["yhonda-ohishi/claude-skills"],
+      appTestEnv(), ["ippoan"], ["yhonda-ohishi/claude-skills"],
     );
     const refs = map.get("ippoan/foo#5");
     expect(refs).toBeDefined();

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -8,7 +8,9 @@ function testEnv(): Env {
   return {
     CI_STATUS: env.CI_STATUS,
     WEBHOOK_SECRET: "test-secret",
-    GITHUB_TOKEN: "test-token",
+    GITHUB_APP_ID: "1",
+    GITHUB_APP_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----\nTEST\n-----END PRIVATE KEY-----",
+    GITHUB_APP_INSTALLATIONS: JSON.stringify({"ippoan":111,"ohishi-exp":222,"yhonda-ohishi":333}),
     CI_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
   };
 }
@@ -82,6 +84,11 @@ function stubFetch(opts: { withProjects?: boolean; withPrs?: boolean } = {}) {
       if (decoded.includes("repo:yhonda-ohishi/claude-skills")) {
         return Response.json({ total_count: 0, incomplete_results: false, items: [] });
       }
+      // Per-org fan-out: only `org:ippoan` returns the seeded PR (it lives in
+      // ippoan/rust-alc-api). Other orgs return empty.
+      if (!decoded.includes("org:ippoan")) {
+        return Response.json({ total_count: 0, incomplete_results: false, items: [] });
+      }
       return Response.json({
         total_count: 1,
         incomplete_results: false,
@@ -127,51 +134,73 @@ function stubFetch(opts: { withProjects?: boolean; withPrs?: boolean } = {}) {
         ],
       });
     }
+    // GitHub App per-org fan-out: each cross-org search is issued separately
+    // with its own installation token. Match on the `org:` qualifier so the
+    // stub returns ONLY that org's rows (mirrors how real GitHub Search
+    // behaves with a per-org-scoped token: cross-org results aren't visible).
+    const ippoanItems = [
+      {
+        number: 7,
+        title: "<script>alert('xss')</script> & ok",
+        state: "open",
+        user: { login: "yhonda-ohishi" },
+        labels: [{ name: "bug" }, { name: "needs-triage" }],
+        assignees: [],
+        comments: 0,
+        created_at: "2026-05-10T00:00:00Z",
+        updated_at: "2026-05-10T03:00:00Z",
+        html_url: "https://github.com/ippoan/rust-alc-api/issues/7",
+        repository_url: "https://api.github.com/repos/ippoan/rust-alc-api",
+      },
+      {
+        number: 99,
+        title: "This is a PR, must be excluded",
+        state: "open",
+        user: { login: "yhonda-ohishi" },
+        labels: [],
+        assignees: [],
+        comments: 0,
+        created_at: "2026-05-08T00:00:00Z",
+        updated_at: "2026-05-08T00:00:00Z",
+        html_url: "https://github.com/ippoan/rust-alc-api/pull/99",
+        repository_url: "https://api.github.com/repos/ippoan/rust-alc-api",
+        pull_request: { url: "https://api.github.com/..." },
+      },
+    ];
+    const ohishiItems = [
+      {
+        number: 3,
+        title: "Add feature X",
+        state: "open",
+        user: { login: "yhonda-ohishi" },
+        labels: [],
+        assignees: [{ login: "yhonda-ohishi" }],
+        comments: 2,
+        created_at: "2026-05-09T00:00:00Z",
+        updated_at: "2026-05-09T05:00:00Z",
+        html_url: "https://github.com/ohishi-exp/daiun-salary/issues/3",
+        repository_url: "https://api.github.com/repos/ohishi-exp/daiun-salary",
+      },
+    ];
+    if (decoded.includes("org:ippoan")) {
+      return Response.json({
+        total_count: ippoanItems.length,
+        incomplete_results: false,
+        items: ippoanItems,
+      });
+    }
+    if (decoded.includes("org:ohishi-exp")) {
+      return Response.json({
+        total_count: ohishiItems.length,
+        incomplete_results: false,
+        items: ohishiItems,
+      });
+    }
+    // Fallback (no org qualifier — preserves callers that hit the bare URL).
     return Response.json({
-      total_count: 3,
+      total_count: ippoanItems.length + ohishiItems.length,
       incomplete_results: false,
-      items: [
-        {
-          number: 7,
-          title: "<script>alert('xss')</script> & ok",
-          state: "open",
-          user: { login: "yhonda-ohishi" },
-          labels: [{ name: "bug" }, { name: "needs-triage" }],
-          assignees: [],
-          comments: 0,
-          created_at: "2026-05-10T00:00:00Z",
-          updated_at: "2026-05-10T03:00:00Z",
-          html_url: "https://github.com/ippoan/rust-alc-api/issues/7",
-          repository_url: "https://api.github.com/repos/ippoan/rust-alc-api",
-        },
-        {
-          number: 3,
-          title: "Add feature X",
-          state: "open",
-          user: { login: "yhonda-ohishi" },
-          labels: [],
-          assignees: [{ login: "yhonda-ohishi" }],
-          comments: 2,
-          created_at: "2026-05-09T00:00:00Z",
-          updated_at: "2026-05-09T05:00:00Z",
-          html_url: "https://github.com/ohishi-exp/daiun-salary/issues/3",
-          repository_url: "https://api.github.com/repos/ohishi-exp/daiun-salary",
-        },
-        {
-          number: 99,
-          title: "This is a PR, must be excluded",
-          state: "open",
-          user: { login: "yhonda-ohishi" },
-          labels: [],
-          assignees: [],
-          comments: 0,
-          created_at: "2026-05-08T00:00:00Z",
-          updated_at: "2026-05-08T00:00:00Z",
-          html_url: "https://github.com/ippoan/rust-alc-api/pull/99",
-          repository_url: "https://api.github.com/repos/ippoan/rust-alc-api",
-          pull_request: { url: "https://api.github.com/..." },
-        },
-      ],
+      items: [...ippoanItems, ...ohishiItems],
     });
   });
 }
@@ -241,32 +270,40 @@ describe("GET /issues", () => {
     expect(html).toContain("&amp;");
   });
 
-  it("queries GitHub Search twice: main orgs and yhonda-ohishi/claude-* repo filter", async () => {
+  it("fans out one /search/issues call per org for both is:issue and is:pr (App auth per-org token requirement)", async () => {
     const spy = stubSearchIssues();
     const req = new Request("http://localhost/issues");
     const ctx = createExecutionContext();
     await worker.fetch(req, testEnv(), ctx);
     await waitOnExecutionContext(ctx);
 
-    // `/search/issues` is hit four times: 2 for `is:issue` (main orgs +
-    // yhonda repo: filter) + 2 for `is:pr` (related-PR map, same shape).
-    // The extra `/graphql` calls for the Projects v2 map are ignored here.
+    // GitHub App installation tokens are scoped per-org so `org:ippoan org:ohishi-exp`
+    // cannot be served by a single search call. After #112 (PAT → App migration),
+    // each cross-org search splits into one call per org. So /search/issues is hit:
+    //   is:issue × 3 (ippoan, ohishi-exp, yhonda-ohishi repo: filter)
+    //   is:pr    × 3 (same shape, related-PR map fan-out)
+    // = 6 total. /graphql calls for the Projects v2 map are ignored here.
     const searchCalls = spy.mock.calls.filter((c) =>
       String(c[0]).includes("/search/issues"));
-    expect(searchCalls).toHaveLength(4);
+    expect(searchCalls).toHaveLength(6);
     const urls = searchCalls.map((c) => c[0] as string);
     const decoded = urls.map((u) => decodeURIComponent(u));
-    const issueDecoded = decoded.filter((d) => d.includes("is:issue"));
-    expect(issueDecoded).toHaveLength(2);
+    const issueDecoded = decoded.filter((d) => d.includes("is:issue") && !d.includes("is:pr"));
+    expect(issueDecoded).toHaveLength(3);
 
-    // Main call: ippoan + ohishi-exp orgs without a repo: qualifier.
-    const main = issueDecoded.find((d) => d.includes("org:ippoan"));
-    expect(main).toBeDefined();
-    expect(main!).toContain("is:issue");
-    expect(main!).toContain("state:open");
-    expect(main!).toContain("org:ippoan");
-    expect(main!).toContain("org:ohishi-exp");
-    expect(main!).not.toContain("repo:yhonda-ohishi/claude-");
+    // Each main org gets its own search with a single `org:` qualifier.
+    const ippoan = issueDecoded.find((d) => d.includes("org:ippoan"));
+    expect(ippoan).toBeDefined();
+    expect(ippoan!).toContain("is:issue");
+    expect(ippoan!).toContain("state:open");
+    expect(ippoan!).toContain("org:ippoan");
+    expect(ippoan!).not.toContain("org:ohishi-exp");
+    expect(ippoan!).not.toContain("repo:yhonda-ohishi/claude-");
+
+    const ohishi = issueDecoded.find((d) => d.includes("org:ohishi-exp"));
+    expect(ohishi).toBeDefined();
+    expect(ohishi!).toContain("org:ohishi-exp");
+    expect(ohishi!).not.toContain("org:ippoan");
 
     // yhonda-ohishi call: repo: qualifiers (OR) for the two active claude
     // tooling repos only — and CRUCIALLY no `org:yhonda-ohishi`. GitHub Search
@@ -282,10 +319,11 @@ describe("GET /issues", () => {
     expect(yhonda!).toContain("repo:yhonda-ohishi/claude-hooks");
     expect(yhonda!).not.toContain("org:yhonda-ohishi");
 
-    // Both calls must exclude archived repos so old projects (e.g.
+    // Every call must exclude archived repos so old projects (e.g.
     // ippoan/cf-secrets-mcp) don't leak open issues into the dashboard.
     // Regression guard for issue #99.
-    expect(main!).toContain("archived:false");
+    expect(ippoan!).toContain("archived:false");
+    expect(ohishi!).toContain("archived:false");
     expect(yhonda!).toContain("archived:false");
 
     for (const u of urls) expect(u).toContain("per_page=100");

--- a/test/mcp/projects.test.ts
+++ b/test/mcp/projects.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { githubGraphQL, GitHubApiError } from "../../src/github-api";
 import { resolveProjectId, resolveIssueContentId } from "../../src/mcp/tools/projects";
+import { appTestEnv } from "../_helpers/app-env";
 
 // These tests exercise the GraphQL helper + Projects v2 tool logic against
 // mocked fetch responses. The MCP transport itself is covered by tools.test.ts.
@@ -127,7 +128,7 @@ describe("Projects v2 tools — integration via MCP server", () => {
         params: { name, arguments: args },
       }),
     });
-    const res = await handleMcpRequest(req, "test-token");
+    const res = await handleMcpRequest(req, appTestEnv());
     expect(res.status).toBe(200);
     const body = await res.json() as {
       result?: { content?: Array<{ type: string; text: string }>; isError?: boolean };

--- a/test/mcp/tools.test.ts
+++ b/test/mcp/tools.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { githubApi, githubApiRaw, parseRepo, validateOrg, GitHubApiError } from "../../src/github-api";
 import { buildUpdateIssuePayload, fetchOrgIssues } from "../../src/mcp/tools/issues";
+import { appTestEnv } from "../_helpers/app-env";
 
 // Test MCP tool logic by calling the same functions the tools use.
 // The MCP protocol layer (JSON-RPC, transport) is tested by the SDK itself.
@@ -566,7 +567,7 @@ describe("list_org_issues tool logic", () => {
       Response.json({ total_count: 0, incomplete_results: false, items: [] }),
     );
 
-    await fetchOrgIssues("token", { orgs: ["ippoan"], state: "open" });
+    await fetchOrgIssues(appTestEnv(), { orgs: ["ippoan"], state: "open" });
 
     const url = fetchSpy.mock.calls[0]![0] as string;
     const decoded = decodeURIComponent(url.replace(/\+/g, " "));
@@ -578,7 +579,7 @@ describe("list_org_issues tool logic", () => {
       Response.json({ total_count: 0, incomplete_results: false, items: [] }),
     );
 
-    await fetchOrgIssues("token", {
+    await fetchOrgIssues(appTestEnv(), {
       orgs: ["ippoan"],
       state: "open",
       query: "archived:true",

--- a/test/projects-page.test.ts
+++ b/test/projects-page.test.ts
@@ -7,7 +7,9 @@ function testEnv(): Env {
   return {
     CI_STATUS: env.CI_STATUS,
     WEBHOOK_SECRET: "test-secret",
-    GITHUB_TOKEN: "test-token",
+    GITHUB_APP_ID: "1",
+    GITHUB_APP_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----\nTEST\n-----END PRIVATE KEY-----",
+    GITHUB_APP_INSTALLATIONS: JSON.stringify({"ippoan":111,"ohishi-exp":222,"yhonda-ohishi":333}),
     CI_HUB: {
       idFromName: () => ({}),
       get: () => ({ fetch: async () => new Response("OK") }),

--- a/test/release-alert.test.ts
+++ b/test/release-alert.test.ts
@@ -1,3 +1,4 @@
+import { appTestEnv } from "./_helpers/app-env";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   computeReleaseAlert,
@@ -82,7 +83,7 @@ describe("computeReleaseAlert", () => {
 
   it("returns null when the repo has no tags", async () => {
     stubGithub({ tags: [] });
-    const result = await computeReleaseAlert("token", "ippoan/foo");
+    const result = await computeReleaseAlert(appTestEnv(), "ippoan/foo");
     expect(result).toBeNull();
   });
 
@@ -93,7 +94,7 @@ describe("computeReleaseAlert", () => {
         "v1.0.0...v1.1.0": { commits: [{ commit: { message: "feat: noop" } }] },
       },
     });
-    const result = await computeReleaseAlert("token", "ippoan/foo");
+    const result = await computeReleaseAlert(appTestEnv(), "ippoan/foo");
     expect(result).toBeNull();
   });
 
@@ -107,7 +108,7 @@ describe("computeReleaseAlert", () => {
       },
       issues: { 42: closedIssue(42) },
     });
-    const result = await computeReleaseAlert("token", "ippoan/foo");
+    const result = await computeReleaseAlert(appTestEnv(), "ippoan/foo");
     expect(result).toBeNull();
   });
 
@@ -128,7 +129,7 @@ describe("computeReleaseAlert", () => {
         12: openIssue(12, "open two"),
       },
     });
-    const result = await computeReleaseAlert("token", "ippoan/foo");
+    const result = await computeReleaseAlert(appTestEnv(), "ippoan/foo");
     expect(result).not.toBeNull();
     expect(result!.repo).toBe("ippoan/foo");
     expect(result!.tag).toBe("v1.2.0");
@@ -150,7 +151,7 @@ describe("computeReleaseAlert", () => {
       },
       issues: { 99: openIssue(99) },
     });
-    const result = await computeReleaseAlert("token", "ippoan/foo", "v1.2.0");
+    const result = await computeReleaseAlert(appTestEnv(), "ippoan/foo", "v1.2.0");
     expect(result?.tag).toBe("v1.2.0");
     expect(result?.openIssues[0]?.number).toBe(99);
   });
@@ -160,13 +161,13 @@ describe("computeReleaseAlert", () => {
       tags: [{ name: "v1.0.0" }],
     });
     await expect(
-      computeReleaseAlert("token", "ippoan/foo", "v9.9.9"),
+      computeReleaseAlert(appTestEnv(), "ippoan/foo", "v9.9.9"),
     ).rejects.toThrow(/Tag .* not present/);
   });
 
   it("rejects disallowed orgs", async () => {
     await expect(
-      computeReleaseAlert("token", "evil-org/foo"),
+      computeReleaseAlert(appTestEnv(), "evil-org/foo"),
     ).rejects.toThrow(/Org not allowed/);
   });
 
@@ -184,7 +185,7 @@ describe("computeReleaseAlert", () => {
       if (issueMatch) return Response.json(openIssue(Number(issueMatch[1])));
       return new Response("unstubbed", { status: 500 });
     });
-    const result = await computeReleaseAlert("token", "ippoan/foo");
+    const result = await computeReleaseAlert(appTestEnv(), "ippoan/foo");
     expect(result?.openIssues.map((i) => i.number)).toEqual([1]);
   });
 
@@ -202,7 +203,7 @@ describe("computeReleaseAlert", () => {
         51: { ...openIssue(51), pull_request: { url: "x" } },
       },
     });
-    const result = await computeReleaseAlert("token", "ippoan/foo");
+    const result = await computeReleaseAlert(appTestEnv(), "ippoan/foo");
     expect(result?.openIssues.map((i) => i.number)).toEqual([50]);
   });
 });
@@ -220,7 +221,7 @@ describe("recomputeAlert", () => {
       },
       issues: { 7: openIssue(7) },
     });
-    const fresh = await recomputeAlert("token", "ippoan/foo", "v1.1.0");
+    const fresh = await recomputeAlert(appTestEnv(), "ippoan/foo", "v1.1.0");
     expect(fresh?.tag).toBe("v1.1.0");
     expect(fresh?.openIssues[0]?.number).toBe(7);
   });
@@ -235,7 +236,7 @@ describe("recomputeAlert", () => {
       },
       issues: { 7: closedIssue(7) },
     });
-    const fresh = await recomputeAlert("token", "ippoan/foo", "v1.1.0");
+    const fresh = await recomputeAlert(appTestEnv(), "ippoan/foo", "v1.1.0");
     expect(fresh).toBeNull();
   });
 });
@@ -265,7 +266,7 @@ describe("computeReleaseAlertForPr", () => {
       },
     });
     const result = await computeReleaseAlertForPr(
-      "token", "ippoan/secrets-inventory-gcp", 42, "deadbeef12345", "main",
+      appTestEnv(), "ippoan/secrets-inventory-gcp", 42, "deadbeef12345", "main",
     );
     expect(result).not.toBeNull();
     expect(result!.repo).toBe("ippoan/secrets-inventory-gcp");
@@ -282,7 +283,7 @@ describe("computeReleaseAlertForPr", () => {
       prCommits: { 1: [{ commit: { message: "feat: thing" } }] },
     });
     const result = await computeReleaseAlertForPr(
-      "token", "ippoan/foo", 1, "abc1234", "main",
+      appTestEnv(), "ippoan/foo", 1, "abc1234", "main",
     );
     expect(result).toBeNull();
   });
@@ -294,7 +295,7 @@ describe("computeReleaseAlertForPr", () => {
       issues: { 5: closedIssue(5) },
     });
     const result = await computeReleaseAlertForPr(
-      "token", "ippoan/foo", 2, "abc1234", "main",
+      appTestEnv(), "ippoan/foo", 2, "abc1234", "main",
     );
     expect(result).toBeNull();
   });
@@ -306,14 +307,14 @@ describe("computeReleaseAlertForPr", () => {
       issues: { 8: openIssue(8) },
     });
     const result = await computeReleaseAlertForPr(
-      "token", "ippoan/foo", 3, null, "main",
+      appTestEnv(), "ippoan/foo", 3, null, "main",
     );
     expect(result?.tag).toBe("main@pr-3");
   });
 
   it("rejects disallowed orgs", async () => {
     await expect(
-      computeReleaseAlertForPr("token", "evil-org/foo", 1, "abc", "main"),
+      computeReleaseAlertForPr(appTestEnv(), "evil-org/foo", 1, "abc", "main"),
     ).rejects.toThrow(/Org not allowed/);
   });
 
@@ -327,7 +328,7 @@ describe("computeReleaseAlertForPr", () => {
       },
     });
     const result = await computeReleaseAlertForPr(
-      "token", "ippoan/foo", 4, "abc1234", "main",
+      appTestEnv(), "ippoan/foo", 4, "abc1234", "main",
     );
     expect(result?.openIssues.map((i) => i.number)).toEqual([50]);
   });

--- a/test/release-close-batch.test.ts
+++ b/test/release-close-batch.test.ts
@@ -7,7 +7,9 @@ function testEnv(): Env {
   return {
     CI_STATUS: env.CI_STATUS,
     WEBHOOK_SECRET: "test-secret",
-    GITHUB_TOKEN: "test-token",
+    GITHUB_APP_ID: "1",
+    GITHUB_APP_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----\nTEST\n-----END PRIVATE KEY-----",
+    GITHUB_APP_INSTALLATIONS: JSON.stringify({"ippoan":111,"ohishi-exp":222,"yhonda-ohishi":333}),
     CI_HUB: {
       idFromName: () => ({}),
       get: () => ({ fetch: async () => new Response("OK") }),

--- a/test/release-close.test.ts
+++ b/test/release-close.test.ts
@@ -7,7 +7,9 @@ function testEnv(): Env {
   return {
     CI_STATUS: env.CI_STATUS,
     WEBHOOK_SECRET: "test-secret",
-    GITHUB_TOKEN: "test-token",
+    GITHUB_APP_ID: "1",
+    GITHUB_APP_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----\nTEST\n-----END PRIVATE KEY-----",
+    GITHUB_APP_INSTALLATIONS: JSON.stringify({"ippoan":111,"ohishi-exp":222,"yhonda-ohishi":333}),
     CI_HUB: {
       idFromName: () => ({}),
       get: () => ({ fetch: async () => new Response("OK") }),

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -12,7 +12,9 @@ function testEnv(opts: { watched?: string[] } = {}): Env {
   return {
     CI_STATUS: env.CI_STATUS,
     WEBHOOK_SECRET: "test-secret",
-    GITHUB_TOKEN: "test-token",
+    GITHUB_APP_ID: "1",
+    GITHUB_APP_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----\nTEST\n-----END PRIVATE KEY-----",
+    GITHUB_APP_INSTALLATIONS: JSON.stringify({"ippoan":111,"ohishi-exp":222,"yhonda-ohishi":333}),
     CI_HUB: {
       idFromName: () => ({}),
       get: () => ({

--- a/test/secret-gen-page.test.ts
+++ b/test/secret-gen-page.test.ts
@@ -13,7 +13,9 @@ function testEnv(): Env {
   return {
     CI_STATUS: env.CI_STATUS,
     WEBHOOK_SECRET: "test-secret",
-    GITHUB_TOKEN: "test-token",
+    GITHUB_APP_ID: "1",
+    GITHUB_APP_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----\nTEST\n-----END PRIVATE KEY-----",
+    GITHUB_APP_INSTALLATIONS: JSON.stringify({"ippoan":111,"ohishi-exp":222,"yhonda-ohishi":333}),
     CI_HUB: {
       idFromName: () => ({}),
       get: () => ({ fetch: async () => new Response("OK") }),

--- a/test/status.test.ts
+++ b/test/status.test.ts
@@ -66,7 +66,9 @@ function testEnv(): Env {
   return {
     CI_STATUS: env.CI_STATUS,
     WEBHOOK_SECRET,
-    GITHUB_TOKEN: "test-token",
+    GITHUB_APP_ID: "1",
+    GITHUB_APP_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----\nTEST\n-----END PRIVATE KEY-----",
+    GITHUB_APP_INSTALLATIONS: JSON.stringify({"ippoan":111,"ohishi-exp":222,"yhonda-ohishi":333}),
     CI_HUB: { idFromName: () => ({}), get: () => hub } as unknown as DurableObjectNamespace,
   };
 }

--- a/test/tag-release.test.ts
+++ b/test/tag-release.test.ts
@@ -1,13 +1,15 @@
-import { createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
 import { describe, it, expect, vi } from "vitest";
 import worker from "../src/index";
 import type { Env } from "../src/index";
 
 function testEnv(): Env {
   return {
-    CI_STATUS: {} as unknown as KVNamespace,
+    CI_STATUS: env.CI_STATUS,
     WEBHOOK_SECRET: "test-secret",
-    GITHUB_TOKEN: "ghp_test_token",
+    GITHUB_APP_ID: "1",
+    GITHUB_APP_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----\nTEST\n-----END PRIVATE KEY-----",
+    GITHUB_APP_INSTALLATIONS: JSON.stringify({"ippoan":111,"ohishi-exp":222,"yhonda-ohishi":333}),
     CI_HUB: {} as unknown as DurableObjectNamespace,
   };
 }

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -148,7 +148,9 @@ function testEnv(): Env {
   return {
     CI_STATUS: env.CI_STATUS,
     WEBHOOK_SECRET,
-    GITHUB_TOKEN: "test-token",
+    GITHUB_APP_ID: "1",
+    GITHUB_APP_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----\nTEST\n-----END PRIVATE KEY-----",
+    GITHUB_APP_INSTALLATIONS: JSON.stringify({"ippoan":111,"ohishi-exp":222,"yhonda-ohishi":333}),
     CI_HUB: { idFromName: () => ({}), get: () => hub } as unknown as DurableObjectNamespace,
   };
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   test: {
     globals: true,
     include: ["test/**/*.test.ts"],
+    setupFiles: ["./test/_helpers/setup-app-env.ts"],
     coverage: {
       provider: "istanbul",
       reporter: ["text", "json-summary", "html"],


### PR DESCRIPTION
## Summary

PR 2/2 of the PAT→GitHub App migration tracked in #112 (PR 1/2 was #113). This swaps every `env.GITHUB_TOKEN` call site to `getInstallationToken(env, org)` and removes the old secret from the Env type entirely.

End state: **no PAT anywhere in the worker** — auth flows from App private key → JWT (10 min) → installation token (1 h, KV-cached ~55 min) → existing `githubApi(token, ...)` callers, completely transparent.

## Worker code (13 files)

- `src/github-api.ts` adds `tokenForOrg(env, owner)` (validateOrg + getInstallationToken in one)
- `src/index.ts` Env: `GITHUB_TOKEN` → `GITHUB_APP_ID` + `GITHUB_APP_PRIVATE_KEY` + `GITHUB_APP_INSTALLATIONS`
- MCP server + 8 tool files: each tool resolves a token from its repo arg
- `fetchOrgIssues` / `fetchAllOpenPrsByIssue` / `fetchOrgProjects` / `fetchProjectIssueMap`: **per-org fan-out** because App installation tokens are scoped per-org (a single `org:ippoan org:ohishi-exp` query can't be served by one token). When `query` pins `repo:owner/...`, the call falls back to a single token derived from that owner.
- All page handlers (issues/projects/releases) and write handlers (release-close, release-close-batch, recheck, tag-release) take `GitHubAppEnv`
- `hub.ts` DO and `release-alert.ts` similarly env-aware

## Test infra

- New `test/_helpers/app-env.ts` + `setup-app-env.ts` (Vitest `setupFiles`) seed `gh-app:token:<installation_id>` in KV before every test so production code skips JWT exchange.
- Every `testEnv()` fixture swaps `GITHUB_TOKEN: "test-token"` for the 3 App vars; direct callsites pass `appTestEnv()`.
- `test/issues-page.test.ts` stub per-org branches (mirrors real GitHub Search with a per-org token) and the search-count regression guard is updated to 6 calls (3 `is:issue` + 3 `is:pr`).

## Multi-org cost impact

`/issues` page goes from 4 → 6 `/search/issues` calls per render (each fanout is now one call per org). Acceptable: the page is KV-cached and each individual call returns ≤100 rows on average. If the rate-limit budget becomes tight we can revisit by collapsing same-org reads into the project-map cache.

## Deploy / cutover

1. Merge this PR.
2. CI deploys `ci-dashboard-staging`.
3. Set 3 secrets on staging (and later top-level prod) — see README "GitHub App セットアップ" for the exact `wrangler secret put` commands:
   - `GITHUB_APP_ID`
   - `GITHUB_APP_PRIVATE_KEY` (PEM)
   - `GITHUB_APP_INSTALLATIONS` (JSON `{"ippoan": ..., "ohishi-exp": ..., "yhonda-ohishi": ...}`)
4. Verify `https://ci-dashboard.ippoan.org/issues` returns 200 and shows all 3 orgs' issues.
5. `wrangler secret delete GITHUB_TOKEN --env staging` to drop the now-unused secret.

## Test plan

- [x] `npm run typecheck` 緑
- [x] `npm test` 265 件 pass (same count as before — refactor preserves behavior under stubbed App tokens)
- [ ] Post-deploy: hit `/issues`, `/projects`, `/releases`, `/api/recheck`, `/api/tag-release` against real GitHub with the App installed
- [ ] Confirm KV entries `gh-app:token:<id>` appear after first request and expire / re-mint after ~55 min

Refs #112

---
_Generated by [Claude Code](https://claude.ai/code/session_011tv9EzE376k1dGcpqaMyph)_