### PR TITLE
fix(secret): migrate WEBHOOK_SECRET to Secrets Store binding (Refs #127)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export { CIDashboardHub } from "./hub";
 // (`auth-client-worker:oauth-tokens`) by the SDK after `/oauth/login`
 // browser flow — there is no operator-facing secret to rotate. Refs #118.
 export interface Env extends AuthClientWorkerEnv {
-  WEBHOOK_SECRET: string;
+  WEBHOOK_SECRET: SecretsStoreSecret;
   CI_HUB: DurableObjectNamespace;
   // Comma-separated `owner/name` list of repos that don't cut tags. PR merges
   // into the default branch are treated as releases for these. See

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -105,7 +105,8 @@ export async function handleWebhook(
 
   const body = await request.text();
 
-  const valid = await verifySignature(env.WEBHOOK_SECRET, body, signature);
+  const secret = await env.WEBHOOK_SECRET.get();
+  const valid = await verifySignature(secret, body, signature);
   if (!valid) {
     return new Response("Invalid signature", { status: 401 });
   }

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -7,7 +7,7 @@ import { escapeHtml, buildClaudeCodeLaunchUrl, CLAUDE_CODE_LAUNCH_REPOS } from "
 function testEnv(): Env {
   return {
     CI_STATUS: env.CI_STATUS,
-    WEBHOOK_SECRET: "test-secret",
+    WEBHOOK_SECRET: { get: async () => "test-secret" } as unknown as SecretsStoreSecret,
     INTERNAL_SHARED_SECRET: { get: async () => "test-internal" } as unknown as SecretsStoreSecret,
     CI_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
   };

--- a/test/projects-page.test.ts
+++ b/test/projects-page.test.ts
@@ -6,7 +6,7 @@ import type { Env } from "../src/index";
 function testEnv(): Env {
   return {
     CI_STATUS: env.CI_STATUS,
-    WEBHOOK_SECRET: "test-secret",
+    WEBHOOK_SECRET: { get: async () => "test-secret" } as unknown as SecretsStoreSecret,
     INTERNAL_SHARED_SECRET: { get: async () => "test-internal" } as unknown as SecretsStoreSecret,
     CI_HUB: {
       idFromName: () => ({}),

--- a/test/release-close-batch.test.ts
+++ b/test/release-close-batch.test.ts
@@ -6,7 +6,7 @@ import type { Env } from "../src/index";
 function testEnv(): Env {
   return {
     CI_STATUS: env.CI_STATUS,
-    WEBHOOK_SECRET: "test-secret",
+    WEBHOOK_SECRET: { get: async () => "test-secret" } as unknown as SecretsStoreSecret,
     INTERNAL_SHARED_SECRET: { get: async () => "test-internal" } as unknown as SecretsStoreSecret,
     CI_HUB: {
       idFromName: () => ({}),

--- a/test/release-close.test.ts
+++ b/test/release-close.test.ts
@@ -6,7 +6,7 @@ import type { Env } from "../src/index";
 function testEnv(): Env {
   return {
     CI_STATUS: env.CI_STATUS,
-    WEBHOOK_SECRET: "test-secret",
+    WEBHOOK_SECRET: { get: async () => "test-secret" } as unknown as SecretsStoreSecret,
     INTERNAL_SHARED_SECRET: { get: async () => "test-internal" } as unknown as SecretsStoreSecret,
     CI_HUB: {
       idFromName: () => ({}),

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -11,7 +11,7 @@ function testEnv(opts: { watched?: string[] } = {}): Env {
   const watched = opts.watched ?? [];
   return {
     CI_STATUS: env.CI_STATUS,
-    WEBHOOK_SECRET: "test-secret",
+    WEBHOOK_SECRET: { get: async () => "test-secret" } as unknown as SecretsStoreSecret,
     INTERNAL_SHARED_SECRET: { get: async () => "test-internal" } as unknown as SecretsStoreSecret,
     CI_HUB: {
       idFromName: () => ({}),

--- a/test/secret-gen-page.test.ts
+++ b/test/secret-gen-page.test.ts
@@ -12,7 +12,7 @@ import type { Env } from "../src/index";
 function testEnv(): Env {
   return {
     CI_STATUS: env.CI_STATUS,
-    WEBHOOK_SECRET: "test-secret",
+    WEBHOOK_SECRET: { get: async () => "test-secret" } as unknown as SecretsStoreSecret,
     INTERNAL_SHARED_SECRET: { get: async () => "test-internal" } as unknown as SecretsStoreSecret,
     CI_HUB: {
       idFromName: () => ({}),

--- a/test/status.test.ts
+++ b/test/status.test.ts
@@ -65,7 +65,7 @@ function testEnv(): Env {
   const hub = mockHub(env.CI_STATUS);
   return {
     CI_STATUS: env.CI_STATUS,
-    WEBHOOK_SECRET,
+    WEBHOOK_SECRET: { get: async () => WEBHOOK_SECRET } as unknown as SecretsStoreSecret,
     INTERNAL_SHARED_SECRET: { get: async () => "test-internal" } as unknown as SecretsStoreSecret,
     CI_HUB: { idFromName: () => ({}), get: () => hub } as unknown as DurableObjectNamespace,
   };

--- a/test/tag-release.test.ts
+++ b/test/tag-release.test.ts
@@ -6,7 +6,7 @@ import type { Env } from "../src/index";
 function testEnv(): Env {
   return {
     CI_STATUS: env.CI_STATUS,
-    WEBHOOK_SECRET: "test-secret",
+    WEBHOOK_SECRET: { get: async () => "test-secret" } as unknown as SecretsStoreSecret,
     INTERNAL_SHARED_SECRET: { get: async () => "test-internal" } as unknown as SecretsStoreSecret,
     CI_HUB: {} as unknown as DurableObjectNamespace,
   };

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -147,7 +147,7 @@ function testEnv(): Env {
   const hub = mockHub(env.CI_STATUS);
   return {
     CI_STATUS: env.CI_STATUS,
-    WEBHOOK_SECRET,
+    WEBHOOK_SECRET: { get: async () => WEBHOOK_SECRET } as unknown as SecretsStoreSecret,
     INTERNAL_SHARED_SECRET: { get: async () => "test-internal" } as unknown as SecretsStoreSecret,
     CI_HUB: { idFromName: () => ({}), get: () => hub } as unknown as DurableObjectNamespace,
   };

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -50,16 +50,25 @@
       "binding": "INTERNAL_SHARED_SECRET",
       "store_id": "bd7bc91a3e5f4111add4acf6cb4b8733",
       "secret_name": "JWT_FOR_CI_DASHBOARD"
+    },
+    // GitHub webhook 配信の HMAC-SHA256 検証用 secret (src/webhook.ts の
+    // env.WEBHOOK_SECRET)。各 GH repo の Webhook 設定の Secret 欄と同値。
+    // 旧 per-worker secret から Secrets Store binding に移行 (Refs #127)。
+    {
+      "binding": "WEBHOOK_SECRET",
+      "store_id": "bd7bc91a3e5f4111add4acf6cb4b8733",
+      "secret_name": "webhook-secret-ci-dashboard"
     }
   ],
   // ci-workflows/secret-verify-gcp.yml が読む宣言。GCP Secret Manager 上に
   // 同名 entry が存在することを CI で検証し、verify SA に権限があれば
   // `used-by-ippoan-ci-dashboard=active` label を自動付与する。
-  // top-level / env.staging 両方とも同じ JWT_FOR_CI_DASHBOARD を bind して
-  // いるので 1 entry で足りる。
+  // top-level / env.staging 両方とも同じ JWT_FOR_CI_DASHBOARD /
+  // webhook-secret-ci-dashboard を bind しているので 1 entry で足りる。
   "secrets": {
     "required": [
-      "JWT_FOR_CI_DASHBOARD"
+      "JWT_FOR_CI_DASHBOARD",
+      "webhook-secret-ci-dashboard"
     ]
   },
   // staging を実運用 env として扱う (secrets-inventory と同じパターン)。
@@ -111,6 +120,11 @@
           "binding": "INTERNAL_SHARED_SECRET",
           "store_id": "bd7bc91a3e5f4111add4acf6cb4b8733",
           "secret_name": "JWT_FOR_CI_DASHBOARD"
+        },
+        {
+          "binding": "WEBHOOK_SECRET",
+          "store_id": "bd7bc91a3e5f4111add4acf6cb4b8733",
+          "secret_name": "webhook-secret-ci-dashboard"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- `ci-dashboard-staging` worker に per-worker secret として WEBHOOK_SECRET が一切設定されておらず、全 webhook (24h で 2486 件) が 500 で reject されていた
- INTERNAL_SHARED_SECRET と同じ Secrets Store binding 方式に統一 (`webhook-secret-ci-dashboard` entry、GCP source-of-truth → CF 伝播)
- Env interface の `WEBHOOK_SECRET` を `string` から `SecretsStoreSecret` に変更、`await env.WEBHOOK_SECRET.get()` で値取得

## Root cause

`src/webhook.ts:97` の verifySignature が `crypto.subtle.importKey` に長さ 0 の HMAC key を渡して例外:
\`\`\`
DataError: Imported HMAC key length (0) must be a non-zero value...
POST /webhook → 500
\`\`\`

`wrangler secret list --env staging` も空配列、wrangler 自身が \`\"secrets\" exists at the top level, but not on \"env.staging\". This is not what you probably want\` と警告していた。

## Secret 投入経路 (operator が実施済)

1. `mcp__claude_ai_secret-manger__create_secret` で GCP に `webhook-secret-ci-dashboard` v1 (暫定値) 作成
2. operator が各 GH repo の Webhook 設定で実値生成 → GCP に new version add
3. operator が `wrangler secrets-store secret create` で同値を CF Secrets Store にコピー

## Test plan

- [x] \`npm run typecheck\` 通過
- [x] \`npx vitest run test/webhook.test.ts\` 全 16 件 pass
- [ ] CI 通過後 staging deploy → https://ci-dashboard.ippoan.org で CI runs が表示されることを確認
- [ ] Worker observability で POST /webhook の status が 200 に戻ることを確認

Refs #127