### PR TITLE
feat(issues): show merged PRs alongside open ones as related-PR chips

### DIFF
--- a/src/issue-prs.ts
+++ b/src/issue-prs.ts
@@ -3,7 +3,14 @@ import { getGitHubToken, type AuthClientWorkerEnv } from "@ippoan/auth-client-wo
 
 /** Lightweight PR descriptor used by the issues page to render "related PR"
  *  chips. Body is intentionally not retained — it's only used to extract
- *  issue refs and would balloon the KV-cached payload. */
+ *  issue refs and would balloon the KV-cached payload.
+ *
+ *  `state: 'merged'` covers PRs that have already merged but whose `Refs #N`
+ *  target issue is still open (the standard "release-pending" zone for this
+ *  repo's CLAUDE.md flow). They're searched separately from open PRs and
+ *  rendered with a distinct chip color (purple) so the reader can tell at a
+ *  glance that the work is done — only the release tag / manual close is
+ *  outstanding. */
 export interface IssuePrRef {
   repo: string;
   number: number;
@@ -11,6 +18,7 @@ export interface IssuePrRef {
   url: string;
   draft: boolean;
   updated_at: string;
+  state: "open" | "merged";
 }
 
 // Matches "<keyword> [owner/repo]#N" where <keyword> is one of the GitHub
@@ -58,23 +66,46 @@ interface SearchPrsResponse {
   items: SearchPrItem[];
 }
 
-/** Single GitHub search call for open PRs. `orgs` (`org:` qualifiers) and
+/** Window for `is:merged` PR lookups, in days. Repo's release-close flow
+ *  (CLAUDE.md) keeps an issue open until the release tag covering the
+ *  merged PR is cut and confirmed; in practice that gap is < 30 days. 60
+ *  days is a generous upper bound that still keeps GitHub Search result
+ *  size well under the 100-item per_page cap. */
+const MERGED_PR_WINDOW_DAYS = 60;
+
+/** Single GitHub search call for PRs. `orgs` (`org:` qualifiers) and
  *  `repos` (`repo:` qualifiers) are mutually exclusive — GitHub Search drops
  *  `repo:` when combined with `org:`. With auth-worker delegation (#116) the
  *  resolved token is user-scope and spans all orgs the operator belongs to,
  *  so cross-org `org:ippoan org:ohishi-exp` fits in one call (no fan-out
- *  needed, unlike the App-installation era). */
+ *  needed, unlike the App-installation era).
+ *
+ *  `state: 'merged'` adds `is:merged` and an `updated:>=<date>` window so the
+ *  result stays bounded. */
 export async function fetchOpenPrsByIssue(
   env: AuthClientWorkerEnv,
-  params: { orgs?: string[]; repos?: string[]; per_page?: number },
+  params: {
+    orgs?: string[];
+    repos?: string[];
+    per_page?: number;
+    state?: "open" | "merged";
+  },
 ): Promise<Map<string, IssuePrRef[]>> {
-  const { orgs = [], repos = [], per_page = 100 } = params;
+  const { orgs = [], repos = [], per_page = 100, state = "open" } = params;
   for (const o of orgs) validateOrg(o);
   for (const r of repos) validateOrg(r.split("/")[0]!);
 
   const token = await getGitHubToken(env, { authWorkerOrigin: AUTH_WORKER_ORIGIN });
 
-  const parts: string[] = ["is:pr", "state:open", "archived:false"];
+  const parts: string[] = ["is:pr", "archived:false"];
+  if (state === "merged") {
+    parts.push("is:merged");
+    const cutoff = new Date(Date.now() - MERGED_PR_WINDOW_DAYS * 86400 * 1000)
+      .toISOString().slice(0, 10);
+    parts.push(`updated:>=${cutoff}`);
+  } else {
+    parts.push("state:open");
+  }
   if (repos.length > 0) {
     for (const r of repos) parts.push(`repo:${r}`);
   } else {
@@ -100,6 +131,7 @@ export async function fetchOpenPrsByIssue(
       url: pr.html_url,
       draft: pr.draft ?? false,
       updated_at: pr.updated_at,
+      state,
     };
     for (const key of refs) {
       const existing = map.get(key);
@@ -110,30 +142,42 @@ export async function fetchOpenPrsByIssue(
   return map;
 }
 
-/** Fetch and merge open-PR → issue maps across the two search shapes the
- *  issues page uses (main orgs + yhonda `repo:` filter). 2 calls because the
- *  two shapes can't be combined in one GitHub search (`repo:` is dropped when
- *  `org:` is also present). */
+/** Fetch and merge PR → issue maps across the two search shapes the issues
+ *  page uses (main orgs + yhonda `repo:` filter) AND the two states we care
+ *  about (open + merged). 4 calls in parallel because the two repo shapes
+ *  can't be combined in one GitHub search (`repo:` is dropped when `org:` is
+ *  also present), and the two states can't be `OR`-ed inside a single
+ *  search query either. Merged PRs surface issues whose `Refs #N` work is
+ *  done but whose release-close hasn't happened yet (CLAUDE.md flow). */
 export async function fetchAllOpenPrsByIssue(
   env: AuthClientWorkerEnv,
   mainOrgs: string[],
   yhondaRepos: string[],
 ): Promise<Map<string, IssuePrRef[]>> {
-  const [main, yhonda] = await Promise.all([
-    fetchOpenPrsByIssue(env, { orgs: mainOrgs }),
-    yhondaRepos.length > 0
-      ? fetchOpenPrsByIssue(env, { repos: yhondaRepos })
-      : Promise.resolve(new Map<string, IssuePrRef[]>()),
-  ]);
-  const merged = new Map<string, IssuePrRef[]>(main);
-  for (const [k, prs] of yhonda) {
-    const existing = merged.get(k);
-    if (existing) existing.push(...prs);
-    else merged.set(k, prs);
+  const calls: Array<Promise<Map<string, IssuePrRef[]>>> = [
+    fetchOpenPrsByIssue(env, { orgs: mainOrgs, state: "open" }),
+    fetchOpenPrsByIssue(env, { orgs: mainOrgs, state: "merged" }),
+  ];
+  if (yhondaRepos.length > 0) {
+    calls.push(fetchOpenPrsByIssue(env, { repos: yhondaRepos, state: "open" }));
+    calls.push(fetchOpenPrsByIssue(env, { repos: yhondaRepos, state: "merged" }));
   }
-  // Sort each list by recency so the most-recently-updated PR renders first.
+  const results = await Promise.all(calls);
+  const merged = new Map<string, IssuePrRef[]>();
+  for (const m of results) {
+    for (const [k, prs] of m) {
+      const existing = merged.get(k);
+      if (existing) existing.push(...prs);
+      else merged.set(k, [...prs]);
+    }
+  }
+  // Sort each list: open first (work still in flight), then merged; within
+  // each group by recency so the most-recently-updated PR renders first.
   for (const prs of merged.values()) {
-    prs.sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+    prs.sort((a, b) => {
+      if (a.state !== b.state) return a.state === "open" ? -1 : 1;
+      return b.updated_at.localeCompare(a.updated_at);
+    });
   }
   return merged;
 }

--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -109,7 +109,9 @@ async function loadProjectMap(
 // new PR opened minutes ago should appear without forcing a manual reload —
 // but the 24 h store window keeps a stale copy as fallback when GitHub search
 // rate-limits the worker.
-const PR_MAP_CACHE_KEY = "issues-page:pr-map";
+// v2 suffix invalidates the open-only payload from before merged PRs were
+// included (the shape changed — `IssuePrRef.state` is now required).
+const PR_MAP_CACHE_KEY = "issues-page:pr-map:v2";
 const PR_MAP_FRESH_SECONDS = 120;
 const PR_MAP_STORE_SECONDS = 86400;
 
@@ -438,6 +440,14 @@ function renderHtml(
       border-color: #6e768188;
     }
     .pr-chip.draft:hover { background: #6e768144; }
+    /* Merged PRs: purple — "work done, release-close pending". Distinguishes
+       from green open PRs (in-flight) at a glance. */
+    .pr-chip.merged {
+      background: #8957e522;
+      color: #d2a8ff;
+      border-color: #8957e588;
+    }
+    .pr-chip.merged:hover { background: #8957e544; }
     .empty {
       padding: 32px;
       text-align: center;
@@ -546,10 +556,19 @@ function renderPrChips(
   const refs = prMap.get(`${i.repo}#${i.number}`);
   if (!refs || refs.length === 0) return "";
   const chips = refs.map((p) => {
-    const draft = p.draft ? " draft" : "";
-    const label = p.draft ? "Draft PR" : "PR";
+    // Merged PRs take precedence over draft styling — a merged PR can't
+    // be draft anymore, but if GitHub ever flipped them simultaneously the
+    // purple "done" signal is more useful than the gray "draft" one.
+    const cls = p.state === "merged" ? " merged" : p.draft ? " draft" : "";
+    const icon = p.state === "merged" ? "✅" : "🔗";
+    const label = p.state === "merged"
+      ? "Merged PR"
+      : p.draft ? "Draft PR" : "PR";
     const title = `${label} #${p.number}: ${p.title}${p.repo === i.repo ? "" : ` (${p.repo})`}`;
-    return `<a class="pr-chip${draft}" href="${escapeHtml(p.url)}" target="_blank" rel="noopener" title="${escapeHtml(title)}">🔗 #${p.number}${p.draft ? " (draft)" : ""}</a>`;
+    const suffix = p.state === "merged"
+      ? " (merged)"
+      : p.draft ? " (draft)" : "";
+    return `<a class="pr-chip${cls}" href="${escapeHtml(p.url)}" target="_blank" rel="noopener" title="${escapeHtml(title)}">${icon} #${p.number}${suffix}</a>`;
   }).join("");
   return `<div class="pr-chips">${chips}</div>`;
 }

--- a/test/issue-prs.test.ts
+++ b/test/issue-prs.test.ts
@@ -97,6 +97,31 @@ describe("fetchOpenPrsByIssue()", () => {
     expect(refs!).toHaveLength(1);
     expect(refs![0]!.number).toBe(10);
     expect(refs![0]!.draft).toBe(false);
+    expect(refs![0]!.state).toBe("open");
+  });
+
+  it("queries with `is:merged` and a recent updated:>= window when state='merged'", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        total_count: 1, incomplete_results: false,
+        items: [{
+          number: 20, title: "feat: done", state: "closed",
+          body: "Refs #5",
+          html_url: "https://github.com/ippoan/foo/pull/20",
+          repository_url: "https://api.github.com/repos/ippoan/foo",
+          draft: false, updated_at: "2026-05-10T00:00:00Z", pull_request: {},
+        }],
+      }),
+    );
+    const map = await fetchOpenPrsByIssue(appTestEnv(), {
+      orgs: ["ippoan"], state: "merged",
+    });
+    const decoded = decodeURIComponent(String(spy.mock.calls[0]![0]));
+    expect(decoded).toContain("is:pr");
+    expect(decoded).toContain("is:merged");
+    expect(decoded).not.toContain("state:open");
+    expect(decoded).toMatch(/updated:>=\d{4}-\d{2}-\d{2}/);
+    expect(map.get("ippoan/foo#5")![0]!.state).toBe("merged");
   });
 
   it("uses repo: qualifiers (and omits org:) when `repos` is set", async () => {
@@ -122,11 +147,15 @@ describe("fetchOpenPrsByIssue()", () => {
 describe("fetchAllOpenPrsByIssue()", () => {
   afterEach(() => { vi.restoreAllMocks(); });
 
-  it("merges main-org and yhonda-repos PR maps, appending refs that share a key", async () => {
+  it("merges main-org and yhonda-repos PR maps (both open and merged), appending refs that share a key", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
       const url = typeof req === "string" ? req : (req as Request).url;
       const decoded = decodeURIComponent(url);
+      const merged = decoded.includes("is:merged");
       if (decoded.includes("repo:yhonda-ohishi/claude-skills")) {
+        if (merged) {
+          return Response.json({ total_count: 0, incomplete_results: false, items: [] });
+        }
         return Response.json({
           total_count: 1, incomplete_results: false,
           items: [{
@@ -136,6 +165,20 @@ describe("fetchAllOpenPrsByIssue()", () => {
             repository_url: "https://api.github.com/repos/yhonda-ohishi/claude-skills",
             draft: true,
             updated_at: "2026-05-12T00:00:00Z",
+            pull_request: {},
+          }],
+        });
+      }
+      if (merged) {
+        return Response.json({
+          total_count: 1, incomplete_results: false,
+          items: [{
+            number: 7, title: "old done work", state: "closed",
+            body: "Refs #5",
+            html_url: "https://github.com/ippoan/foo/pull/7",
+            repository_url: "https://api.github.com/repos/ippoan/foo",
+            draft: false,
+            updated_at: "2026-05-09T00:00:00Z",
             pull_request: {},
           }],
         });
@@ -159,10 +202,13 @@ describe("fetchAllOpenPrsByIssue()", () => {
     );
     const refs = map.get("ippoan/foo#5");
     expect(refs).toBeDefined();
-    expect(refs!).toHaveLength(2);
-    // Sorted by updated_at desc, so the yhonda PR (later) comes first.
+    expect(refs!).toHaveLength(3);
+    // Open PRs come first (sorted by updated_at desc), then merged PRs.
+    expect(refs![0]!.state).toBe("open");
     expect(refs![0]!.number).toBe(99);
-    expect(refs![0]!.draft).toBe(true);
+    expect(refs![1]!.state).toBe("open");
     expect(refs![1]!.number).toBe(10);
+    expect(refs![2]!.state).toBe("merged");
+    expect(refs![2]!.number).toBe(7);
   });
 });

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -15,18 +15,22 @@ function testEnv(): Env {
 
 // Stub /search/issues + /graphql. The page fires parallel calls:
 //   - /search/issues `is:issue` × 2 (main orgs + yhonda repo: filter)
-//   - /search/issues `is:pr`    × 2 (main orgs + yhonda repo: filter,
-//     for the related-PR lookup)
+//   - /search/issues `is:pr`    × 4 (main orgs × {open, merged}
+//                                    + yhonda repo: filter × {open, merged})
 //   - /graphql for the per-org Projects v2 listing + per-project items
 // We branch on URL + (for GraphQL) on the request body so each call gets the
 // data its handler expects. By default the project map is empty so existing
 // assertions still see the per-repo grouping. Pass `withProjects` to seed a
 // project that maps to `ippoan/rust-alc-api#7` (i.e. the hostile-title issue),
 // which is what the project-section tests below rely on. Pass `withPrs` to
-// seed a PR that references `ippoan/rust-alc-api#7` for the PR-chip tests.
-function stubFetch(opts: { withProjects?: boolean; withPrs?: boolean } = {}) {
+// seed an open PR that references `ippoan/rust-alc-api#7` for the PR-chip
+// tests; pass `withMergedPrs` to seed a merged PR for the same issue.
+function stubFetch(
+  opts: { withProjects?: boolean; withPrs?: boolean; withMergedPrs?: boolean } = {},
+) {
   const withProjects = !!opts.withProjects;
   const withPrs = !!opts.withPrs;
+  const withMergedPrs = !!opts.withMergedPrs;
   return vi.spyOn(globalThis, "fetch").mockImplementation(async (req, init) => {
     const url = typeof req === "string" ? req : (req as Request).url;
     // `init.body` is set by `githubGraphQL`; a bare Request also exposes it.
@@ -76,10 +80,33 @@ function stubFetch(opts: { withProjects?: boolean; withPrs?: boolean } = {}) {
 
     // ---- PR search branch (is:pr) ----
     if (decoded.includes("is:pr")) {
-      if (!withPrs) {
+      const isMerged = decoded.includes("is:merged");
+      if (decoded.includes("repo:yhonda-ohishi/claude-skills")) {
         return Response.json({ total_count: 0, incomplete_results: false, items: [] });
       }
-      if (decoded.includes("repo:yhonda-ohishi/claude-skills")) {
+      if (isMerged) {
+        if (!withMergedPrs) {
+          return Response.json({ total_count: 0, incomplete_results: false, items: [] });
+        }
+        return Response.json({
+          total_count: 1, incomplete_results: false,
+          items: [{
+            number: 50,
+            title: "feat: previously merged work",
+            state: "closed",
+            body: "Refs #7",
+            user: { login: "yhonda-ohishi" },
+            labels: [], assignees: [], comments: 0,
+            created_at: "2026-04-20T00:00:00Z",
+            updated_at: "2026-04-22T00:00:00Z",
+            html_url: "https://github.com/ippoan/rust-alc-api/pull/50",
+            repository_url: "https://api.github.com/repos/ippoan/rust-alc-api",
+            draft: false,
+            pull_request: { url: "https://api.github.com/...", merged_at: "2026-04-22T00:00:00Z" },
+          }],
+        });
+      }
+      if (!withPrs) {
         return Response.json({ total_count: 0, incomplete_results: false, items: [] });
       }
       return Response.json({
@@ -191,7 +218,7 @@ describe("GET /issues", () => {
   // map from a no-project fixture happily masks any subsequent fetch).
   beforeEach(async () => {
     await env.CI_STATUS.delete("issues-page:project-map");
-    await env.CI_STATUS.delete("issues-page:pr-map");
+    await env.CI_STATUS.delete("issues-page:pr-map:v2");
   });
   afterEach(() => { vi.restoreAllMocks(); });
 
@@ -244,7 +271,7 @@ describe("GET /issues", () => {
     expect(html).toContain("&amp;");
   });
 
-  it("queries GitHub Search twice for issues + twice for PRs (main orgs + yhonda repo: filter)", async () => {
+  it("queries GitHub Search twice for issues + four times for PRs (main + yhonda × open + merged)", async () => {
     const spy = stubSearchIssues();
     const req = new Request("http://localhost/issues");
     const ctx = createExecutionContext();
@@ -255,15 +282,19 @@ describe("GET /issues", () => {
     // so cross-org `org:ippoan org:ohishi-exp` fits in one search call.
     // /search/issues is hit:
     //   is:issue × 2 (main orgs combined + yhonda repo: filter)
-    //   is:pr    × 2 (same shape)
-    // = 4 total. /graphql calls for the Projects v2 map are ignored here.
+    //   is:pr    × 4 (each repo shape × {open, merged} so CLAUDE.md's
+    //                 "merged but release-close pending" issues get chips)
+    // = 6 total. /graphql calls for the Projects v2 map are ignored here.
     const searchCalls = spy.mock.calls.filter((c) =>
       String(c[0]).includes("/search/issues"));
-    expect(searchCalls).toHaveLength(4);
+    expect(searchCalls).toHaveLength(6);
     const urls = searchCalls.map((c) => c[0] as string);
     const decoded = urls.map((u) => decodeURIComponent(u));
     const issueDecoded = decoded.filter((d) => d.includes("is:issue") && !d.includes("is:pr"));
     expect(issueDecoded).toHaveLength(2);
+    const prDecoded = decoded.filter((d) => d.includes("is:pr"));
+    expect(prDecoded.filter((d) => d.includes("is:merged"))).toHaveLength(2);
+    expect(prDecoded.filter((d) => d.includes("state:open"))).toHaveLength(2);
 
     // Main call: ippoan + ohishi-exp orgs without a repo: qualifier.
     const main = issueDecoded.find((d) => d.includes("org:ippoan"));
@@ -368,7 +399,7 @@ describe("GET /issues", () => {
 describe("GET /issues — Project section", () => {
   beforeEach(async () => {
     await env.CI_STATUS.delete("issues-page:project-map");
-    await env.CI_STATUS.delete("issues-page:pr-map");
+    await env.CI_STATUS.delete("issues-page:pr-map:v2");
   });
   afterEach(() => { vi.restoreAllMocks(); });
 
@@ -516,7 +547,7 @@ describe("buildClaudeCodeLaunchUrl()", () => {
 describe("GET /issues — Claude Code launch button", () => {
   beforeEach(async () => {
     await env.CI_STATUS.delete("issues-page:project-map");
-    await env.CI_STATUS.delete("issues-page:pr-map");
+    await env.CI_STATUS.delete("issues-page:pr-map:v2");
   });
   afterEach(() => { vi.restoreAllMocks(); });
 
@@ -563,7 +594,7 @@ describe("GET /issues — Claude Code launch button", () => {
 describe("GET /issues — Related-PR chips", () => {
   beforeEach(async () => {
     await env.CI_STATUS.delete("issues-page:project-map");
-    await env.CI_STATUS.delete("issues-page:pr-map");
+    await env.CI_STATUS.delete("issues-page:pr-map:v2");
   });
   afterEach(() => { vi.restoreAllMocks(); });
 
@@ -585,6 +616,36 @@ describe("GET /issues — Related-PR chips", () => {
     expect(chipCount).toBe(1);
   });
 
+  it("renders a purple .merged pr-chip when only a merged PR references the issue", async () => {
+    stubFetch({ withMergedPrs: true });
+    const req = new Request("http://localhost/issues");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    const html = await res.text();
+    // Seeded merged PR is rust-alc-api#50 referencing #7.
+    expect(html).toContain('class="pr-chip merged"');
+    expect(html).toContain("https://github.com/ippoan/rust-alc-api/pull/50");
+    expect(html).toContain(">✅ #50 (merged)<");
+  });
+
+  it("renders both open and merged chips when both exist for the same issue", async () => {
+    stubFetch({ withPrs: true, withMergedPrs: true });
+    const req = new Request("http://localhost/issues");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    const html = await res.text();
+    // Open chip ordered before merged chip in the rendered HTML.
+    const openIdx = html.indexOf(">🔗 #42<");
+    const mergedIdx = html.indexOf(">✅ #50 (merged)<");
+    expect(openIdx).toBeGreaterThan(-1);
+    expect(mergedIdx).toBeGreaterThan(-1);
+    expect(openIdx).toBeLessThan(mergedIdx);
+  });
+
   it("marks draft PRs with the .draft class", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (req, init) => {
       const url = typeof req === "string" ? req : (req as Request).url;
@@ -599,7 +660,10 @@ describe("GET /issues — Related-PR chips", () => {
       }
       const decoded = decodeURIComponent(url);
       if (decoded.includes("is:pr")) {
-        if (decoded.includes("repo:yhonda-ohishi/claude-skills")) {
+        // Only return the draft PR for the open-state search — merged search
+        // gets an empty result so the assertions below only see the draft chip.
+        if (decoded.includes("is:merged")
+          || decoded.includes("repo:yhonda-ohishi/claude-skills")) {
           return Response.json({ total_count: 0, incomplete_results: false, items: [] });
         }
         return Response.json({


### PR DESCRIPTION
## 背景

`/issues` の関連 PR chip は `state:open` フィルタのみで取得していたため、
本リポジトリ CLAUDE.md の運用フロー (`Refs #N` で merge → release tag → 目視
close) では「PR は merge 済みだが issue がまだ open」という **release 待ちゾーン
の issue** には chip が一切出ず、画面から「実は work 済」が読み取れなかった。

例: ライブの `/issues` で `ippoan/auth-worker` や `ippoan/ci-dashboard` の
open issue を見ても chip がほぼ存在しなかった (= 関連 PR は全て merge 済み
で `is:open` ヒット 0 件のため)。

## 変更点

### `src/issue-prs.ts`

- `fetchOpenPrsByIssue` に `state: 'open' | 'merged'` 引数を追加
  - `merged` 時は GitHub Search に `is:merged` + 60 日の `updated:>=<date>`
    window を付与して結果サイズを bounded に保つ
- `fetchAllOpenPrsByIssue` は 4 本のクエリを並列発行:
  - main orgs × `open` / `merged`
  - yhonda repos × `open` / `merged`
  - GitHub Search は `repo:` と `org:` を OR で混ぜられず、`state:open` と
    `is:merged` も 1 クエリで OR できないため 4 本展開が必須
- 同一 issue 行内では open chip を先、merged chip を後に並べる (in-flight
  作業 → release 待ち作業の自然な視線順)
- `IssuePrRef` に `state` field 追加

### `src/issues-page.ts`

- merged chip: 紫 (`.pr-chip.merged`) + ✅ アイコン + " (merged)" 表記で
  open (緑 🔗) / draft (灰) と視覚的に区別
- KV cache key を `issues-page:pr-map` → `issues-page:pr-map:v2` に bump し
  て旧 payload (state field 無し) を invalidate

### tests

- `test/issue-prs.test.ts`: `state: 'merged'` の query 形状 (`is:merged`,
  `updated:>=`) と `fetchAllOpenPrsByIssue` の 4 本展開を検証
- `test/issues-page.test.ts`:
  - PR 検索の call count を 2 → 4 に更新 (open + merged × 2 shape)
  - `withMergedPrs` stub option 追加
  - merged chip render の golden test 追加 (✅ / `.merged` クラス / 並び順)

## 動作確認

- [x] `npm run typecheck` clean
- [x] `npm test` — 252 passed (3 new)
- [ ] staging deploy 後にブラウザで `/issues` を開き、`Refs #N` で merge 済み
      かつ issue が open のままの行に紫 ✅ chip が出ることを確認

Refs #107

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwaDdiH1FDxmH9QUUPCksT)_