### PR TITLE
fix(oauth): point ci-dashboard at auth-staging.ippoan.org (Refs #118)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,8 +39,12 @@ export interface Env extends AuthClientWorkerEnv {
 }
 
 // OAuth flow config — shared between /oauth/login and /oauth/callback.
+// `authWorkerOrigin` は staging worker を指す。`auth.ippoan.org` (top-level prod)
+// は `MCP_OAUTH_KV` バインドを持たず `/mcp/register` が 503 になる仕様
+// (ippoan/auth-worker の wrangler.toml top-level vs `[env.staging]` 参照)。
+// ci-dashboard 自身も staging-as-prod 運用なので staging 側に揃える。
 const OAUTH_OPTS = {
-  authWorkerOrigin: "https://auth.ippoan.org",
+  authWorkerOrigin: "https://auth-staging.ippoan.org",
   redirectUri: "https://ci-dashboard.ippoan.org/oauth/callback",
   scope: "mcp.write mcp.workflow mcp.project",
   clientName: "ci-dashboard",


### PR DESCRIPTION
## 障害

deploy 後 `/oauth/login` が 500。原因:

```
auth-worker /mcp/register failed (503):
{"error":"server_error","error_description":"MCP OAuth Provider not configured"}
```

auth-worker の wrangler.toml で **`MCP_OAUTH_KV` binding は `[env.staging]` だけに定義**されている。top-level prod (= `auth.ippoan.org` のルート先) には bind されておらず、`/mcp/register` ハンドラの `if (!env.MCP_OAUTH_KV) return 503` で蹴られる。

## 修正

ci-dashboard を **`auth-staging.ippoan.org`** に向け直す。ci-dashboard 自身も staging-as-prod 運用 (`ci-dashboard.ippoan.org` → `ci-dashboard-staging`) なので、auth-worker 側も staging に揃えるのが一貫している。

```diff
- authWorkerOrigin: "https://auth.ippoan.org",
+ authWorkerOrigin: "https://auth-staging.ippoan.org",
```

## 前提

Cloudflare Secrets Store の `INTERNAL_SHARED_SECRET` (ci-dashboard が保有) の値が **`mcp-internal-shared-secret-staging` と完全一致** している必要あり。auth-worker staging 側がこの secret 名で introspect リクエストを照合するため。一致しない場合は再度 503 (introspect 側) が出る。

## 別件: WEBHOOK_SECRET 未設定

同じ wrangler tail に POST /webhook で:
```
DataError: Imported HMAC key length (0) must be a non-zero value...
```

ci-dashboard-staging worker に `WEBHOOK_SECRET` secret が未設定。webhook を使うなら別途設定が必要 (本 PR scope 外):
```bash
echo -n "<webhook secret>" | npx wrangler secret put WEBHOOK_SECRET --env staging
```

## test plan

- [ ] merge → deploy → `/oauth/login` → GitHub 同意 → `/oauth/callback` で `/issues` に redirect → 200
- [ ] auth-worker staging の log に `/mcp/register` 200 が出る

Refs #118

---
_Generated by [Claude Code](https://claude.ai/code/session_011tv9EzE376k1dGcpqaMyph)_