### PR TITLE
fix(oauth): pass AUTH_WORKER_ORIGIN to getGitHubToken (Refs #118)

### DIFF
--- a/src/github-api.ts
+++ b/src/github-api.ts
@@ -4,6 +4,16 @@ const GITHUB_API = "https://api.github.com";
 const ALLOWED_ORGS = ["ippoan", "ohishi-exp", "yhonda-ohishi"];
 const DEFAULT_ORG = "ippoan";
 
+// auth-worker MCP OAuth Provider origin. Defined here (not in index.ts) to
+// avoid a circular import — many src/*.ts modules pull this constant via
+// tokenForOrg() and indirectly via getGitHubToken default. `index.ts` also
+// re-imports from here for OAUTH_OPTS in /oauth/login + /oauth/callback.
+//
+// Staging worker (`auth-staging.ippoan.org`) で固定。top-level prod
+// (`auth.ippoan.org`) は `MCP_OAUTH_KV` を持たず /mcp/* 系が 503 になる
+// (ippoan/auth-worker wrangler.toml 参照、Refs #118)。
+export const AUTH_WORKER_ORIGIN = "https://auth-staging.ippoan.org";
+
 export function parseRepo(repo: string): { owner: string; repo: string } {
   if (repo.includes("/")) {
     const [owner, name] = repo.split("/", 2);
@@ -25,7 +35,7 @@ export function validateOrg(owner: string): void {
  *  code path. */
 export async function tokenForOrg(env: AuthClientWorkerEnv, owner: string): Promise<string> {
   validateOrg(owner);
-  return getGitHubToken(env);
+  return getGitHubToken(env, { authWorkerOrigin: AUTH_WORKER_ORIGIN });
 }
 
 export class GitHubApiError extends Error {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
   handleOAuthCallback,
   type AuthClientWorkerEnv,
 } from "@ippoan/auth-client-worker";
+import { AUTH_WORKER_ORIGIN } from "./github-api";
 import { handleWebhook } from "./webhook";
 import { handleDashboard } from "./dashboard";
 import { handleIssuesPage } from "./issues-page";
@@ -38,13 +39,11 @@ export interface Env extends AuthClientWorkerEnv {
   TAGLESS_REPOS?: string;
 }
 
-// OAuth flow config — shared between /oauth/login and /oauth/callback.
-// `authWorkerOrigin` は staging worker を指す。`auth.ippoan.org` (top-level prod)
-// は `MCP_OAUTH_KV` バインドを持たず `/mcp/register` が 503 になる仕様
-// (ippoan/auth-worker の wrangler.toml top-level vs `[env.staging]` 参照)。
-// ci-dashboard 自身も staging-as-prod 運用なので staging 側に揃える。
+// OAuth flow config — shared between /oauth/login, /oauth/callback, and the
+// runtime `tokenForOrg()` -> `getGitHubToken()` calls. `AUTH_WORKER_ORIGIN`
+// lives in github-api.ts to avoid a circular import.
 const OAUTH_OPTS = {
-  authWorkerOrigin: "https://auth-staging.ippoan.org",
+  authWorkerOrigin: AUTH_WORKER_ORIGIN,
   redirectUri: "https://ci-dashboard.ippoan.org/oauth/callback",
   scope: "mcp.write mcp.workflow mcp.project",
   clientName: "ci-dashboard",

--- a/src/issue-prs.ts
+++ b/src/issue-prs.ts
@@ -1,4 +1,4 @@
-import { githubApi, validateOrg } from "./github-api";
+import { githubApi, validateOrg, AUTH_WORKER_ORIGIN } from "./github-api";
 import { getGitHubToken, type AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
 
 /** Lightweight PR descriptor used by the issues page to render "related PR"
@@ -72,7 +72,7 @@ export async function fetchOpenPrsByIssue(
   for (const o of orgs) validateOrg(o);
   for (const r of repos) validateOrg(r.split("/")[0]!);
 
-  const token = await getGitHubToken(env);
+  const token = await getGitHubToken(env, { authWorkerOrigin: AUTH_WORKER_ORIGIN });
 
   const parts: string[] = ["is:pr", "state:open", "archived:false"];
   if (repos.length > 0) {

--- a/src/mcp/tools/issues.ts
+++ b/src/mcp/tools/issues.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { githubApi, parseRepo, tokenForOrg, validateOrg } from "../../github-api";
+import { githubApi, parseRepo, tokenForOrg, validateOrg, AUTH_WORKER_ORIGIN } from "../../github-api";
 import { getGitHubToken, type AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
 
 /** Build the PATCH body for `update_issue` from optional fields. Strips
@@ -437,7 +437,7 @@ export async function fetchOrgIssues(
   if (query) parts.push(query);
   const q = parts.join(" ");
 
-  const token = await getGitHubToken(env);
+  const token = await getGitHubToken(env, { authWorkerOrigin: AUTH_WORKER_ORIGIN });
   const data = await githubApi<SearchIssuesResponse>(
     token, "GET", "/search/issues", undefined,
     { q, per_page: String(per_page) },

--- a/src/mcp/tools/projects.ts
+++ b/src/mcp/tools/projects.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { githubGraphQL, parseRepo, tokenForOrg, validateOrg, GitHubApiError } from "../../github-api";
+import { githubGraphQL, parseRepo, tokenForOrg, validateOrg, GitHubApiError, AUTH_WORKER_ORIGIN } from "../../github-api";
 import { getGitHubToken, type AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
 
 // --------------------------------------------------------------------------
@@ -164,7 +164,7 @@ export async function fetchOrgProjects(
   const { orgs, first = 50, include_closed = false } = params;
   for (const o of orgs) validateOrg(o);
   return Promise.all(orgs.map(async (org) => {
-    const token = await getGitHubToken(env);
+    const token = await getGitHubToken(env, { authWorkerOrigin: AUTH_WORKER_ORIGIN });
     const data = await githubGraphQL<{
       repositoryOwner: {
         projectsV2?: { nodes: OrgProject[] };
@@ -221,7 +221,7 @@ export async function fetchProjectIssueMap(
   await Promise.all(
     orgsProjects.flatMap(({ org, projects }) =>
       projects.map(async (p) => {
-        const token = await getGitHubToken(env);
+        const token = await getGitHubToken(env, { authWorkerOrigin: AUTH_WORKER_ORIGIN });
         const data = await githubGraphQL<{
           node: {
             items: { nodes: Array<{


### PR DESCRIPTION
## 障害

PR #120 deploy 後、`/oauth/login` → `/oauth/callback` は成功するが、`/issues` が:
```
auth-worker /mcp/introspect failed (503): {"active":false,"error":"server_error"}
```

auth-worker tail で確認すると **`host: auth.ippoan.org`** (prod) に request が行っていた。staging worker の `MCP_OAUTH_KV` 等は揃っているが、prod auth-worker は MCP bindings を持たないため 503。

## 原因

PR #120 で `OAUTH_OPTS.authWorkerOrigin = "https://auth-staging.ippoan.org"` を設定したが、これは `handleOAuthLogin` / `handleOAuthCallback` にしか渡らない。runtime の `getGitHubToken(env)` は **SDK の `DEFAULT_AUTH_WORKER_ORIGIN = "https://auth.ippoan.org"`** を使っていた。

flow:
- `/oauth/login` → auth-staging ✅
- `/oauth/callback` → auth-staging ✅
- `/issues` → getGitHubToken(env) → **auth.ippoan.org** ❌ → 503

## 修正

全 `getGitHubToken(env)` call site (5 箇所) に明示的に `{ authWorkerOrigin: AUTH_WORKER_ORIGIN }` を渡す:

- `src/github-api.ts` `tokenForOrg()`
- `src/issue-prs.ts` `fetchOpenPrsByIssue()`
- `src/mcp/tools/issues.ts` `fetchOrgIssues()`
- `src/mcp/tools/projects.ts` `fetchOrgProjects()` + `fetchProjectIssueMap()`

`AUTH_WORKER_ORIGIN` constant は `src/github-api.ts` に export (`src/index.ts` に置くと循環 import になる)。`index.ts` の `OAUTH_OPTS` も同じ constant を参照するように修正。

## test plan

- [ ] deploy 後、`/issues` 200 で issues 表示
- [ ] auth-worker tail で `/mcp/introspect` の host が `auth-staging.ippoan.org` になっていることを確認
- [ ] `npm test` 緑

Refs #118

---
_Generated by [Claude Code](https://claude.ai/code/session_011tv9EzE376k1dGcpqaMyph)_