### PR TITLE
feat(projects): webhook 駆動 KV cache で /projects SSR の GraphQL fan-out を削減 (Refs #131)

### DIFF
--- a/src/project-cache.ts
+++ b/src/project-cache.ts
@@ -1,0 +1,156 @@
+import type { AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
+import {
+  fetchOrgProjects,
+  fetchProjectItems,
+  type OrgProject,
+  type OrgProjectsResult,
+  type ProjectItemSummary,
+} from "./mcp/tools/projects";
+
+// KV schema (Refs #131):
+//   project:org-list:<org>            -> OrgProject[]
+//   project:items:<org>:<number>      -> ProjectItemSummary[]
+//
+// 設計方針:
+// - TTL 30 分。webhook (projects_v2 / projects_v2_item) が届いたら該当
+//   key を delete → 次の SSR hit で refetch。incremental update ではなく
+//   invalidation-based (`projects_v2_item.content_node_id` を repo#number に
+//   解決するには追加 GraphQL が要るので旨味が薄い)。
+// - watermark 不要 (cache 全 replace でよい)。
+
+const ORG_LIST_PREFIX = "project:org-list:";
+const ITEMS_PREFIX = "project:items:";
+const TTL_SECONDS = 30 * 60;
+
+// `/issues` SSR 側の project map cache key。Phase 1 (#129) で導入済み。
+// `projects_v2_item` event が来た時に併せて invalidate して /issues 側も
+// 同期する (TTL 5min より早く反映される)。
+const ISSUES_PAGE_PROJECT_MAP_KEY = "issues-page:project-map";
+
+function orgListKey(org: string): string {
+  return `${ORG_LIST_PREFIX}${org}`;
+}
+
+function itemsKey(org: string, number: number): string {
+  return `${ITEMS_PREFIX}${org}:${number}`;
+}
+
+/** Cache-first で per-org の Projects v2 list を返す。miss なら GraphQL に
+ *  当てて KV に書き込む。orgs 並列で取りに行く。 */
+export async function getOrFetchOrgProjects(
+  env: AuthClientWorkerEnv,
+  orgs: string[],
+): Promise<OrgProjectsResult[]> {
+  const kv = env.CI_STATUS;
+  return Promise.all(orgs.map(async (org) => {
+    const cached = await kv.get(orgListKey(org), "json") as OrgProject[] | null;
+    if (cached) return { org, projects: cached };
+    const fetched = await fetchOrgProjects(env, { orgs: [org], include_closed: false });
+    const list = fetched[0]?.projects ?? [];
+    await kv.put(orgListKey(org), JSON.stringify(list), { expirationTtl: TTL_SECONDS });
+    return { org, projects: list };
+  }));
+}
+
+/** Cache-first で 1 つの project の items を返す。miss なら fetch + 保存。 */
+export async function getOrFetchProjectItems(
+  env: AuthClientWorkerEnv,
+  org: string,
+  number: number,
+): Promise<ProjectItemSummary[]> {
+  const kv = env.CI_STATUS;
+  const cached = await kv.get(itemsKey(org, number), "json") as ProjectItemSummary[] | null;
+  if (cached) return cached;
+  const items = await fetchProjectItems(env, org, number);
+  await kv.put(itemsKey(org, number), JSON.stringify(items), { expirationTtl: TTL_SECONDS });
+  return items;
+}
+
+/** 該当 org の board list cache だけ flush。`projects_v2` event 用 (board
+ *  の create/close/delete/edit で list そのものが変わる)。 */
+export async function invalidateOrgList(kv: KVNamespace, org: string): Promise<void> {
+  await kv.delete(orgListKey(org));
+}
+
+/** 該当 org の全 project items cache を flush。`projects_v2_item` event 用
+ *  (個別 item の add/edit/delete で該当 project の items が変わる)。
+ *
+ *  本来は project number 単位で精密に消したいが、event payload には
+ *  `project_node_id` (global node ID) しか入っておらず number への解決に
+ *  追加 GraphQL が要るため over-invalidation を選ぶ。org 当たりの active
+ *  project 数は 10 件程度なので影響限定的。 */
+export async function invalidateOrgItems(kv: KVNamespace, org: string): Promise<void> {
+  let cursor: string | undefined;
+  do {
+    const page = await kv.list({ prefix: `${ITEMS_PREFIX}${org}:`, cursor });
+    await Promise.all(page.keys.map((k) => kv.delete(k.name)));
+    cursor = page.list_complete ? undefined : page.cursor;
+  } while (cursor);
+}
+
+/** `/issues` page の project map cache (Phase 1 で既存) を flush。
+ *  `projects_v2_item` event でカードが移動した時、/issues 側の 5min TTL を
+ *  待たずに即反映するために併せて呼ぶ。 */
+export async function invalidateIssuesPageProjectMap(kv: KVNamespace): Promise<void> {
+  await kv.delete(ISSUES_PAGE_PROJECT_MAP_KEY);
+}
+
+// ───── Webhook payload types ─────
+
+export interface ProjectsV2WebhookPayload {
+  action: string;
+  projects_v2: {
+    id: number;
+    node_id: string;
+    owner?: { login: string };
+  };
+  organization?: { login: string };
+}
+
+export interface ProjectsV2ItemWebhookPayload {
+  action: string;
+  projects_v2_item: {
+    id: number;
+    node_id: string;
+    project_node_id: string;
+    content_node_id: string;
+    content_type: "Issue" | "PullRequest" | "DraftIssue";
+  };
+  organization?: { login: string };
+}
+
+/** `projects_v2` event 適用。board level (create/close/delete/edit/reopened)
+ *  なので list と items 両方を flush。 */
+export async function applyProjectsV2Event(
+  kv: KVNamespace,
+  p: ProjectsV2WebhookPayload,
+): Promise<void> {
+  const org = p.organization?.login ?? p.projects_v2.owner?.login;
+  if (!org) return;
+  await invalidateOrgList(kv, org);
+  await invalidateOrgItems(kv, org);
+  await invalidateIssuesPageProjectMap(kv);
+}
+
+/** `projects_v2_item` event 適用。item の add/edit/delete/archive/reorder
+ *  で該当 project の items が変わる。list 自体は変わらないので list cache
+ *  は保つ。issues-page project map も items 変化で stale になるので併せて
+ *  flush。 */
+export async function applyProjectsV2ItemEvent(
+  kv: KVNamespace,
+  p: ProjectsV2ItemWebhookPayload,
+): Promise<void> {
+  const org = p.organization?.login;
+  if (!org) return;
+  await invalidateOrgItems(kv, org);
+  await invalidateIssuesPageProjectMap(kv);
+}
+
+export const __testing = {
+  ORG_LIST_PREFIX,
+  ITEMS_PREFIX,
+  TTL_SECONDS,
+  ISSUES_PAGE_PROJECT_MAP_KEY,
+  orgListKey,
+  itemsKey,
+};

--- a/src/projects-page.ts
+++ b/src/projects-page.ts
@@ -1,6 +1,4 @@
 import {
-  fetchOrgProjects,
-  fetchProjectItems,
   type OrgProject,
   type ProjectItemSummary,
 } from "./mcp/tools/projects";
@@ -8,6 +6,7 @@ import type { AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
 import { renderTabs, TAB_STYLES } from "./nav-tabs";
 import { PWA_HEAD_TAGS, PWA_REGISTER_SCRIPT } from "./pwa";
 import { escapeHtml } from "./issues-page";
+import { getOrFetchOrgProjects, getOrFetchProjectItems } from "./project-cache";
 
 // Same set of orgs as the `/issues` Projects-aggregate section. Three orgs ×
 // ~10 open projects each is well under the GraphQL rate-limit budget for one
@@ -26,9 +25,11 @@ interface OrgSection {
 }
 
 export async function handleProjectsPage(env: AuthClientWorkerEnv): Promise<Response> {
+  // KV cache (Refs #131) 経由で per-org の board list を取る。miss なら
+  // GraphQL fan-out、hit なら API 0 call。TTL 30min + webhook invalidation。
   let perOrg;
   try {
-    perOrg = await fetchOrgProjects(env, { orgs: PROJECT_ORGS });
+    perOrg = await getOrFetchOrgProjects(env, PROJECT_ORGS);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return new Response(renderError(msg), {
@@ -37,16 +38,16 @@ export async function handleProjectsPage(env: AuthClientWorkerEnv): Promise<Resp
     });
   }
 
-  // Fan-out: one items() GraphQL call per (org, project). `allSettled` so a
-  // single project that errors out (e.g. permission, deleted between list and
-  // fetch) doesn't blank the whole page — that project surfaces an inline
-  // error in its <details> block instead.
+  // Fan-out: one items() GraphQL call per (org, project) — but each call is
+  // KV cache-first. `allSettled` so a single project that errors out (e.g.
+  // permission, deleted between list and fetch) doesn't blank the whole page
+  // — that project surfaces an inline error in its <details> block instead.
   const flat = perOrg.flatMap(({ org, projects }) =>
     projects.map((p) => ({ org, project: p })),
   );
   const itemResults = await Promise.allSettled(
     flat.map(({ org, project }) =>
-      fetchProjectItems(env, org, project.number),
+      getOrFetchProjectItems(env, org, project.number),
     ),
   );
 

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -7,6 +7,12 @@ import {
   type IssueWebhookPayload,
   type IssueCommentWebhookPayload,
 } from "./issue-cache";
+import {
+  applyProjectsV2Event,
+  applyProjectsV2ItemEvent,
+  type ProjectsV2WebhookPayload,
+  type ProjectsV2ItemWebhookPayload,
+} from "./project-cache";
 
 interface WorkflowRunPayload {
   action: string;
@@ -209,6 +215,23 @@ export async function handleWebhook(
   if (event === "issue_comment") {
     const payload: IssueCommentWebhookPayload = JSON.parse(body);
     await applyIssueCommentEvent(env.CI_STATUS, payload);
+    return new Response("OK", { status: 200 });
+  }
+
+  // /projects SSR の KV cache (project-cache.ts) invalidation 経路。
+  // `projects_v2` event = board level (create/close/delete/edit) なので
+  //   org list + items 両方 flush。Refs #131。
+  if (event === "projects_v2") {
+    const payload: ProjectsV2WebhookPayload = JSON.parse(body);
+    await applyProjectsV2Event(env.CI_STATUS, payload);
+    return new Response("OK", { status: 200 });
+  }
+
+  // `projects_v2_item` event = 個別 card の add/edit/delete/archive/reorder。
+  //   list は不変、該当 org の items cache + issues-page project map を flush。
+  if (event === "projects_v2_item") {
+    const payload: ProjectsV2ItemWebhookPayload = JSON.parse(body);
+    await applyProjectsV2ItemEvent(env.CI_STATUS, payload);
     return new Response("OK", { status: 200 });
   }
 

--- a/test/project-cache.test.ts
+++ b/test/project-cache.test.ts
@@ -1,0 +1,192 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import {
+  getOrFetchOrgProjects,
+  getOrFetchProjectItems,
+  invalidateOrgList,
+  invalidateOrgItems,
+  invalidateIssuesPageProjectMap,
+  applyProjectsV2Event,
+  applyProjectsV2ItemEvent,
+  __testing,
+} from "../src/project-cache";
+
+const { orgListKey, itemsKey, ISSUES_PAGE_PROJECT_MAP_KEY } = __testing;
+
+async function clearCache(): Promise<void> {
+  for (const prefix of ["project:", "issues-page:project-map"]) {
+    let cursor: string | undefined;
+    do {
+      const page = await env.CI_STATUS.list({ prefix, cursor });
+      await Promise.all(page.keys.map((k) => env.CI_STATUS.delete(k.name)));
+      cursor = page.list_complete ? undefined : page.cursor;
+    } while (cursor);
+  }
+}
+
+// 最小の GraphQL stub。`projectsV2` list と project `items` の両 query 形に
+// 反応する。auth-worker /mcp/token も握り潰す。
+function stubGraphQLOnce() {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (req, init) => {
+    const url = typeof req === "string" ? req : (req as Request).url;
+    if (url.includes("auth-worker") || url.includes("/mcp/token")) {
+      return Response.json({ access_token: "tok" });
+    }
+    if (url.includes("/graphql")) {
+      const body = (init?.body as string | undefined)
+        ?? (typeof req === "string" ? "" : await (req as Request).clone().text());
+      if (body.includes("projectsV2(first:")) {
+        return Response.json({
+          data: { repositoryOwner: { projectsV2: { nodes: [
+            { id: "PVT_1", number: 1, title: "Board A",
+              url: "https://github.com/orgs/ippoan/projects/1",
+              closed: false, shortDescription: null },
+          ] } } },
+        });
+      }
+      if (body.includes("projectV2(number:")) {
+        return Response.json({
+          data: { repositoryOwner: { projectV2: { items: { nodes: [
+            { id: "PVTI_1", type: "ISSUE", content: {
+              __typename: "Issue", number: 1, title: "t",
+              url: "u", state: "OPEN",
+              repository: { nameWithOwner: "ippoan/x" },
+            }, fieldValues: { nodes: [] } },
+          ] } } } },
+        });
+      }
+    }
+    return new Response("ignored", { status: 404 });
+  });
+}
+
+describe("project-cache", () => {
+  beforeEach(clearCache);
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  describe("getOrFetchOrgProjects", () => {
+    it("cache miss は GraphQL を叩いて KV に書く、hit は API 0 call", async () => {
+      const spy = stubGraphQLOnce();
+      const first = await getOrFetchOrgProjects(env, ["ippoan"]);
+      expect(first).toHaveLength(1);
+      expect(first[0]!.projects[0]!.title).toBe("Board A");
+      const graphqlCalls1 = spy.mock.calls.filter((c) =>
+        String(c[0]).includes("/graphql")).length;
+      expect(graphqlCalls1).toBeGreaterThan(0);
+
+      const second = await getOrFetchOrgProjects(env, ["ippoan"]);
+      expect(second).toEqual(first);
+      const graphqlCalls2 = spy.mock.calls.filter((c) =>
+        String(c[0]).includes("/graphql")).length;
+      // 2 回目は cache hit なので GraphQL call 数増えない
+      expect(graphqlCalls2).toBe(graphqlCalls1);
+    });
+  });
+
+  describe("getOrFetchProjectItems", () => {
+    it("cache miss → fetch → cache hit で API 0 call", async () => {
+      const spy = stubGraphQLOnce();
+      const first = await getOrFetchProjectItems(env, "ippoan", 1);
+      expect(first).toHaveLength(1);
+      const graphqlCalls1 = spy.mock.calls.filter((c) =>
+        String(c[0]).includes("/graphql")).length;
+      expect(graphqlCalls1).toBeGreaterThan(0);
+
+      await getOrFetchProjectItems(env, "ippoan", 1);
+      const graphqlCalls2 = spy.mock.calls.filter((c) =>
+        String(c[0]).includes("/graphql")).length;
+      expect(graphqlCalls2).toBe(graphqlCalls1);
+    });
+  });
+
+  describe("invalidate*", () => {
+    it("invalidateOrgList は該当 org の list key だけ消す", async () => {
+      await env.CI_STATUS.put(orgListKey("ippoan"), '[]');
+      await env.CI_STATUS.put(orgListKey("ohishi-exp"), '[]');
+      await invalidateOrgList(env.CI_STATUS, "ippoan");
+      expect(await env.CI_STATUS.get(orgListKey("ippoan"))).toBeNull();
+      expect(await env.CI_STATUS.get(orgListKey("ohishi-exp"))).toBe('[]');
+    });
+
+    it("invalidateOrgItems は該当 org の全 items key を消す", async () => {
+      await env.CI_STATUS.put(itemsKey("ippoan", 1), '[]');
+      await env.CI_STATUS.put(itemsKey("ippoan", 2), '[]');
+      await env.CI_STATUS.put(itemsKey("ohishi-exp", 1), '[]');
+      await invalidateOrgItems(env.CI_STATUS, "ippoan");
+      expect(await env.CI_STATUS.get(itemsKey("ippoan", 1))).toBeNull();
+      expect(await env.CI_STATUS.get(itemsKey("ippoan", 2))).toBeNull();
+      expect(await env.CI_STATUS.get(itemsKey("ohishi-exp", 1))).toBe('[]');
+    });
+
+    it("invalidateIssuesPageProjectMap は issues-page の project-map key を消す", async () => {
+      await env.CI_STATUS.put(ISSUES_PAGE_PROJECT_MAP_KEY, '{}');
+      await invalidateIssuesPageProjectMap(env.CI_STATUS);
+      expect(await env.CI_STATUS.get(ISSUES_PAGE_PROJECT_MAP_KEY)).toBeNull();
+    });
+  });
+
+  describe("applyProjectsV2Event", () => {
+    it("organization.login から org を引いて list + items + project-map を flush", async () => {
+      await env.CI_STATUS.put(orgListKey("ippoan"), '[]');
+      await env.CI_STATUS.put(itemsKey("ippoan", 1), '[]');
+      await env.CI_STATUS.put(ISSUES_PAGE_PROJECT_MAP_KEY, '{}');
+      await applyProjectsV2Event(env.CI_STATUS, {
+        action: "edited",
+        projects_v2: { id: 1, node_id: "PVT_1" },
+        organization: { login: "ippoan" },
+      });
+      expect(await env.CI_STATUS.get(orgListKey("ippoan"))).toBeNull();
+      expect(await env.CI_STATUS.get(itemsKey("ippoan", 1))).toBeNull();
+      expect(await env.CI_STATUS.get(ISSUES_PAGE_PROJECT_MAP_KEY)).toBeNull();
+    });
+
+    it("organization が無くても projects_v2.owner.login で fallback", async () => {
+      await env.CI_STATUS.put(orgListKey("ippoan"), '[]');
+      await applyProjectsV2Event(env.CI_STATUS, {
+        action: "created",
+        projects_v2: { id: 2, node_id: "PVT_2", owner: { login: "ippoan" } },
+      });
+      expect(await env.CI_STATUS.get(orgListKey("ippoan"))).toBeNull();
+    });
+
+    it("org が解決できない時は no-op", async () => {
+      await env.CI_STATUS.put(orgListKey("ippoan"), '[]');
+      await applyProjectsV2Event(env.CI_STATUS, {
+        action: "edited",
+        projects_v2: { id: 1, node_id: "PVT_1" },
+      });
+      expect(await env.CI_STATUS.get(orgListKey("ippoan"))).toBe('[]');
+    });
+  });
+
+  describe("applyProjectsV2ItemEvent", () => {
+    it("items + issues-page project-map だけ flush し、list は保つ", async () => {
+      await env.CI_STATUS.put(orgListKey("ippoan"), '[]');
+      await env.CI_STATUS.put(itemsKey("ippoan", 1), '[]');
+      await env.CI_STATUS.put(ISSUES_PAGE_PROJECT_MAP_KEY, '{}');
+      await applyProjectsV2ItemEvent(env.CI_STATUS, {
+        action: "created",
+        projects_v2_item: {
+          id: 1, node_id: "PVTI_1", project_node_id: "PVT_1",
+          content_node_id: "I_1", content_type: "Issue",
+        },
+        organization: { login: "ippoan" },
+      });
+      expect(await env.CI_STATUS.get(orgListKey("ippoan"))).toBe('[]'); // 残る
+      expect(await env.CI_STATUS.get(itemsKey("ippoan", 1))).toBeNull(); // 消える
+      expect(await env.CI_STATUS.get(ISSUES_PAGE_PROJECT_MAP_KEY)).toBeNull(); // 消える
+    });
+
+    it("organization が無い (user-owned projects 等) なら no-op", async () => {
+      await env.CI_STATUS.put(itemsKey("ippoan", 1), '[]');
+      await applyProjectsV2ItemEvent(env.CI_STATUS, {
+        action: "created",
+        projects_v2_item: {
+          id: 1, node_id: "PVTI_1", project_node_id: "PVT_1",
+          content_node_id: "I_1", content_type: "Issue",
+        },
+      });
+      expect(await env.CI_STATUS.get(itemsKey("ippoan", 1))).toBe('[]');
+    });
+  });
+});

--- a/test/projects-page.test.ts
+++ b/test/projects-page.test.ts
@@ -1,5 +1,5 @@
 import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import worker from "../src/index";
 import type { Env } from "../src/index";
 
@@ -112,6 +112,18 @@ function stubGraphQL(opts: { failItemsFor?: string } = {}) {
 }
 
 describe("GET /projects", () => {
+  // Phase 2 (#131) で導入された KV cache を毎テスト前にクリア。残ると
+  // 次の it で stubGraphQL を当てても cache hit して fetch が走らない。
+  beforeEach(async () => {
+    for (const prefix of ["project:", "issues-page:project-map"]) {
+      let cursor: string | undefined;
+      do {
+        const page = await env.CI_STATUS.list({ prefix, cursor });
+        await Promise.all(page.keys.map((k) => env.CI_STATUS.delete(k.name)));
+        cursor = page.list_complete ? undefined : page.cursor;
+      } while (cursor);
+    }
+  });
   afterEach(() => { vi.restoreAllMocks(); });
 
   it("renders an HTML page with the Projects tab active and 🗂️ Projects header", async () => {


### PR DESCRIPTION
Refs #131

## 問題

Phase 1 (#129 / #130) で `/issues` SSR は webhook 駆動 cache に切替済だが、`/projects` SSR は cache 一切なし。毎リクエストで:

- 3 org × `projectsV2` GraphQL list query
- per project の `projectV2.items` GraphQL fan-out

を発火。PWA タブ持続で yhonda-ohishi user pool を圧迫。

## 設計

**Invalidation-based KV cache** (Phase 1 の watermark/list-since とは別パターン):

```
Read:  KV hit → API 0 call
       KV miss → GraphQL → KV upsert (TTL 30min)

Write: projects_v2 / projects_v2_item webhook → KV key を delete
```

### watermark を使わない理由

`projects_v2_item.content_node_id` は global node ID で `repo#number` への解決に追加 GraphQL が必要。incremental update する旨味が薄いので cache 全 replace で済ます。TTL 30 min + webhook invalidation の組み合わせで「webhook 取りこぼしても 30 分内に refresh」担保。

### KV schema

- `project:org-list:<org>` → `OrgProject[]`
- `project:items:<org>:<number>` → `ProjectItemSummary[]`
- TTL 30 分

## 変更

| ファイル | 内容 |
|---|---|
| `src/project-cache.ts` (新規) | per-org list + per-project items の KV cache、invalidation helpers、webhook payload 適用関数 |
| `src/webhook.ts` | `projects_v2` / `projects_v2_item` event handler 追加 |
| `src/projects-page.ts` | `fetchOrgProjects` / `fetchProjectItems` 直叩き → `getOrFetchOrgProjects` / `getOrFetchProjectItems` に置換 |
| `test/project-cache.test.ts` (新規) | cache miss/hit, invalidate, webhook payload 適用の smoke test |
| `test/projects-page.test.ts` | `beforeEach` で project cache をクリア |

## 副作用 (意図的)

`projects_v2_item` webhook 受信時に Phase 1 で導入した `issues-page:project-map` key も flush する → `/issues` page の Project chip が webhook 駆動で即時更新される (従来 5 min TTL 待ち)。

## scope 外 (follow-up)

- Phase 3: `/releases` page の webhook 駆動化 (`release` event)
- Phase 4: GitHub App installation token 切替

## デプロイ後の作業

3 org の GitHub webhook 設定で配信 event 種別に以下を追加:

- `projects_v2`
- `projects_v2_item`

設定前は cold-start fetch で動く (= 現状と同等) ので壊れない。設定後は webhook 駆動で `/projects` が API 0 call 化、`/issues` の project chip も即時反映。

## test plan

- [x] `npm run typecheck` (CI で確認)
- [x] `npm run test` (CI で確認)
- [ ] staging deploy 後、`/projects` を 2 回連続で開いて 2 回目に GraphQL call が出ないこと (Cloudflare logs) を確認
- [ ] org webhook 設定後、project board に issue を add → `/projects` を開くと数秒以内に反映されることを確認
- [ ] 同じ操作で `/issues` の Project chip も即時更新されることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01Td2kA4uyYYnZqXxgSjwmKx)_