### PR TITLE
feat(issues): redirect to /oauth/login on auth failures (Refs #118)

### DIFF
--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -151,6 +151,21 @@ async function loadPrMap(
   }
 }
 
+// `@ippoan/auth-client-worker` SDK が auth-worker delegation 中に投げる error
+// は `Error.message` に常に診断文字列を入れる (introspect.ts / tokens.ts /
+// dcr.ts 参照)。message に以下のどれかが含まれたら「再ログインで解決可能」と
+// 判定して `/oauth/login` にリダイレクトする (= ユーザーは 502 ページではなく
+// GitHub 同意画面に飛ぶ)。それ以外 (GitHub rate limit など) は従来通り 502 を
+// 表示する。
+function isAuthError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return (
+    /No (DCR client registered|OAuth tokens stored)/.test(msg) ||
+    /auth-worker \/mcp\/(introspect|token).*failed \((401|403)/.test(msg) ||
+    /JWT inactive/.test(msg)
+  );
+}
+
 export async function handleIssuesPage(env: AuthClientWorkerEnv): Promise<Response> {
   // Search REST gives us the issues themselves; this is the only fetch that
   // can fail the page outright. Project map is loaded separately below so a
@@ -176,6 +191,13 @@ export async function handleIssuesPage(env: AuthClientWorkerEnv): Promise<Respon
       items: [...main.items, ...yhonda.items],
     };
   } catch (err) {
+    if (isAuthError(err)) {
+      // 認証失効: GitHub 同意画面 → /oauth/callback → return_to で /issues に戻る
+      return new Response(null, {
+        status: 302,
+        headers: { Location: "/oauth/login?return_to=/issues" },
+      });
+    }
     const msg = err instanceof Error ? err.message : String(err);
     return new Response(renderError(msg), {
       status: 502,

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -313,6 +313,24 @@ describe("GET /issues", () => {
     expect(html).toContain("← CI Dashboard");
   });
 
+  // When the SDK can't auth against auth-worker (no DCR / no stored tokens /
+  // introspect 401 / refresh 401), don't show a 502 dead-end — bounce the
+  // user to `/oauth/login` so they can log in and come back to `/issues`.
+  it("redirects to /oauth/login when getGitHubToken hits an auth error", async () => {
+    // Drop the seeded gh-token cache so `getGitHubToken` falls through to
+    // `readDcrFromKv`. KV has no DCR record either, so the SDK throws
+    // `"No DCR client registered. Visit /oauth/login first..."` — the
+    // canonical auth-failure shape.
+    await env.CI_STATUS.delete("auth-client-worker:gh-token");
+    const req = new Request("http://localhost/issues");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("Location")).toBe("/oauth/login?return_to=/issues");
+  });
+
   it("renders an empty-state message when no issues match", async () => {
     // Use mockImplementation, not mockResolvedValue: the page fires three
     // fetches in parallel (2× /search/issues, 1+ /graphql) and a single


### PR DESCRIPTION
## Summary

`/issues` で `@ippoan/auth-client-worker` SDK が **auth-worker への認証に失敗** したとき、502 ページではなく **`/oauth/login?return_to=/issues` に 302 redirect** する。GitHub 同意画面 → `/oauth/callback` → SDK が `return_to` を尊重して `/issues` に戻る、というブラウザ完結のフローでログイン切れを自動回復させる。

## 動機

直前のスクリーンショットで:

```
Failed to fetch issues: auth-worker /mcp/introspect failed (401): {"error":"unauthorized"}
```

が出ていた。原因が secret 不一致だったので #122 で本質修正したが、**今後 refresh_token が期限切れたり KV が剥がれたりした場合** にも同じ画面が出る。その場合の正しい UX は「ログインしてやり直して」なので、自動で redirect する。

## 実装

`isAuthError(err)` で SDK が投げる **認証関連 error** だけを識別:

| message パターン | 原因 |
|---|---|
| `No DCR client registered` | KV から DCR レコードが消えた |
| `No OAuth tokens stored` | 初回ログイン未完了 / KV から tokens が消えた |
| `auth-worker /mcp/introspect failed (401\|403)` | access_token は valid でも introspect で弾かれた (今回みたいに secret 不一致のとき) |
| `auth-worker /mcp/token .*failed (401\|403)` | refresh_token rotation 拒否 (期限切れ / 取消) |
| `JWT inactive` | introspect が `active:false` を返した (KV の `github_token:{sub}` が無い等) |

該当時のみ 302。`GitHub API 403:` のような github 側 error はパターン不一致なので従来どおり 502 を表示する (再ログインしても直らないため UX 上 redirect は逆効果)。

`Location` ヘッダは相対 URL `/oauth/login?return_to=/issues`。`handleOAuthLogin` (auth-client-worker SDK) は `?return_to=/path` を sanitize 済みで受け、callback 完了後そこへ戻す既存挙動を再利用するだけなので auth-worker 側変更は不要。

## test plan

- [x] 新規 test: gh-token cache を消した状態で `/issues` を叩くと 302 + Location ヘッダが `/oauth/login?return_to=/issues` になる
- [x] 既存 test (`GitHub API 403:` 経路) は 502 のまま (regex 非マッチ)
- [ ] CI 緑
- [ ] merge → staging deploy
- [ ] (動作確認) KV から `auth-client-worker:oauth-tokens` を消して `/issues` を踏むと OAuth フローに飛ぶ

Refs #118

---
_Generated by [Claude Code](https://claude.ai/code/session_017QWHymgUSh331TLy6tAcvm)_