### PR TITLE
feat(releases): webhook 駆動 invalidation で release-cache freshness を向上 (Refs #133)

### DIFF
--- a/src/release-cache.ts
+++ b/src/release-cache.ts
@@ -188,6 +188,55 @@ export async function invalidateIssue(
   await kv.delete(`${PREFIX}issue:${owner}/${name}:${n}`);
 }
 
+// Phase 3 (Refs #133): webhook 駆動 invalidation の helper 群。`release` /
+// `push` (tag) / `push` (default branch) event を受け取った時に該当 repo の
+// 関連 cache を一括 flush する。TTL (300s / 60s) は据え置き、これら helper
+// は freshness 向上のための追加レイヤー。
+
+async function invalidateRepoPrefix(
+  kv: KVNamespace | undefined,
+  prefix: string,
+): Promise<void> {
+  if (!kv) return;
+  let cursor: string | undefined;
+  do {
+    const list = await kv.list({ prefix, cursor });
+    await Promise.all(list.keys.map((k) => kv.delete(k.name)));
+    cursor = list.list_complete ? undefined : list.cursor;
+  } while (cursor);
+}
+
+/** 該当 repo の tag list cache を flush。`release` event / tag push 時に呼ぶ。 */
+export async function invalidateRepoTags(
+  kv: KVNamespace | undefined,
+  owner: string,
+  name: string,
+): Promise<void> {
+  await invalidateRepoPrefix(kv, `${PREFIX}tags:${owner}/${name}:`);
+}
+
+/** 該当 repo の commits cache (synthetic-block 用 HEAD listing) を flush。
+ *  default branch への push 時に呼ぶ。 */
+export async function invalidateRepoCommits(
+  kv: KVNamespace | undefined,
+  owner: string,
+  name: string,
+): Promise<void> {
+  await invalidateRepoPrefix(kv, `${PREFIX}commits:${owner}/${name}:`);
+}
+
+/** 該当 repo の repo-meta (default_branch 等) cache を flush。
+ *  `repository` event (rename / default_branch 変更) で呼ぶ想定。
+ *  現状の webhook handler では未使用だが API 表面として用意しておく。 */
+export async function invalidateRepoMeta(
+  kv: KVNamespace | undefined,
+  owner: string,
+  name: string,
+): Promise<void> {
+  if (!kv) return;
+  await kv.delete(`${PREFIX}repo:${owner}/${name}`);
+}
+
 // Exposed for tests so afterEach can wipe inter-fixture pollution; production
 // callers never need this (TTL handles eviction).
 export async function clearReleaseCache(kv: KVNamespace): Promise<void> {

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -13,6 +13,28 @@ import {
   type ProjectsV2WebhookPayload,
   type ProjectsV2ItemWebhookPayload,
 } from "./project-cache";
+import {
+  invalidateIssue as invalidateReleaseCacheIssue,
+  invalidateRepoTags,
+  invalidateRepoCommits,
+} from "./release-cache";
+
+interface ReleaseWebhookPayload {
+  action: string;
+  release: {
+    tag_name: string;
+    id: number;
+  };
+  repository: { full_name: string };
+}
+
+interface PushWebhookPayload {
+  ref: string;
+  repository: {
+    full_name: string;
+    default_branch: string;
+  };
+}
 
 interface WorkflowRunPayload {
   action: string;
@@ -202,10 +224,18 @@ export async function handleWebhook(
   // /issues SSR page の KV cache (issue-cache.ts) 更新経路。Webhook で来た
   // 個別 issue を upsert する。watermark は意図的に touch しない (配信ミス
   // 時に list-since reconcile が必ず拾うための担保)。Refs #129。
+  //
+  // Phase 3 (Refs #133): /releases page も release-cache.cachedIssue (60s TTL)
+  // で同 issue を別 cache に保持しているため、外部から close された時に
+  // release-cache 側も invalidate して /releases の close-status を即時反映する。
   if (event === "issues") {
     const payload: IssueWebhookPayload = JSON.parse(body);
     const issue = webhookIssueToOrgIssue(payload);
     await upsertIssue(env.CI_STATUS, issue);
+    const [owner, name] = payload.repository.full_name.split("/");
+    if (owner && name) {
+      await invalidateReleaseCacheIssue(env.CI_STATUS, owner, name, payload.issue.number);
+    }
     return new Response("OK", { status: 200 });
   }
 
@@ -232,6 +262,40 @@ export async function handleWebhook(
   if (event === "projects_v2_item") {
     const payload: ProjectsV2ItemWebhookPayload = JSON.parse(body);
     await applyProjectsV2ItemEvent(env.CI_STATUS, payload);
+    return new Response("OK", { status: 200 });
+  }
+
+  // /releases SSR の release-cache.ts (TTL 300s tags) を webhook で flush。
+  // 新規 release が publish/edit/delete された時に該当 repo の tag list cache
+  // を delete → 次の /releases ロードで refetch。Refs #133。
+  if (event === "release") {
+    const payload: ReleaseWebhookPayload = JSON.parse(body);
+    const [owner, name] = payload.repository.full_name.split("/");
+    if (owner && name) {
+      await invalidateRepoTags(env.CI_STATUS, owner, name);
+    }
+    return new Response("OK", { status: 200 });
+  }
+
+  // `push` event は tag push (refs/tags/*) なら tags cache、default branch
+  // への push なら commits cache (synthetic-block の HEAD listing 用) を
+  // flush する。それ以外の branch push は noop。malformed payload (test fixture
+  // 等) も noop して 200 を返す。Refs #133。
+  if (event === "push") {
+    const payload = JSON.parse(body) as Partial<PushWebhookPayload>;
+    const fullName = payload.repository?.full_name;
+    const defaultBranch = payload.repository?.default_branch;
+    const ref = payload.ref;
+    if (fullName && ref) {
+      const [owner, name] = fullName.split("/");
+      if (owner && name) {
+        if (ref.startsWith("refs/tags/")) {
+          await invalidateRepoTags(env.CI_STATUS, owner, name);
+        } else if (defaultBranch && ref === `refs/heads/${defaultBranch}`) {
+          await invalidateRepoCommits(env.CI_STATUS, owner, name);
+        }
+      }
+    }
     return new Response("OK", { status: 200 });
   }
 

--- a/test/release-cache.test.ts
+++ b/test/release-cache.test.ts
@@ -2,9 +2,13 @@ import { env } from "cloudflare:test";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   cachedTags,
+  cachedCommits,
   cachedIssue,
   cachedCompare,
   invalidateIssue,
+  invalidateRepoTags,
+  invalidateRepoCommits,
+  invalidateRepoMeta,
   clearReleaseCache,
 } from "../src/release-cache";
 
@@ -79,5 +83,62 @@ describe("release-cache", () => {
     await expect(
       invalidateIssue(undefined, "ippoan", "ci-dashboard", 1),
     ).resolves.toBeUndefined();
+  });
+
+  // Phase 3 (Refs #133): webhook 駆動 invalidation helpers。
+  it("invalidateRepoTags: 該当 repo の tags cache を全 per_page 分 flush する", async () => {
+    let calls = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      calls++;
+      return Response.json([{ name: "v1.0.0", commit: { sha: "a" } }]);
+    });
+    // 2 different per_page values populate 2 different KV keys
+    await cachedTags("tok", env.CI_STATUS, "ippoan", "ci-dashboard", 10);
+    await cachedTags("tok", env.CI_STATUS, "ippoan", "ci-dashboard", 30);
+    // 別 repo は触らないことの確認用
+    await cachedTags("tok", env.CI_STATUS, "ippoan", "other", 10);
+    expect(calls).toBe(3);
+
+    await invalidateRepoTags(env.CI_STATUS, "ippoan", "ci-dashboard");
+
+    // 該当 repo は cache miss → 再 fetch (calls 増える)
+    await cachedTags("tok", env.CI_STATUS, "ippoan", "ci-dashboard", 10);
+    await cachedTags("tok", env.CI_STATUS, "ippoan", "ci-dashboard", 30);
+    expect(calls).toBe(5);
+    // 別 repo は cache hit のまま
+    await cachedTags("tok", env.CI_STATUS, "ippoan", "other", 10);
+    expect(calls).toBe(5);
+  });
+
+  it("invalidateRepoCommits: 該当 repo の commits cache を flush する", async () => {
+    let calls = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      calls++;
+      return Response.json([{ sha: "a", commit: { message: "m" } }]);
+    });
+    await cachedCommits("tok", env.CI_STATUS, "ippoan", "ci-dashboard", "main", 50);
+    await cachedCommits("tok", env.CI_STATUS, "ippoan", "other", "main", 50);
+    expect(calls).toBe(2);
+
+    await invalidateRepoCommits(env.CI_STATUS, "ippoan", "ci-dashboard");
+
+    await cachedCommits("tok", env.CI_STATUS, "ippoan", "ci-dashboard", "main", 50);
+    expect(calls).toBe(3); // 該当 repo 再 fetch
+    await cachedCommits("tok", env.CI_STATUS, "ippoan", "other", "main", 50);
+    expect(calls).toBe(3); // 別 repo は hit
+  });
+
+  it("invalidateRepoMeta: 該当 repo の repo-meta key だけ消す", async () => {
+    await env.CI_STATUS.put("rcache:v1:repo:ippoan/ci-dashboard", '{"default_branch":"main"}');
+    await env.CI_STATUS.put("rcache:v1:repo:ippoan/other", '{"default_branch":"main"}');
+    await invalidateRepoMeta(env.CI_STATUS, "ippoan", "ci-dashboard");
+    expect(await env.CI_STATUS.get("rcache:v1:repo:ippoan/ci-dashboard")).toBeNull();
+    expect(await env.CI_STATUS.get("rcache:v1:repo:ippoan/other")).toBeTruthy();
+  });
+
+  it("invalidateRepoTags / invalidateRepoCommits / invalidateRepoMeta は kv=undefined で no-op", async () => {
+    await expect(invalidateRepoTags(undefined, "x", "y")).resolves.toBeUndefined();
+    await expect(invalidateRepoCommits(undefined, "x", "y")).resolves.toBeUndefined();
+    await expect(invalidateRepoMeta(undefined, "x", "y")).resolves.toBeUndefined();
   });
 });

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -185,7 +185,9 @@ describe("POST /webhook", () => {
     expect(await res.text()).toBe("Invalid signature");
   });
 
-  it("ignores non-workflow_run events", async () => {
+  // Phase 3 (Refs #133) で push event 自体は handler 持つようになったため、
+  // テストの対象 event を fall-through 確実な watch に切替。
+  it("ignores unrecognized events (fall-through 200)", async () => {
     const body = "{}";
     const signature = await sign(body, WEBHOOK_SECRET);
     const req = new Request("http://localhost/webhook", {
@@ -193,14 +195,14 @@ describe("POST /webhook", () => {
       body,
       headers: {
         "X-Hub-Signature-256": signature,
-        "X-GitHub-Event": "push",
+        "X-GitHub-Event": "watch",
       },
     });
     const ctx = createExecutionContext();
     const res = await worker.fetch(req, testEnv(), ctx);
     await waitOnExecutionContext(ctx);
     expect(res.status).toBe(200);
-    expect(await res.text()).toBe("Ignored event: push");
+    expect(await res.text()).toBe("Ignored event: watch");
   });
 
   it("stores workflow_run status in KV", async () => {
@@ -625,5 +627,135 @@ describe("POST /webhook", () => {
     );
     await waitOnExecutionContext(ctx);
     expect(hubCalls.filter((c) => c.path === "/release-alert-detect")).toHaveLength(0);
+  });
+
+  // ───── Phase 3 (Refs #133): release / push / issues → release-cache invalidation ─────
+
+  it("release event flushes tags cache for the repo", async () => {
+    // Seed the tags cache for ippoan/foo
+    await env.CI_STATUS.put(
+      "rcache:v1:tags:ippoan/foo:10",
+      JSON.stringify([{ name: "v0.0.1", commit: { sha: "a" } }]),
+      { expirationTtl: 300 },
+    );
+    const body = JSON.stringify({
+      action: "published",
+      release: { tag_name: "v0.0.2", id: 1 },
+      repository: { full_name: "ippoan/foo" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST",
+        body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "release" },
+      }),
+      testEnv(),
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(200);
+    expect(await env.CI_STATUS.get("rcache:v1:tags:ippoan/foo:10")).toBeNull();
+  });
+
+  it("push to refs/tags/* flushes tags cache", async () => {
+    await env.CI_STATUS.put("rcache:v1:tags:ippoan/foo:10", "[]", { expirationTtl: 300 });
+    const body = JSON.stringify({
+      ref: "refs/tags/v0.0.3",
+      repository: { full_name: "ippoan/foo", default_branch: "main" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST",
+        body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "push" },
+      }),
+      testEnv(),
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(await env.CI_STATUS.get("rcache:v1:tags:ippoan/foo:10")).toBeNull();
+  });
+
+  it("push to default branch flushes commits cache (not tags)", async () => {
+    await env.CI_STATUS.put("rcache:v1:tags:ippoan/foo:10", "[]", { expirationTtl: 300 });
+    await env.CI_STATUS.put("rcache:v1:commits:ippoan/foo:main:50", "[]", { expirationTtl: 60 });
+    const body = JSON.stringify({
+      ref: "refs/heads/main",
+      repository: { full_name: "ippoan/foo", default_branch: "main" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST",
+        body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "push" },
+      }),
+      testEnv(),
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(await env.CI_STATUS.get("rcache:v1:commits:ippoan/foo:main:50")).toBeNull();
+    // tags cache は触らない (push が tag じゃないので)
+    expect(await env.CI_STATUS.get("rcache:v1:tags:ippoan/foo:10")).toBe("[]");
+  });
+
+  it("push to feature branch is noop for release-cache", async () => {
+    await env.CI_STATUS.put("rcache:v1:commits:ippoan/foo:main:50", "[]", { expirationTtl: 60 });
+    const body = JSON.stringify({
+      ref: "refs/heads/feature-x",
+      repository: { full_name: "ippoan/foo", default_branch: "main" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST",
+        body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "push" },
+      }),
+      testEnv(),
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    // 触らない
+    expect(await env.CI_STATUS.get("rcache:v1:commits:ippoan/foo:main:50")).toBe("[]");
+  });
+
+  it("issues event also invalidates release-cache issue key (close immediately reflects on /releases)", async () => {
+    await env.CI_STATUS.put(
+      "rcache:v1:issue:ippoan/foo:42",
+      JSON.stringify({ number: 42, state: "open" }),
+      { expirationTtl: 60 },
+    );
+    const body = JSON.stringify({
+      action: "closed",
+      issue: {
+        number: 42, title: "x", state: "closed", user: { login: "y" },
+        labels: [], assignees: [], comments: 0,
+        created_at: "2026-05-27T00:00:00Z",
+        updated_at: "2026-05-27T01:00:00Z",
+        html_url: "https://github.com/ippoan/foo/issues/42",
+      },
+      repository: { full_name: "ippoan/foo" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST",
+        body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "issues" },
+      }),
+      testEnv(),
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(200);
+    expect(await env.CI_STATUS.get("rcache:v1:issue:ippoan/foo:42")).toBeNull();
   });
 });


### PR DESCRIPTION
Refs #133

## 問題

Phase 1 (#129 / #130) / Phase 2 (#131 / #132) で `/issues` と `/projects` は webhook 駆動 cache に切替済。`/releases` SSR は既に `src/release-cache.ts` で KV cache を持つが、webhook 駆動 invalidation が無いため低 TTL (`tags` 300s / `commits` 60s / `issue` 60s) で stale が許容されていた。

実害:
- 新規 tag を push しても 5 min まで `/releases` に表示されない
- 外部 (`gh` / Claude Code / GitHub UI) から close した issue が 60s stale
- default branch への push が synthetic-block の HEAD listing に反映されるまで 60s

## 設計

既存 release-cache.ts に invalidation helper を追加し、webhook event 受信時に該当 cache key を delete:

| Event | Invalidate |
|---|---|
| `release` (published / created / edited / deleted) | `rcache:v1:tags:<owner>/<name>:*` |
| `push` (ref = `refs/tags/*`) | 同上 |
| `push` (ref = `refs/heads/<default_branch>`) | `rcache:v1:commits:<owner>/<name>:*` |
| `issues` (Phase 1 既存 handler を拡張) | `rcache:v1:issue:<owner>/<name>:<n>` |

`compare` (24h) / `pr` (24h) / `repo-meta` (1h) は immutable / 低頻度なので touch しない。

### TTL は据え置き

現状の `tags` 300s / `commits` 60s / `issue` 60s は維持。webhook は freshness 向上の追加レイヤーで、取りこぼし時は既存 TTL が safety net。

## 変更

| ファイル | 内容 |
|---|---|
| `src/release-cache.ts` | `invalidateRepoTags` / `invalidateRepoCommits` / `invalidateRepoMeta` 追加 (private `invalidateRepoPrefix` helper 経由) |
| `src/webhook.ts` | `release` / `push` event handler 追加 (malformed payload に defensive)、既存 `issues` handler に release-cache.invalidateIssue 呼び出し追加 |
| `test/release-cache.test.ts` | 新 helper の cache miss/hit + 別 repo 非干渉 smoke test |
| `test/webhook.test.ts` | release / push (tag / default / feature branch) / issues→release-cache の動作確認、既存 fall-through test を `push` → `watch` event に変更 |

## scope 外 (follow-up)

- TTL aggressive 延長 (例: tags 300s → 24h)
- Phase 4: GitHub App installation token 切替 (user 87104778 pool から完全離脱)

## デプロイ後の作業

3 org の GitHub webhook 設定で event 種別に追加:

- `release`
- `push` (既に他 workflow の都合で配信されている可能性あり、その場合は noop)

`issues` は Phase 1 で追加済。

## test plan

- [x] `npm run typecheck` (CI)
- [x] `npm run test` (CI)
- [ ] staging deploy 後、release tag を push → `/releases` に数秒以内に反映されることを確認
- [ ] `gh issue close` を叩いて → `/releases` の該当 issue が 60s 待たずに closed 表示されることを確認
- [ ] feature branch に push しても `/releases` の commits cache に影響しないことを確認 (logs)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Td2kA4uyYYnZqXxgSjwmKx)_