### PR TITLE
fix(wrangler): use JWT_FOR_CI_DASHBOARD secret entry (Refs #118)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -38,14 +38,18 @@
   // GitHub auth は @ippoan/auth-client-worker 経由で auth-worker に delegate
   // (issue #118)。`/oauth/login` ブラウザフロー (Auth Code + PKCE) でログイン後、
   // access_token + refresh_token は CI_STATUS KV に SDK が保存する。
-  // Cloudflare 側に必要な long-lived secret は INTERNAL_SHARED_SECRET だけ
-  // (auth-worker `/mcp/introspect` の認証用、auth-worker と同値、cc-relay
-  // broker / github-mcp-server-rs と共有)。
+  // Cloudflare 側に必要な long-lived secret は INTERNAL_SHARED_SECRET (binding 名)
+  // だけ — auth-worker `/mcp/introspect` の worker-to-worker doorman として使う。
+  // 値は ci-dashboard 専用 `JWT_FOR_CI_DASHBOARD` Secrets Store entry。
+  // auth-worker 側は `INTERNAL_SHARED_SECRET_CI_DASHBOARD` binding で同 entry を
+  // bind しており、`resolveAllSharedSecrets` (auth-worker #190) が prefix match
+  // で発見する (auth-worker #192)。MCP CLI 系 `mcp-internal-shared-secret-*` とは
+  // 切り離してある (blast radius / rotation を独立化)。
   "secrets_store_secrets": [
     {
       "binding": "INTERNAL_SHARED_SECRET",
       "store_id": "bd7bc91a3e5f4111add4acf6cb4b8733",
-      "secret_name": "INTERNAL_SHARED_SECRET"
+      "secret_name": "JWT_FOR_CI_DASHBOARD"
     }
   ],
   // staging を実運用 env として扱う (secrets-inventory と同じパターン)。
@@ -96,7 +100,7 @@
         {
           "binding": "INTERNAL_SHARED_SECRET",
           "store_id": "bd7bc91a3e5f4111add4acf6cb4b8733",
-          "secret_name": "INTERNAL_SHARED_SECRET"
+          "secret_name": "JWT_FOR_CI_DASHBOARD"
         }
       ]
     }


### PR DESCRIPTION
## Summary

`secrets_store_secrets[].secret_name` を `"INTERNAL_SHARED_SECRET"` (歴史的 MCP 共有 entry) から `"JWT_FOR_CI_DASHBOARD"` (ci-dashboard 専用 entry) に切替。top-level と `env.staging` 両方。

## なぜ必要か

`https://ci-dashboard.ippoan.org/oauth/login` → GitHub 同意 → `/issues` が **502** になる問題の根本対応。

OAuth flow (login → authorize → callback) は 303 で正常終了するが、ci-dashboard backend → auth-worker `/mcp/introspect` 呼び出しが **401 `{"error":"unauthorized"}`** で失敗していた。原因は ci-dashboard が読む secret entry (`INTERNAL_SHARED_SECRET`) と auth-worker が認識する値 (`mcp-internal-shared-secret-*`) が物理的に別 entry だったこと。

## 対応設計

ci-dashboard は OAuth Code + PKCE consumer なので、MCP CLI 系 (`mcp-internal-shared-secret-*` / 旧 `INTERNAL_SHARED_SECRET` 共有 entry) を流用するのは概念衝突。ci-dashboard 専用 `JWT_FOR_CI_DASHBOARD` entry に分離する。

- auth-worker #192 (merged): `INTERNAL_SHARED_SECRET_CI_DASHBOARD` binding を `JWT_FOR_CI_DASHBOARD` entry に bind 済
- 本 PR: ci-dashboard の `INTERNAL_SHARED_SECRET` binding も同 entry を point させる
- 結果: 両 worker が同一 entry を読む → ci-dashboard が送る doorman secret が `resolveAllSharedSecrets` (auth-worker #190) に当たって 200 active:true

binding 名 (env var) は `INTERNAL_SHARED_SECRET` のまま維持 — `@ippoan/auth-client-worker` SDK (`getGitHubToken` → `env.INTERNAL_SHARED_SECRET.get()`) はコード無変更で動く。

## test plan

- [x] wrangler.jsonc syntax 妥当
- [ ] CI 緑
- [ ] merge → staging auto-deploy 成功
- [ ] `https://ci-dashboard.ippoan.org/oauth/login` → GitHub 同意 → `/issues` 200 (502 が解消)
- [ ] (任意) middle-term: top-level の secret_name は staging 運用なので `JWT_FOR_CI_DASHBOARD` で問題ないが、将来 prod を分けるなら別 entry を作る

Refs #118

---
_Generated by [Claude Code](https://claude.ai/code/session_017QWHymgUSh331TLy6tAcvm)_