### PR TITLE
ci(wrangler): declare secrets.required for secret-verify

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -52,6 +52,16 @@
       "secret_name": "JWT_FOR_CI_DASHBOARD"
     }
   ],
+  // ci-workflows/secret-verify-gcp.yml が読む宣言。GCP Secret Manager 上に
+  // 同名 entry が存在することを CI で検証し、verify SA に権限があれば
+  // `used-by-ippoan-ci-dashboard=active` label を自動付与する。
+  // top-level / env.staging 両方とも同じ JWT_FOR_CI_DASHBOARD を bind して
+  // いるので 1 entry で足りる。
+  "secrets": {
+    "required": [
+      "JWT_FOR_CI_DASHBOARD"
+    ]
+  },
   // staging を実運用 env として扱う (secrets-inventory と同じパターン)。
   // PR push 毎に `ci-dashboard-staging` Worker に auto-deploy され、`v*` tag の
   // production (top-level `ci-dashboard`) は将来用に予約。top-level 設定は


### PR DESCRIPTION
## Summary

`wrangler.jsonc` に `secrets.required` block を追加し、ci-workflows#50-53 で導入された secret-verify gate + org vars auto-fallback + apply_labels default true に乗る。

## 変更

```jsonc
"secrets": {
  "required": [
    "JWT_FOR_CI_DASHBOARD"
  ]
}
```

`JWT_FOR_CI_DASHBOARD` は top-level / env.staging 両方の `secrets_store_secrets` で同名 bind されているため 1 entry で足りる。

## 期待挙動

merge + main CI 完走後:
1. `secret-verify-required` gate skip (vars あり)
2. `secret-verify` 起動 → `JWT_FOR_CI_DASHBOARD` が GCP に存在することを確認 (auth-worker#193 で backup 済)
3. `used-by-ippoan-ci-dashboard=active` label が GCP の同 secret に付与
4. secrets-inventory dashboard で active consumer として可視化

## 関連

- ippoan/auth-worker#193 (同パターンの先行例)
- ippoan/ci-workflows#50 / #51 / #52 / #53 (gate + vars fallback + label default)

---
_Generated by [Claude Code](https://claude.ai/code/session_019R4NxnrqGztpjRNLW5FuQb)_