### PR TITLE
perf(issues): loadProjectMap を project-cache 経由に統一して cold-start 54s を解消 (Refs #135)

### DIFF
--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -1,10 +1,14 @@
 import { type OrgIssue } from "./mcp/tools/issues";
-import { fetchProjectIssueMap, type ProjectRef } from "./mcp/tools/projects";
+import { type ProjectRef } from "./mcp/tools/projects";
 import { fetchAllOpenPrsByIssue, type IssuePrRef } from "./issue-prs";
 import type { AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
 import { renderTabs, TAB_STYLES } from "./nav-tabs";
 import { PWA_HEAD_TAGS, PWA_REGISTER_SCRIPT } from "./pwa";
 import { listCachedOpenIssues, reconcileIssues } from "./issue-cache";
+import {
+  getOrFetchProjectIssueMap,
+  type ProjectIssueMapResult,
+} from "./project-cache";
 
 // Orgs fetched in full. Same allowlist as github-api.ts (not imported because
 // ALLOWED_ORGS isn't exported; keep the two in sync if either grows).
@@ -58,52 +62,10 @@ export function buildClaudeCodeLaunchUrl(repo: string, issueNumber: number): str
   return `https://claude.ai/code?repositories=${CLAUDE_CODE_LAUNCH_REPOS.join(",")}&prompt=${encoded}`;
 }
 
-// KV cache for the cross-org Project v2 → issue map. GraphQL fan-out is
-// expensive (one call per open project × per org) and its 5000 points/h budget
-// is easy to exhaust when the dashboard's MCP tools share the same token. A
-// short fresh window (5 min) is plenty for the issues page — Project boards
-// don't churn second-by-second — and a long store window (24 h) keeps a stale
-// copy around so a temporary rate-limit hit doesn't blank the page.
-const PROJECT_MAP_CACHE_KEY = "issues-page:project-map";
-const PROJECT_MAP_FRESH_SECONDS = 300;
-const PROJECT_MAP_STORE_SECONDS = 86400;
-
-interface ProjectMapCacheEntry {
-  storedAt: number;
-  data: Record<string, ProjectRef[]>;
-}
-
-interface ProjectMapResult {
-  map: Map<string, ProjectRef[]>;
-  stale: boolean;
-  error: string | null;
-}
-
-async function loadProjectMap(
-  env: AuthClientWorkerEnv,
-  orgs: string[],
-): Promise<ProjectMapResult> {
-  const kv = env.CI_STATUS;
-  const cached = await kv.get(PROJECT_MAP_CACHE_KEY, "json") as ProjectMapCacheEntry | null;
-  const now = Date.now();
-  if (cached && now - cached.storedAt < PROJECT_MAP_FRESH_SECONDS * 1000) {
-    return { map: new Map(Object.entries(cached.data)), stale: false, error: null };
-  }
-  try {
-    const fresh = await fetchProjectIssueMap(env, { orgs });
-    const entry: ProjectMapCacheEntry = { storedAt: now, data: Object.fromEntries(fresh) };
-    await kv.put(PROJECT_MAP_CACHE_KEY, JSON.stringify(entry), {
-      expirationTtl: PROJECT_MAP_STORE_SECONDS,
-    });
-    return { map: fresh, stale: false, error: null };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (cached) {
-      return { map: new Map(Object.entries(cached.data)), stale: true, error: message };
-    }
-    return { map: new Map(), stale: false, error: message };
-  }
-}
+// Cross-org Project v2 → issue map は `/projects` page と共通の KV cache
+// (project-cache.ts) を経由して取得する (Refs #135)。`/projects` を先に開いて
+// あれば warm cache を共有して即返、`projects_v2_item` webhook が来ると
+// project-cache.applyProjectsV2ItemEvent が KV を flush する。
 
 // PR map cache mirrors the project-map cache pattern. The freshness window is
 // shorter (2 min) because PR state churns faster than Project board edits — a
@@ -213,7 +175,7 @@ export async function handleIssuesPage(env: AuthClientWorkerEnv): Promise<Respon
   };
 
   const [project, prs] = await Promise.all([
-    loadProjectMap(env, PROJECT_ORGS),
+    getOrFetchProjectIssueMap(env, PROJECT_ORGS),
     loadPrMap(env, ORGS, YHONDA_REPOS),
   ]);
   const projectMap = project.map;
@@ -257,7 +219,7 @@ function renderHtml(
   incomplete: boolean,
   projectTagged: ReadonlyArray<{ issue: OrgIssue; projects: ProjectRef[] }>,
   repos: ReadonlyArray<readonly [string, OrgIssue[]]>,
-  project: ProjectMapResult,
+  project: ProjectIssueMapResult,
   prs: PrMapResult,
   issueStaleError: string | null,
 ): string {

--- a/src/project-cache.ts
+++ b/src/project-cache.ts
@@ -5,6 +5,7 @@ import {
   type OrgProject,
   type OrgProjectsResult,
   type ProjectItemSummary,
+  type ProjectRef,
 } from "./mcp/tools/projects";
 
 // KV schema (Refs #131):
@@ -64,6 +65,69 @@ export async function getOrFetchProjectItems(
   const items = await fetchProjectItems(env, org, number);
   await kv.put(itemsKey(org, number), JSON.stringify(items), { expirationTtl: TTL_SECONDS });
   return items;
+}
+
+// ───── /issues page 向け project map (Refs #135) ─────
+
+export interface ProjectIssueMapResult {
+  map: Map<string, ProjectRef[]>;
+  /** True if the result is from cache because fresh fetch failed. 本実装は
+   *  cache 層が個別に TTL 管理するため常に false。元の loadProjectMap API と
+   *  互換性を保つために残してある。 */
+  stale: boolean;
+  /** いずれかの per-project fetch / org list fetch が失敗した場合の最初の
+   *  メッセージ。map は best-effort で部分結果を返す。 */
+  error: string | null;
+}
+
+/** `/issues` page の `Project 付き` セクション用に `repo#number → ProjectRef[]`
+ *  map を返す。`/projects` page と同じ KV cache (`project:org-list:*` /
+ *  `project:items:*`) を共有するので、片方を warm にしておくともう片方の
+ *  初回ロードが速い。Refs #135 (旧 issues-page:project-map cache の置換)。 */
+export async function getOrFetchProjectIssueMap(
+  env: AuthClientWorkerEnv,
+  orgs: string[],
+): Promise<ProjectIssueMapResult> {
+  let perOrg: OrgProjectsResult[];
+  try {
+    perOrg = await getOrFetchOrgProjects(env, orgs);
+  } catch (err) {
+    return {
+      map: new Map(),
+      stale: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  const map = new Map<string, ProjectRef[]>();
+  let firstError: string | null = null;
+
+  await Promise.all(
+    perOrg.flatMap(({ org, projects }) =>
+      projects.map(async (p) => {
+        try {
+          const items = await getOrFetchProjectItems(env, org, p.number);
+          for (const item of items) {
+            if (item.content.type !== "issue") continue;
+            const c = item.content;
+            const key = `${c.repo}#${c.number}`;
+            const ref: ProjectRef = {
+              org, number: p.number, title: p.title, url: p.url,
+            };
+            const cur = map.get(key);
+            if (cur) cur.push(ref);
+            else map.set(key, [ref]);
+          }
+        } catch (err) {
+          if (!firstError) {
+            firstError = err instanceof Error ? err.message : String(err);
+          }
+        }
+      }),
+    ),
+  );
+
+  return { map, stale: false, error: firstError };
 }
 
 /** 該当 org の board list cache だけ flush。`projects_v2` event 用 (board

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -509,8 +509,22 @@ describe("GET /issues — Project section", () => {
             data: { repositoryOwner: { projectsV2: { nodes: [] } } },
           });
         }
-        // Both projects claim the same issue #7. Map both project IDs to
-        // the same item list so the issue ends up with two refs.
+        // Both projects claim the same issue #7. Refs #135: /issues は
+        // fetchProjectItems (projectV2(number:) query) 経由なので新 shape で
+        // 返す。両 project の items query で同じ #7 を出して 2 refs にする。
+        if (body.includes("projectV2(number:")) {
+          return Response.json({
+            data: { repositoryOwner: { projectV2: { items: { nodes: [
+              { id: "PVTI_1", type: "ISSUE", content: {
+                __typename: "Issue",
+                number: 7, title: "x", url: "u", state: "OPEN",
+                repository: { nameWithOwner: "ippoan/rust-alc-api" },
+              }, fieldValues: { nodes: [] } },
+            ] } } } },
+          });
+        }
+        // Legacy node(id:) shape — kept for fetchProjectIssueMap callers
+        // (現状 unreachable).
         return Response.json({
           data: { node: { items: { nodes: [
             { content: {

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -55,10 +55,29 @@ function stubFetch(
           data: { repositoryOwner: { projectsV2: { nodes: [] } } },
         });
       }
-      if (body.includes("items(first:")) {
-        // Second-pass: items for a specific project. Map our seed project to
-        // the rust-alc-api#7 issue (the hostile-title one), plus a draft we
+      if (body.includes("projectV2(number:")) {
+        // Phase 2/Refs #135: /issues page uses fetchProjectItems via
+        // getOrFetchProjectIssueMap (shared with /projects). Returns the
+        // richer ProjectItemSummary shape with fieldValues. Map our seed
+        // project to the rust-alc-api#7 issue (hostile-title) + a draft we
         // must ignore.
+        return Response.json({
+          data: { repositoryOwner: { projectV2: { items: { nodes: [
+            { id: "PVTI_1", type: "ISSUE", content: {
+              __typename: "Issue",
+              number: 7, title: "x", url: "u", state: "OPEN",
+              repository: { nameWithOwner: "ippoan/rust-alc-api" },
+            }, fieldValues: { nodes: [] } },
+            { id: "PVTI_2", type: "DRAFT_ISSUE", content: {
+              __typename: "DraftIssue", title: "draft",
+            }, fieldValues: { nodes: [] } },
+          ] } } } },
+        });
+      }
+      if (body.includes("items(first:")) {
+        // Legacy fetchProjectIssueMap shape (node(id:$id) → ProjectV2). 現状
+        // /issues は projectV2(number:) 経路に移行 (Refs #135) したため未到達
+        // だが、mcp tool 等が将来的に呼ぶ可能性があるため残す。
         return Response.json({
           data: { node: { items: { nodes: [
             { content: {
@@ -223,12 +242,16 @@ describe("GET /issues", () => {
     // reconcile が fresh window 判定で skip し、cold-start の fetch が
     // 走らないため stub が当たらず空 cache を返す。
     await env.CI_STATUS.delete("issues:watermark");
-    let cursor: string | undefined;
-    do {
-      const page = await env.CI_STATUS.list({ prefix: "issue:", cursor });
-      await Promise.all(page.keys.map((k) => env.CI_STATUS.delete(k.name)));
-      cursor = page.list_complete ? undefined : page.cursor;
-    } while (cursor);
+    // Refs #135: /issues も project-cache の KV (`project:*`) を共有するため
+    // テスト間で flush しないと前テストの fixture が漏れる。
+    for (const prefix of ["issue:", "project:"]) {
+      let cursor: string | undefined;
+      do {
+        const page = await env.CI_STATUS.list({ prefix, cursor });
+        await Promise.all(page.keys.map((k) => env.CI_STATUS.delete(k.name)));
+        cursor = page.list_complete ? undefined : page.cursor;
+      } while (cursor);
+    }
   });
   afterEach(() => { vi.restoreAllMocks(); });
 
@@ -414,12 +437,16 @@ describe("GET /issues — Project section", () => {
     // reconcile が fresh window 判定で skip し、cold-start の fetch が
     // 走らないため stub が当たらず空 cache を返す。
     await env.CI_STATUS.delete("issues:watermark");
-    let cursor: string | undefined;
-    do {
-      const page = await env.CI_STATUS.list({ prefix: "issue:", cursor });
-      await Promise.all(page.keys.map((k) => env.CI_STATUS.delete(k.name)));
-      cursor = page.list_complete ? undefined : page.cursor;
-    } while (cursor);
+    // Refs #135: /issues も project-cache の KV (`project:*`) を共有するため
+    // テスト間で flush しないと前テストの fixture が漏れる。
+    for (const prefix of ["issue:", "project:"]) {
+      let cursor: string | undefined;
+      do {
+        const page = await env.CI_STATUS.list({ prefix, cursor });
+        await Promise.all(page.keys.map((k) => env.CI_STATUS.delete(k.name)));
+        cursor = page.list_complete ? undefined : page.cursor;
+      } while (cursor);
+    }
   });
   afterEach(() => { vi.restoreAllMocks(); });
 
@@ -572,12 +599,16 @@ describe("GET /issues — Claude Code launch button", () => {
     // reconcile が fresh window 判定で skip し、cold-start の fetch が
     // 走らないため stub が当たらず空 cache を返す。
     await env.CI_STATUS.delete("issues:watermark");
-    let cursor: string | undefined;
-    do {
-      const page = await env.CI_STATUS.list({ prefix: "issue:", cursor });
-      await Promise.all(page.keys.map((k) => env.CI_STATUS.delete(k.name)));
-      cursor = page.list_complete ? undefined : page.cursor;
-    } while (cursor);
+    // Refs #135: /issues も project-cache の KV (`project:*`) を共有するため
+    // テスト間で flush しないと前テストの fixture が漏れる。
+    for (const prefix of ["issue:", "project:"]) {
+      let cursor: string | undefined;
+      do {
+        const page = await env.CI_STATUS.list({ prefix, cursor });
+        await Promise.all(page.keys.map((k) => env.CI_STATUS.delete(k.name)));
+        cursor = page.list_complete ? undefined : page.cursor;
+      } while (cursor);
+    }
   });
   afterEach(() => { vi.restoreAllMocks(); });
 
@@ -629,12 +660,16 @@ describe("GET /issues — Related-PR chips", () => {
     // reconcile が fresh window 判定で skip し、cold-start の fetch が
     // 走らないため stub が当たらず空 cache を返す。
     await env.CI_STATUS.delete("issues:watermark");
-    let cursor: string | undefined;
-    do {
-      const page = await env.CI_STATUS.list({ prefix: "issue:", cursor });
-      await Promise.all(page.keys.map((k) => env.CI_STATUS.delete(k.name)));
-      cursor = page.list_complete ? undefined : page.cursor;
-    } while (cursor);
+    // Refs #135: /issues も project-cache の KV (`project:*`) を共有するため
+    // テスト間で flush しないと前テストの fixture が漏れる。
+    for (const prefix of ["issue:", "project:"]) {
+      let cursor: string | undefined;
+      do {
+        const page = await env.CI_STATUS.list({ prefix, cursor });
+        await Promise.all(page.keys.map((k) => env.CI_STATUS.delete(k.name)));
+        cursor = page.list_complete ? undefined : page.cursor;
+      } while (cursor);
+    }
   });
   afterEach(() => { vi.restoreAllMocks(); });
 

--- a/test/project-cache.test.ts
+++ b/test/project-cache.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import {
   getOrFetchOrgProjects,
   getOrFetchProjectItems,
+  getOrFetchProjectIssueMap,
   invalidateOrgList,
   invalidateOrgItems,
   invalidateIssuesPageProjectMap,
@@ -156,6 +157,98 @@ describe("project-cache", () => {
         projects_v2: { id: 1, node_id: "PVT_1" },
       });
       expect(await env.CI_STATUS.get(orgListKey("ippoan"))).toBe('[]');
+    });
+  });
+
+  describe("getOrFetchProjectIssueMap (Refs #135)", () => {
+    it("Project items の Issue を repo#number → ProjectRef[] に集約する", async () => {
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (req, init) => {
+        const url = typeof req === "string" ? req : (req as Request).url;
+        if (url.includes("auth-worker") || url.includes("/mcp/token")) {
+          return Response.json({ access_token: "tok" });
+        }
+        if (url.includes("/graphql")) {
+          const body = (init?.body as string | undefined)
+            ?? (typeof req === "string" ? "" : await (req as Request).clone().text());
+          if (body.includes("projectsV2(first:")) {
+            return Response.json({
+              data: { repositoryOwner: { projectsV2: { nodes: [
+                { id: "PVT_1", number: 1, title: "Board",
+                  url: "https://github.com/orgs/ippoan/projects/1",
+                  closed: false, shortDescription: null },
+              ] } } },
+            });
+          }
+          if (body.includes("projectV2(number:")) {
+            return Response.json({
+              data: { repositoryOwner: { projectV2: { items: { nodes: [
+                { id: "PVTI_1", type: "ISSUE", content: {
+                  __typename: "Issue", number: 42, title: "t",
+                  url: "u", state: "OPEN",
+                  repository: { nameWithOwner: "ippoan/foo" },
+                }, fieldValues: { nodes: [] } },
+                { id: "PVTI_2", type: "DRAFT_ISSUE", content: {
+                  __typename: "DraftIssue", title: "d",
+                }, fieldValues: { nodes: [] } },
+              ] } } } },
+            });
+          }
+        }
+        return new Response("ignored", { status: 404 });
+      });
+
+      const result = await getOrFetchProjectIssueMap(env, ["ippoan"]);
+      expect(result.error).toBeNull();
+      expect(result.stale).toBe(false);
+      // Issue だけ map に乗る、DraftIssue は無視
+      const ref = result.map.get("ippoan/foo#42");
+      expect(ref).toHaveLength(1);
+      expect(ref![0]!.title).toBe("Board");
+      expect(ref![0]!.org).toBe("ippoan");
+      expect(ref![0]!.number).toBe(1);
+    });
+
+    it("org list fetch が fail したら error をセットして空 map を返す", async () => {
+      vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+        return new Response("rate limit", { status: 403 });
+      });
+      const result = await getOrFetchProjectIssueMap(env, ["ippoan"]);
+      expect(result.map.size).toBe(0);
+      expect(result.error).toBeTruthy();
+    });
+
+    it("2 回目は cache hit で GraphQL を叩かない", async () => {
+      const spy = vi.spyOn(globalThis, "fetch").mockImplementation(async (req, init) => {
+        const url = typeof req === "string" ? req : (req as Request).url;
+        if (url.includes("auth-worker") || url.includes("/mcp/token")) {
+          return Response.json({ access_token: "tok" });
+        }
+        if (url.includes("/graphql")) {
+          const body = (init?.body as string | undefined)
+            ?? (typeof req === "string" ? "" : await (req as Request).clone().text());
+          if (body.includes("projectsV2(first:")) {
+            return Response.json({
+              data: { repositoryOwner: { projectsV2: { nodes: [
+                { id: "PVT_1", number: 1, title: "B", url: "u",
+                  closed: false, shortDescription: null },
+              ] } } },
+            });
+          }
+          if (body.includes("projectV2(number:")) {
+            return Response.json({
+              data: { repositoryOwner: { projectV2: { items: { nodes: [] } } } },
+            });
+          }
+        }
+        return new Response("ignored", { status: 404 });
+      });
+      await getOrFetchProjectIssueMap(env, ["ippoan"]);
+      const calls1 = spy.mock.calls.filter((c) =>
+        String(c[0]).includes("/graphql")).length;
+      await getOrFetchProjectIssueMap(env, ["ippoan"]);
+      const calls2 = spy.mock.calls.filter((c) =>
+        String(c[0]).includes("/graphql")).length;
+      expect(calls2).toBe(calls1);
     });
   });
 


### PR DESCRIPTION
Refs #135

## 問題

Phase 1-3 deploy 後の動作検証で `/issues` 初回ロードが **54 秒** かかる問題が判明 (Cloudflare observability で `wallTimeMs: 53944, cpuTimeMs: 58` 計測 — JS は ~0 秒で、ほぼ全部 subrequest 待ち)。

原因: `/issues` (`src/issues-page.ts`) 内の `loadProjectMap` が Phase 2 (#131) で導入した `project-cache.ts` を**未利用**で、独自の 5min TTL KV cache (`issues-page:project-map`) + `fetchProjectIssueMap` GraphQL fan-out (3 org × ~10 project = ~33 query) を発火 → user 87104778 rate limit に踏み込んでいた。

## 設計

`project-cache.ts` に `getOrFetchProjectIssueMap(env, orgs)` を追加し、`/issues` の `loadProjectMap` をこれに置換。新関数は内部で:

1. `getOrFetchOrgProjects(env, orgs)` で per-org board list を取る (`/projects` page と KV 共有)
2. project 毎に `getOrFetchProjectItems(env, org, p.number)` で items を取る (同上)
3. items を Issue 型でフィルタして `Map<repo#number, ProjectRef[]>` を組み立てる

→ `/projects` page を先に開いていれば `/issues` の初回も KV hit で即返、逆順でも 2 回目以降は warm cache 共有。`projects_v2_item` webhook 駆動 invalidation (Phase 2) も自動連動。

## 期待効果

- `/issues` 初回 (`/projects` warm の場合): 54s → 数秒
- 2 回目以降: 349ms (既に達成) のまま
- 旧 KV key `issues-page:project-map` は 24h TTL で自然消滅 (cleanup script 不要)

## 変更

| ファイル | 内容 |
|---|---|
| `src/project-cache.ts` | `getOrFetchProjectIssueMap` + `ProjectIssueMapResult` 型を追加 |
| `src/issues-page.ts` | 旧 `loadProjectMap` + 関連 KV constants / interfaces を撤去、新関数経由に置換 |
| `test/issues-page.test.ts` | GraphQL stub に `projectV2(number:)` branch を追加 (新 query 形)、`beforeEach` の KV クリアに `project:` prefix を追加 |
| `test/project-cache.test.ts` | 新関数の smoke test (Issue 集約、error fallback、cache hit) |

## test plan

- [x] `npm run typecheck` (CI)
- [x] `npm run test` (CI)
- [ ] staging deploy 後、`/projects` を先に開いてから `/issues` を開いて初回が数秒で返ることを確認 (Cloudflare logs で wallTime 比較)
- [ ] 別ブラウザで `/issues` を先に開いて初回が 54s に逆戻りしていないことを確認 (cold-start でも `/projects` page と同じ KV cache miss の cost に下がるはず)
- [ ] webhook で project item を動かして両ページに即時反映されることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01Td2kA4uyYYnZqXxgSjwmKx)_