### PR TITLE
feat(issues): webhook 駆動 KV cache で /issues SSR の API 消費を削減 (Refs #129)

### DIFF
--- a/src/issue-cache.ts
+++ b/src/issue-cache.ts
@@ -1,0 +1,197 @@
+import type { OrgIssue, FetchOrgIssuesParams } from "./mcp/tools/issues";
+import { fetchOrgIssues } from "./mcp/tools/issues";
+import type { AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
+
+// KV schema:
+//   issue:<owner>/<name>#<number>  -> OrgIssue JSON   (open issues only;
+//                                                      closed → delete)
+//   issues:watermark               -> ISO timestamp   (last successful
+//                                                      list-since reconcile)
+//
+// 設計方針 (Refs #129):
+// - SSR は KV から read のみ。reconcile は watermark が古い時だけ走る。
+// - Webhook (issues / issue_comment) は個別 issue を patch するが watermark
+//   は触らない。watermark の意味は「ここまでは list-since が確実に拾った」。
+//   webhook 配信ミスは次の reconcile の delta クエリが必ず救う。
+
+const KEY_WATERMARK = "issues:watermark";
+const KEY_PREFIX = "issue:";
+
+// SSR 連続リロード時の thundering herd を吸収しつつ「stale すぎる」と
+// 感じさせない値。書き込みは webhook が数秒以内に届くので 60s 内の更新
+// ラグは webhook 側でほぼ埋まる。
+const FRESH_THRESHOLD_MS = 60 * 1000;
+
+// Watermark を `now - SAFETY_WINDOW_MS` でセット。次回 delta の
+// `updated:>=watermark` が clock skew 5s ぶんを overlap 検索するための
+// バッファ。upsert は idempotent なので overlap は無害。
+const SAFETY_WINDOW_MS = 5 * 1000;
+
+export function issueKey(repo: string, number: number): string {
+  return `${KEY_PREFIX}${repo}#${number}`;
+}
+
+/** Webhook 経路から呼ぶ単一 issue 反映。open → put / closed → delete。
+ *  watermark は意図的に touch しない (上記設計方針参照)。 */
+export async function upsertIssue(
+  kv: KVNamespace,
+  issue: OrgIssue,
+): Promise<void> {
+  const key = issueKey(issue.repo, issue.number);
+  if (issue.state === "open") {
+    await kv.put(key, JSON.stringify(issue));
+  } else {
+    await kv.delete(key);
+  }
+}
+
+/** Cache 上の全 open issue を返す。KV.list で prefix 走査。現状 issue 数
+ *  数百のオーダーなので 1-2 page で完了する。 */
+export async function listCachedOpenIssues(kv: KVNamespace): Promise<OrgIssue[]> {
+  const out: OrgIssue[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await kv.list({ prefix: KEY_PREFIX, cursor });
+    const vals = await Promise.all(
+      page.keys.map((k) => kv.get(k.name, "json") as Promise<OrgIssue | null>),
+    );
+    for (const v of vals) if (v) out.push(v);
+    cursor = page.list_complete ? undefined : page.cursor;
+  } while (cursor);
+  return out;
+}
+
+export interface ReconcileParams {
+  mainOrgs: string[];
+  yhondaRepos: string[];
+}
+
+export interface ReconcileResult {
+  /** Number of issues touched by this reconcile. 0 if cache was fresh. */
+  patched: number;
+  /** Whether we actually hit GitHub. false = within FRESH_THRESHOLD_MS. */
+  fetched: boolean;
+}
+
+/** Watermark を見て GitHub に当てに行く。fresh window 内なら no-op。
+ *  Cold start (watermark なし) は state:open の全件取得、それ以降は
+ *  state:all + updated:>=watermark の delta。auth error 等はそのまま throw。 */
+export async function reconcileIssues(
+  env: AuthClientWorkerEnv,
+  params: ReconcileParams,
+): Promise<ReconcileResult> {
+  const kv = env.CI_STATUS;
+  const watermark = await kv.get(KEY_WATERMARK);
+  const now = Date.now();
+  if (watermark && now - Date.parse(watermark) < FRESH_THRESHOLD_MS) {
+    return { patched: 0, fetched: false };
+  }
+
+  const isCold = !watermark;
+  // Cold start: state:open で「現時点の open 集合」をブートストラップ。
+  // Warm: state:all + updated:>= で delta のみ (close も拾う)。
+  const sinceQ = watermark ? `updated:>=${watermark}` : "";
+  const stateFilter: FetchOrgIssuesParams["state"] = isCold ? "open" : "all";
+
+  // 既存の issues-page.ts と同じ 2-query pattern。GitHub search は org: と
+  // repo: を組み合わせると repo: 側を黙って drop するので yhonda-ohishi
+  // 特定 repo は別 query に分離する必要がある (mcp/tools/issues.ts 参照)。
+  const mainParams: FetchOrgIssuesParams = {
+    orgs: params.mainOrgs,
+    state: stateFilter,
+    per_page: 100,
+  };
+  if (sinceQ) mainParams.query = sinceQ;
+
+  const yhondaQ = [
+    ...params.yhondaRepos.map((r) => `repo:${r}`),
+    sinceQ,
+  ].filter(Boolean).join(" ");
+  const yhondaParams: FetchOrgIssuesParams = {
+    orgs: ["yhonda-ohishi"],
+    state: stateFilter,
+    per_page: 100,
+    query: yhondaQ,
+  };
+
+  const [main, yhonda] = await Promise.all([
+    fetchOrgIssues(env, mainParams),
+    fetchOrgIssues(env, yhondaParams),
+  ]);
+
+  const all = [...main.items, ...yhonda.items];
+  for (const issue of all) {
+    await upsertIssue(kv, issue);
+  }
+
+  const newWm = new Date(now - SAFETY_WINDOW_MS).toISOString();
+  await kv.put(KEY_WATERMARK, newWm);
+
+  return { patched: all.length, fetched: true };
+}
+
+// ───── Webhook payload → OrgIssue 正規化 ─────
+
+export interface IssueWebhookPayload {
+  action: string;
+  issue: {
+    number: number;
+    title: string;
+    state: "open" | "closed";
+    user: { login: string } | null;
+    labels: Array<{ name: string }>;
+    assignees: Array<{ login: string }>;
+    comments: number;
+    created_at: string;
+    updated_at: string;
+    html_url: string;
+  };
+  repository: { full_name: string };
+}
+
+export function webhookIssueToOrgIssue(p: IssueWebhookPayload): OrgIssue {
+  return {
+    repo: p.repository.full_name,
+    number: p.issue.number,
+    title: p.issue.title,
+    state: p.issue.state,
+    author: p.issue.user?.login ?? "",
+    labels: p.issue.labels.map((l) => l.name),
+    assignees: p.issue.assignees.map((a) => a.login),
+    comments: p.issue.comments,
+    created_at: p.issue.created_at,
+    updated_at: p.issue.updated_at,
+    url: p.issue.html_url,
+  };
+}
+
+export interface IssueCommentWebhookPayload {
+  action: "created" | "edited" | "deleted";
+  issue: { number: number };
+  repository: { full_name: string };
+}
+
+/** issue_comment event を反映。comment 数だけ inc/dec する。`edited` は
+ *  comment 数を変えないので skip。cache miss (該当 issue が KV に居ない)
+ *  は no-op — どうせ次の reconcile delta で full record が来る。 */
+export async function applyIssueCommentEvent(
+  kv: KVNamespace,
+  p: IssueCommentWebhookPayload,
+): Promise<void> {
+  if (p.action === "edited") return;
+  const key = issueKey(p.repository.full_name, p.issue.number);
+  const existing = await kv.get(key, "json") as OrgIssue | null;
+  if (!existing) return;
+  existing.comments += p.action === "created" ? 1 : -1;
+  if (existing.comments < 0) existing.comments = 0;
+  existing.updated_at = new Date().toISOString();
+  await kv.put(key, JSON.stringify(existing));
+}
+
+// Test 用に内部定数を公開。production code からは呼ばない。
+export const __testing = {
+  KEY_WATERMARK,
+  KEY_PREFIX,
+  FRESH_THRESHOLD_MS,
+  SAFETY_WINDOW_MS,
+};

--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -193,7 +193,7 @@ export async function handleIssuesPage(env: AuthClientWorkerEnv): Promise<Respon
   const mainOrgSet = new Set(ORGS);
   const yhondaRepoSet = new Set(YHONDA_REPOS);
   const filtered = cached.filter((i) => {
-    const owner = i.repo.split("/")[0];
+    const owner = i.repo.split("/")[0] ?? "";
     if (mainOrgSet.has(owner)) return true;
     return yhondaRepoSet.has(i.repo);
   });

--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -1,9 +1,10 @@
-import { fetchOrgIssues, type OrgIssue } from "./mcp/tools/issues";
+import { type OrgIssue } from "./mcp/tools/issues";
 import { fetchProjectIssueMap, type ProjectRef } from "./mcp/tools/projects";
 import { fetchAllOpenPrsByIssue, type IssuePrRef } from "./issue-prs";
 import type { AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
 import { renderTabs, TAB_STYLES } from "./nav-tabs";
 import { PWA_HEAD_TAGS, PWA_REGISTER_SCRIPT } from "./pwa";
+import { listCachedOpenIssues, reconcileIssues } from "./issue-cache";
 
 // Orgs fetched in full. Same allowlist as github-api.ts (not imported because
 // ALLOWED_ORGS isn't exported; keep the two in sync if either grows).
@@ -169,29 +170,12 @@ function isAuthError(err: unknown): boolean {
 }
 
 export async function handleIssuesPage(env: AuthClientWorkerEnv): Promise<Response> {
-  // Search REST gives us the issues themselves; this is the only fetch that
-  // can fail the page outright. Project map is loaded separately below so a
-  // GraphQL rate-limit doesn't blank the page (Refs #94 follow-up).
-  let merged;
+  // KV cache-first 読み出し (Refs #129)。reconcile は watermark が古い時
+  // だけ走り、それ以外は KV read で完結する (= GitHub API 0 call)。
+  // reconcile 失敗時も cache が空でなければ stale banner 付きで render する。
+  let reconcileError: string | null = null;
   try {
-    const [main, yhonda] = await Promise.all([
-      fetchOrgIssues(env, {
-        orgs: ORGS,
-        state: "open",
-        per_page: 100,
-      }),
-      fetchOrgIssues(env, {
-        orgs: ["yhonda-ohishi"],
-        state: "open",
-        per_page: 100,
-        query: YHONDA_REPOS.map((r) => `repo:${r}`).join(" "),
-      }),
-    ]);
-    merged = {
-      total_count: main.total_count + yhonda.total_count,
-      incomplete: main.incomplete || yhonda.incomplete,
-      items: [...main.items, ...yhonda.items],
-    };
+    await reconcileIssues(env, { mainOrgs: ORGS, yhondaRepos: YHONDA_REPOS });
   } catch (err) {
     if (isAuthError(err)) {
       // 認証失効: GitHub 同意画面 → /oauth/callback → return_to で /issues に戻る
@@ -200,12 +184,33 @@ export async function handleIssuesPage(env: AuthClientWorkerEnv): Promise<Respon
         headers: { Location: "/oauth/login?return_to=/issues" },
       });
     }
-    const msg = err instanceof Error ? err.message : String(err);
-    return new Response(renderError(msg), {
+    reconcileError = err instanceof Error ? err.message : String(err);
+  }
+
+  const cached = await listCachedOpenIssues(env.CI_STATUS);
+  // KV には過去設定の repo が残っている可能性があるので allowlist で
+  // filter。mainOrgs 配下は全 repo 許可、yhonda-ohishi は YHONDA_REPOS のみ。
+  const mainOrgSet = new Set(ORGS);
+  const yhondaRepoSet = new Set(YHONDA_REPOS);
+  const filtered = cached.filter((i) => {
+    const owner = i.repo.split("/")[0];
+    if (mainOrgSet.has(owner)) return true;
+    return yhondaRepoSet.has(i.repo);
+  });
+
+  // Cache が空かつ reconcile も fail → 完全に表示不能なので 502。
+  if (filtered.length === 0 && reconcileError) {
+    return new Response(renderError(reconcileError), {
       status: 502,
       headers: { "Content-Type": "text/html; charset=utf-8" },
     });
   }
+
+  const merged = {
+    total_count: filtered.length,
+    incomplete: false,
+    items: filtered,
+  };
 
   const [project, prs] = await Promise.all([
     loadProjectMap(env, PROJECT_ORGS),
@@ -242,7 +247,7 @@ export async function handleIssuesPage(env: AuthClientWorkerEnv): Promise<Respon
     ] as const);
 
   return new Response(
-    renderHtml(merged.total_count, merged.incomplete, projectTagged, repos, project, prs),
+    renderHtml(merged.total_count, merged.incomplete, projectTagged, repos, project, prs, reconcileError),
     { headers: { "Content-Type": "text/html; charset=utf-8" } },
   );
 }
@@ -254,6 +259,7 @@ function renderHtml(
   repos: ReadonlyArray<readonly [string, OrgIssue[]]>,
   project: ProjectMapResult,
   prs: PrMapResult,
+  issueStaleError: string | null,
 ): string {
   const repoSections = repos
     .map(([repo, items]) => renderRepoSection(repo, items, prs.map))
@@ -265,6 +271,11 @@ function renderHtml(
 
   const incompleteBanner = incomplete
     ? `<div class="banner">⚠️ Result was truncated by GitHub search. Showing ${total} issues but more may exist.</div>`
+    : "";
+  // KV cache の reconcile が fail した時の stale 注意。cache がある以上
+  // ページは出せるが、最新の close / open は反映されていない可能性がある。
+  const issueStaleBanner = issueStaleError
+    ? `<div class="banner banner-info">📋 Issue list shown is from KV cache — fresh reconcile failed (${escapeHtml(issueStaleError)})</div>`
     : "";
   const projectBanner = project.stale
     ? `<div class="banner banner-info">📋 Project tags shown are from the last successful sync — fresh fetch failed (${escapeHtml(project.error ?? "")})</div>`
@@ -468,6 +479,7 @@ function renderHtml(
     </div>
   </header>
   ${incompleteBanner}
+  ${issueStaleBanner}
   ${projectBanner}
   ${prBanner}
   ${projectSection}

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -1,5 +1,12 @@
 import type { Env } from "./index";
 import { parseTaglessRepos } from "./tagless-repos";
+import {
+  upsertIssue,
+  webhookIssueToOrgIssue,
+  applyIssueCommentEvent,
+  type IssueWebhookPayload,
+  type IssueCommentWebhookPayload,
+} from "./issue-cache";
 
 interface WorkflowRunPayload {
   action: string;
@@ -183,6 +190,25 @@ export async function handleWebhook(
         }),
       }));
     }
+    return new Response("OK", { status: 200 });
+  }
+
+  // /issues SSR page の KV cache (issue-cache.ts) 更新経路。Webhook で来た
+  // 個別 issue を upsert する。watermark は意図的に touch しない (配信ミス
+  // 時に list-since reconcile が必ず拾うための担保)。Refs #129。
+  if (event === "issues") {
+    const payload: IssueWebhookPayload = JSON.parse(body);
+    const issue = webhookIssueToOrgIssue(payload);
+    await upsertIssue(env.CI_STATUS, issue);
+    return new Response("OK", { status: 200 });
+  }
+
+  // /issues SSR の comment 数表示用。`created` / `deleted` だけ反映、
+  // `edited` は無視 (件数変わらない)。cache miss (該当 issue が KV に
+  // 居ない) は no-op — 次の reconcile delta が full record で上書きする。
+  if (event === "issue_comment") {
+    const payload: IssueCommentWebhookPayload = JSON.parse(body);
+    await applyIssueCommentEvent(env.CI_STATUS, payload);
     return new Response("OK", { status: 200 });
   }
 

--- a/test/issue-cache.test.ts
+++ b/test/issue-cache.test.ts
@@ -1,0 +1,240 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { OrgIssue } from "../src/mcp/tools/issues";
+import {
+  upsertIssue,
+  listCachedOpenIssues,
+  reconcileIssues,
+  webhookIssueToOrgIssue,
+  applyIssueCommentEvent,
+  issueKey,
+  __testing,
+} from "../src/issue-cache";
+
+function makeIssue(over: Partial<OrgIssue> = {}): OrgIssue {
+  return {
+    repo: "ippoan/ci-dashboard",
+    number: 1,
+    title: "test issue",
+    state: "open",
+    author: "yhonda",
+    labels: [],
+    assignees: [],
+    comments: 0,
+    created_at: "2026-05-27T00:00:00Z",
+    updated_at: "2026-05-27T00:00:00Z",
+    url: "https://github.com/ippoan/ci-dashboard/issues/1",
+    ...over,
+  };
+}
+
+async function clearCache(): Promise<void> {
+  // KV.list でテスト間 leak しないよう全 prefix を flush。
+  for (const prefix of [__testing.KEY_PREFIX, "issues:"]) {
+    let cursor: string | undefined;
+    do {
+      const page = await env.CI_STATUS.list({ prefix, cursor });
+      await Promise.all(page.keys.map((k) => env.CI_STATUS.delete(k.name)));
+      cursor = page.list_complete ? undefined : page.cursor;
+    } while (cursor);
+  }
+}
+
+describe("issue-cache", () => {
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await clearCache();
+  });
+
+  describe("upsertIssue", () => {
+    it("open issue は put、closed は delete する", async () => {
+      const issue = makeIssue({ number: 42 });
+      await upsertIssue(env.CI_STATUS, issue);
+      const stored = await env.CI_STATUS.get(issueKey(issue.repo, 42), "json");
+      expect(stored).toEqual(issue);
+
+      await upsertIssue(env.CI_STATUS, { ...issue, state: "closed" });
+      const after = await env.CI_STATUS.get(issueKey(issue.repo, 42));
+      expect(after).toBeNull();
+    });
+
+    it("watermark を touch しない (webhook 配信ミス時に list-since で拾える担保)", async () => {
+      await env.CI_STATUS.put(__testing.KEY_WATERMARK, "2026-05-26T00:00:00Z");
+      await upsertIssue(env.CI_STATUS, makeIssue());
+      const wm = await env.CI_STATUS.get(__testing.KEY_WATERMARK);
+      expect(wm).toBe("2026-05-26T00:00:00Z");
+    });
+  });
+
+  describe("listCachedOpenIssues", () => {
+    it("複数 repo の open issue を全件返す", async () => {
+      await upsertIssue(env.CI_STATUS, makeIssue({ number: 1 }));
+      await upsertIssue(env.CI_STATUS, makeIssue({ number: 2, repo: "ohishi-exp/other" }));
+      const all = await listCachedOpenIssues(env.CI_STATUS);
+      expect(all).toHaveLength(2);
+      expect(all.map((i) => i.number).sort()).toEqual([1, 2]);
+    });
+
+    it("cache 空なら空配列", async () => {
+      const all = await listCachedOpenIssues(env.CI_STATUS);
+      expect(all).toEqual([]);
+    });
+  });
+
+  describe("reconcileIssues", () => {
+    function mockSearchResponse(items: OrgIssue[]) {
+      return Response.json({
+        total_count: items.length,
+        incomplete_results: false,
+        items: items.map((i) => ({
+          number: i.number,
+          title: i.title,
+          state: i.state,
+          user: { login: i.author },
+          labels: i.labels.map((n) => ({ name: n })),
+          assignees: i.assignees.map((a) => ({ login: a })),
+          comments: i.comments,
+          created_at: i.created_at,
+          updated_at: i.updated_at,
+          html_url: i.url,
+          repository_url: `https://api.github.com/repos/${i.repo}`,
+        })),
+      });
+    }
+
+    it("fresh window 内は GitHub を叩かない", async () => {
+      // watermark を「ちょっと前」にセット → fresh 判定で skip
+      const recent = new Date(Date.now() - 10 * 1000).toISOString();
+      await env.CI_STATUS.put(__testing.KEY_WATERMARK, recent);
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+      const result = await reconcileIssues(env, { mainOrgs: ["ippoan"], yhondaRepos: [] });
+      expect(result.fetched).toBe(false);
+      expect(result.patched).toBe(0);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("cold start で全件 fetch + watermark セット", async () => {
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+        const url = typeof input === "string" ? input : (input as Request).url;
+        // auth-worker token 取得呼び出しは skip して mock 値返す
+        if (url.includes("auth-worker") || url.includes("/mcp/token")) {
+          return Response.json({ access_token: "tok" });
+        }
+        if (url.includes("/search/issues")) {
+          return mockSearchResponse([
+            makeIssue({ number: 10 }),
+            makeIssue({ number: 11, repo: "ippoan/other" }),
+          ]);
+        }
+        return new Response("ignored", { status: 404 });
+      });
+
+      const result = await reconcileIssues(env, {
+        mainOrgs: ["ippoan"], yhondaRepos: [],
+      });
+      expect(result.fetched).toBe(true);
+      // 2 query (main + yhonda) で各 2 件 → 計 4 件 (mock は両 query 同レスポンス)
+      expect(result.patched).toBeGreaterThan(0);
+
+      const wm = await env.CI_STATUS.get(__testing.KEY_WATERMARK);
+      expect(wm).toBeTruthy();
+      expect(Date.parse(wm!)).toBeLessThanOrEqual(Date.now());
+    });
+  });
+
+  describe("webhookIssueToOrgIssue", () => {
+    it("webhook payload を OrgIssue 形に正規化", async () => {
+      const issue = webhookIssueToOrgIssue({
+        action: "opened",
+        issue: {
+          number: 7,
+          title: "from webhook",
+          state: "open",
+          user: { login: "alice" },
+          labels: [{ name: "bug" }, { name: "p1" }],
+          assignees: [{ login: "bob" }],
+          comments: 3,
+          created_at: "2026-05-27T01:00:00Z",
+          updated_at: "2026-05-27T02:00:00Z",
+          html_url: "https://github.com/x/y/issues/7",
+        },
+        repository: { full_name: "x/y" },
+      });
+      expect(issue).toEqual({
+        repo: "x/y",
+        number: 7,
+        title: "from webhook",
+        state: "open",
+        author: "alice",
+        labels: ["bug", "p1"],
+        assignees: ["bob"],
+        comments: 3,
+        created_at: "2026-05-27T01:00:00Z",
+        updated_at: "2026-05-27T02:00:00Z",
+        url: "https://github.com/x/y/issues/7",
+      });
+    });
+
+    it("user が null (deleted account) でも author=空文字で受ける", () => {
+      const issue = webhookIssueToOrgIssue({
+        action: "opened",
+        issue: {
+          number: 1, title: "x", state: "open", user: null,
+          labels: [], assignees: [], comments: 0,
+          created_at: "t", updated_at: "t", html_url: "u",
+        },
+        repository: { full_name: "a/b" },
+      });
+      expect(issue.author).toBe("");
+    });
+  });
+
+  describe("applyIssueCommentEvent", () => {
+    it("created で comments を +1", async () => {
+      await upsertIssue(env.CI_STATUS, makeIssue({ number: 5, comments: 2 }));
+      await applyIssueCommentEvent(env.CI_STATUS, {
+        action: "created",
+        issue: { number: 5 },
+        repository: { full_name: "ippoan/ci-dashboard" },
+      });
+      const updated = await env.CI_STATUS.get(
+        issueKey("ippoan/ci-dashboard", 5), "json",
+      ) as OrgIssue;
+      expect(updated.comments).toBe(3);
+    });
+
+    it("deleted で comments を -1 (0 未満にはならない)", async () => {
+      await upsertIssue(env.CI_STATUS, makeIssue({ number: 5, comments: 0 }));
+      await applyIssueCommentEvent(env.CI_STATUS, {
+        action: "deleted",
+        issue: { number: 5 },
+        repository: { full_name: "ippoan/ci-dashboard" },
+      });
+      const updated = await env.CI_STATUS.get(
+        issueKey("ippoan/ci-dashboard", 5), "json",
+      ) as OrgIssue;
+      expect(updated.comments).toBe(0);
+    });
+
+    it("edited は no-op (件数変わらない)", async () => {
+      await upsertIssue(env.CI_STATUS, makeIssue({ number: 5, comments: 2 }));
+      await applyIssueCommentEvent(env.CI_STATUS, {
+        action: "edited",
+        issue: { number: 5 },
+        repository: { full_name: "ippoan/ci-dashboard" },
+      });
+      const updated = await env.CI_STATUS.get(
+        issueKey("ippoan/ci-dashboard", 5), "json",
+      ) as OrgIssue;
+      expect(updated.comments).toBe(2);
+    });
+
+    it("cache miss は no-op で throw しない", async () => {
+      await expect(applyIssueCommentEvent(env.CI_STATUS, {
+        action: "created",
+        issue: { number: 999 },
+        repository: { full_name: "unknown/repo" },
+      })).resolves.toBeUndefined();
+    });
+  });
+});

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -219,6 +219,16 @@ describe("GET /issues", () => {
   beforeEach(async () => {
     await env.CI_STATUS.delete("issues-page:project-map");
     await env.CI_STATUS.delete("issues-page:pr-map:v2");
+    // KV cache (Refs #129) も毎テスト前にクリア。watermark が残っていると
+    // reconcile が fresh window 判定で skip し、cold-start の fetch が
+    // 走らないため stub が当たらず空 cache を返す。
+    await env.CI_STATUS.delete("issues:watermark");
+    let cursor: string | undefined;
+    do {
+      const page = await env.CI_STATUS.list({ prefix: "issue:", cursor });
+      await Promise.all(page.keys.map((k) => env.CI_STATUS.delete(k.name)));
+      cursor = page.list_complete ? undefined : page.cursor;
+    } while (cursor);
   });
   afterEach(() => { vi.restoreAllMocks(); });
 
@@ -400,6 +410,16 @@ describe("GET /issues — Project section", () => {
   beforeEach(async () => {
     await env.CI_STATUS.delete("issues-page:project-map");
     await env.CI_STATUS.delete("issues-page:pr-map:v2");
+    // KV cache (Refs #129) も毎テスト前にクリア。watermark が残っていると
+    // reconcile が fresh window 判定で skip し、cold-start の fetch が
+    // 走らないため stub が当たらず空 cache を返す。
+    await env.CI_STATUS.delete("issues:watermark");
+    let cursor: string | undefined;
+    do {
+      const page = await env.CI_STATUS.list({ prefix: "issue:", cursor });
+      await Promise.all(page.keys.map((k) => env.CI_STATUS.delete(k.name)));
+      cursor = page.list_complete ? undefined : page.cursor;
+    } while (cursor);
   });
   afterEach(() => { vi.restoreAllMocks(); });
 
@@ -548,6 +568,16 @@ describe("GET /issues — Claude Code launch button", () => {
   beforeEach(async () => {
     await env.CI_STATUS.delete("issues-page:project-map");
     await env.CI_STATUS.delete("issues-page:pr-map:v2");
+    // KV cache (Refs #129) も毎テスト前にクリア。watermark が残っていると
+    // reconcile が fresh window 判定で skip し、cold-start の fetch が
+    // 走らないため stub が当たらず空 cache を返す。
+    await env.CI_STATUS.delete("issues:watermark");
+    let cursor: string | undefined;
+    do {
+      const page = await env.CI_STATUS.list({ prefix: "issue:", cursor });
+      await Promise.all(page.keys.map((k) => env.CI_STATUS.delete(k.name)));
+      cursor = page.list_complete ? undefined : page.cursor;
+    } while (cursor);
   });
   afterEach(() => { vi.restoreAllMocks(); });
 
@@ -595,6 +625,16 @@ describe("GET /issues — Related-PR chips", () => {
   beforeEach(async () => {
     await env.CI_STATUS.delete("issues-page:project-map");
     await env.CI_STATUS.delete("issues-page:pr-map:v2");
+    // KV cache (Refs #129) も毎テスト前にクリア。watermark が残っていると
+    // reconcile が fresh window 判定で skip し、cold-start の fetch が
+    // 走らないため stub が当たらず空 cache を返す。
+    await env.CI_STATUS.delete("issues:watermark");
+    let cursor: string | undefined;
+    do {
+      const page = await env.CI_STATUS.list({ prefix: "issue:", cursor });
+      await Promise.all(page.keys.map((k) => env.CI_STATUS.delete(k.name)));
+      cursor = page.list_complete ? undefined : page.cursor;
+    } while (cursor);
   });
   afterEach(() => { vi.restoreAllMocks(); });
 


### PR DESCRIPTION
Refs #129

## 問題

`/issues` SSR が毎リクエストで GitHub Search API を 2 query 叩いていた。PWA タブ開きっぱなしで rate limit (yhonda-ohishi user 87104778 の 5000/h pool) を枯渇させ、cross-repo の `auto-merge.yml` ジョブまで巻き込んで fail させていた。

実害事例:
- ci-dashboard run 26333118357 / 26333304018
- ref-files-worker run 26386634750
- egov-shinsei-sdk run 26387344292
- auth-worker run 26431073030

## 設計

書き込みと読み込みを分離:

```
Read  (SSR):  GitHub event → webhook → KV update
              browser → SSR → KV read  (idle 時 0 API call)

Write:        Claude Code / 人 → MCP / gh / GitHub UI → GitHub API
                                                       ↓
                                                  webhook → KV upsert
```

- **Watermark は webhook で advance しない** — webhook 配信ミスを次の list-since reconcile が必ず拾う担保
- **cron / backfill script 不要** — 初回 `watermark=null` で cold-start fetch、以降は delta `updated:>=<watermark>`
- 60s fresh window で SSR 連続リロード時の thundering herd を吸収

## 変更

| ファイル | 内容 |
|---|---|
| `src/issue-cache.ts` (新規) | KV cache + on-demand reconcile + webhook payload 正規化 |
| `src/webhook.ts` | `issues` / `issue_comment` event handler 追加 |
| `src/issues-page.ts` | `fetchOrgIssues` 直叩き → `reconcileIssues` + `listCachedOpenIssues` cache-first に書き換え、reconcile fail 時の stale banner 追加 |
| `test/issue-cache.test.ts` (新規) | upsert / list / reconcile fresh-skip / cold-start / webhook 正規化 / comment 数の inc/dec の smoke test |
| `test/issues-page.test.ts` | beforeEach に `issue:*` / `issues:watermark` の KV クリア追加 (4 describe block 共通) |

## デプロイ後の作業 (本 PR merge 後に必要)

3 org の GitHub webhook 設定で配信 event 種別を拡張する必要がある:

- `ippoan`
- `ohishi-exp`
- `yhonda-ohishi`

現状の `workflow_run` / `workflow_job` / `pull_request` に加え:

- `issues` (opened / edited / closed / reopened / labeled / unlabeled / assigned / unassigned)
- `issue_comment` (created / deleted)

設定前は cold-start fetch で動作する (壊れない) が、API call 削減効果は webhook 配信が開始してから現れる。

## scope 外 (follow-up issue)

- `/projects` page の webhook 駆動化 (`projects_v2` / `projects_v2_item` event)
- `/releases` page の webhook 駆動化 (`release` event)
- GitHub App installation token への切替 (user 87104778 pool から完全離脱)

## test plan

- [x] `npm run typecheck` (CI で確認)
- [x] `npm run test` (CI で確認)
- [ ] staging deploy 後、`/issues` を開いて表示されることを確認
- [ ] org webhook で `issues` event 拡張後、新規 issue 作成 → ci-dashboard webhook receiver でログ確認 → 数秒以内に `/issues` ページに反映されることを確認
- [ ] 1 分後にもう一度 `/issues` を開いても GitHub API call が発生しない (Cloudflare logs 確認) ことを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01Td2kA4uyYYnZqXxgSjwmKx)_