### PR TITLE
docs(readme): mention SSR dashboard + verify auto-merge 401 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ci-dashboard
 
-GitHub CI 監視 + リポジトリ操作のための MCP (Model Context Protocol) サーバー。
-Cloudflare Workers にデプロイされ、Claude などの MCP クライアントから GitHub Actions ワークフローや issue / PR を操作できる。
+GitHub CI 監視 + リポジトリ操作のための MCP (Model Context Protocol) サーバー + SSR ダッシュボード。
+Cloudflare Workers にデプロイされ、Claude などの MCP クライアントから GitHub Actions ワークフローや issue / PR / release を操作できる。
 
 ## アーキテクチャ
 


### PR DESCRIPTION
## Summary

ci-workflows#55 で `auto-merge.yml` の job permissions に `actions: write` を追加した cross-repo 401 fix が、本 PR の Auto Merge job (= cross-repo reusable chain) で実際に green になるかを検証する trigger PR。

本コミット自体は README の説明に「SSR ダッシュボード + release 操作」を追記する trivial 修正のみ (1 行)。

## 検証ポイント

- ci-workflows#55 で `actions: write` 追加済
- 本 PR の `Auto Merge` job が **success** になれば仮説 1 (actions:write 不足) で 401 解消確定
- 依然 401 → 次の PR で `peter-evans/enable-pull-request-automerge@v3` action へ切り替え

## 関連

- ci-workflows#55 (本 PR の trigger となる actions:write 追加)
- [cli/cli#11493 — Error message for missing actions permission misleading](https://github.com/cli/cli/issues/11493)
- auth-worker#193 / ci-dashboard#125 (本 PR 直前の本筋作業、label 化完了済)

---
_Generated by [Claude Code](https://claude.ai/code/session_019R4NxnrqGztpjRNLW5FuQb)_