### PR TITLE
feat(release-wave): add pure state machine for wave lifecycle (Phase 3a)

### DIFF
--- a/src/release-wave/state.ts
+++ b/src/release-wave/state.ts
@@ -353,11 +353,20 @@ function applyFail(
   state: WaveState,
   event: Extract<WaveEvent, { kind: "fail" }>,
 ): TransitionResult {
-  // fail は終了 state 以外ならいつでも受け付ける (operator が手動で kill する用途含む)。
+  // fail は in-progress (= staging / pending-approval / flipping) でのみ受ける。
+  // 終了 state は TERMINAL_STATE で reject (= 重複 fail / `flipped` から逆走する fail を阻止)。
+  // `flipped` も非 terminal だが「成功側」に進んだ wave なので、問題が出た場合は
+  // fail ではなく rollback を使う設計 (issue #137 diagram 参照)。
   if (isTerminal(state.state)) {
     return fail(
       "TERMINAL_STATE",
       `wave already in terminal state ${state.state}`,
+    );
+  }
+  if (state.state === "flipped") {
+    return fail(
+      "INVALID_TRANSITION",
+      `fail invalid on 'flipped' state, use rollback instead`,
     );
   }
   const next = cloneWaveForUpdate(state);
@@ -417,9 +426,14 @@ function applyContractApplied(
 // Helpers
 // ----------------------------------------------------------------------------
 
-/** state が終了 (= 以降の遷移を受けない) state か。 */
+/**
+ * state が「以降の遷移を受け付けない」終了 state か。
+ *
+ * `flipped` は **terminal ではない**: rollback と contract_applied を受ける
+ * 中間定常 state。本関数の対象は rolled-back / failed / aborted の 3 つ。
+ */
 export function isTerminal(state: WaveStateName): boolean {
-  return state === "flipped" || state === "rolled-back" || state === "failed" || state === "aborted";
+  return state === "rolled-back" || state === "failed" || state === "aborted";
 }
 
 function fail(code: TransitionErrorCode, error: string): TransitionResult {

--- a/src/release-wave/state.ts
+++ b/src/release-wave/state.ts
@@ -1,0 +1,447 @@
+/**
+ * Release Wave の純粋 state machine。
+ *
+ * DO や HTTP に依存しない: 入力 (state, event) → 出力 (next state | error) の
+ * 関数だけを export する。テストは pure function として書ける。
+ *
+ * 設計の親 issue: ippoan/ci-dashboard#137
+ */
+
+import type {
+  FlipPolicy,
+  RepoState,
+  RollbackSafety,
+  TransitionErrorCode,
+  TransitionResult,
+  WaveEvent,
+  WaveEventRecord,
+  WaveState,
+  WaveStateName,
+} from "./types";
+
+// ----------------------------------------------------------------------------
+// Public: 初期 state 構築
+// ----------------------------------------------------------------------------
+
+/**
+ * 新規 wave の初期 state を構築する (`start` event の効果)。state machine 入口。
+ *
+ * 1 wave = 1 DO instance に 1 record の前提なので、caller (DO) は本関数で
+ * 作った state を storage に put し、以後の transition 結果も同 key で
+ * 上書きする。再 start は許さない (DO 側で `ALREADY_STARTED` を返す)。
+ */
+export function createWave(input: {
+  wave_id: string;
+  flip_policy: FlipPolicy;
+  note: string;
+  repos: Array<{ repo: string; target_tag: string; head_sha: string }>;
+  now: string;
+}): WaveState {
+  const repos: RepoState[] = input.repos.map((r) => ({
+    repo: r.repo,
+    target_tag: r.target_tag,
+    head_sha: r.head_sha,
+    stage_status: "pending",
+    preview_url: null,
+    stage_error: null,
+    flip_status: "pending",
+    flip_error: null,
+    flip_from_revision: null,
+    rolled_back_to_revision: null,
+  }));
+
+  const rollback: RollbackSafety = {
+    safe: true,
+    unsafe_reason: null,
+    unsafe_since: null,
+    unsafe_by_migration: null,
+  };
+
+  const start_record: WaveEventRecord = {
+    at: input.now,
+    kind: "start",
+    summary: `wave started with ${repos.length} repo(s), policy=${input.flip_policy}`,
+    detail: {
+      repos: repos.map((r) => r.repo),
+      flip_policy: input.flip_policy,
+      note: input.note,
+    },
+  };
+
+  return {
+    wave_id: input.wave_id,
+    state: "staging",
+    flip_policy: input.flip_policy,
+    note: input.note,
+    repos,
+    rollback,
+    started_at: input.now,
+    staged_at: null,
+    approved_at: null,
+    approved_by: null,
+    flipped_at: null,
+    rolled_back_at: null,
+    rolled_back_by: null,
+    failed_at: null,
+    aborted_at: null,
+    events: [start_record],
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Public: 状態遷移
+// ----------------------------------------------------------------------------
+
+/**
+ * `state` に `event` を適用して次 state を返す純粋関数。
+ *
+ * - 入力 state は immutable (本関数は cloning して新 state を返す)
+ * - 不正遷移は `{ ok: false, code }` を返す。caller は前 state を保持して再 issue する
+ * - 時刻は `event.now` を使う (= 内部で `Date.now()` を呼ばない)
+ */
+export function transition(state: WaveState, event: WaveEvent): TransitionResult {
+  // すでに終了 state なら何も受け付けない
+  if (isTerminal(state.state) && event.kind !== "contract_applied") {
+    return fail(
+      "TERMINAL_STATE",
+      `wave is in terminal state ${state.state}, cannot apply ${event.kind}`,
+    );
+  }
+
+  switch (event.kind) {
+    case "start":
+      // createWave 経由で作るべき; 既存 state に対する start は重複扱い
+      return fail("ALREADY_STARTED", "wave already started, use createWave() instead");
+
+    case "stage_report":
+      return applyStageReport(state, event);
+
+    case "approve":
+      return applyApprove(state, event);
+
+    case "flip_report":
+      return applyFlipReport(state, event);
+
+    case "rollback":
+      return applyRollback(state, event);
+
+    case "abort":
+      return applyAbort(state, event);
+
+    case "fail":
+      return applyFail(state, event);
+
+    case "contract_applied":
+      return applyContractApplied(state, event);
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Per-event handlers
+// ----------------------------------------------------------------------------
+
+function applyStageReport(
+  state: WaveState,
+  event: Extract<WaveEvent, { kind: "stage_report" }>,
+): TransitionResult {
+  if (state.state !== "staging") {
+    return fail(
+      "INVALID_TRANSITION",
+      `stage_report only valid in 'staging', current=${state.state}`,
+    );
+  }
+
+  const repoIdx = state.repos.findIndex((r) => r.repo === event.repo);
+  if (repoIdx === -1) {
+    return fail("REPO_NOT_IN_WAVE", `repo ${event.repo} is not in this wave`);
+  }
+  const repoBefore = state.repos[repoIdx]!;
+
+  // permanent な failed をひっくり返さない: failed → done 等は受け付けない
+  if (repoBefore.stage_status === "failed") {
+    return fail(
+      "INVALID_TRANSITION",
+      `repo ${event.repo} stage already failed (permanent)`,
+    );
+  }
+
+  const next = cloneWaveForUpdate(state);
+  const repoNext = next.repos[repoIdx]!;
+  if (event.ok) {
+    repoNext.stage_status = "done";
+    repoNext.preview_url = event.preview_url ?? null;
+    repoNext.flip_from_revision = event.flip_from_revision ?? null;
+    repoNext.stage_error = null;
+  } else {
+    repoNext.stage_status = "failed";
+    repoNext.stage_error = event.error ?? "stage failed (no detail)";
+  }
+
+  // 全 stage 完了? - failed が 1 つでもあれば failed transition
+  const anyFailed = next.repos.some((r) => r.stage_status === "failed");
+  const allDone = next.repos.every((r) => r.stage_status === "done");
+
+  let summary = `stage ${event.ok ? "ok" : "failed"}: ${event.repo}`;
+
+  if (anyFailed) {
+    next.state = "failed";
+    next.failed_at = event.now;
+    summary = `stage failed (${event.repo}); wave -> failed`;
+  } else if (allDone) {
+    next.staged_at = event.now;
+    if (state.flip_policy === "auto") {
+      next.state = "flipping";
+      summary = `all repos staged; auto policy -> flipping`;
+    } else {
+      next.state = "pending-approval";
+      summary = `all repos staged; awaiting approval`;
+    }
+  }
+
+  next.events = appendEvent(state.events, {
+    at: event.now,
+    kind: "stage_report",
+    summary,
+    detail: { repo: event.repo, ok: event.ok },
+  });
+  return { ok: true, state: next };
+}
+
+function applyApprove(
+  state: WaveState,
+  event: Extract<WaveEvent, { kind: "approve" }>,
+): TransitionResult {
+  // approve は pending-approval (manual-approval policy) からのみ
+  if (state.state !== "pending-approval") {
+    return fail(
+      "INVALID_TRANSITION",
+      `approve only valid in 'pending-approval', current=${state.state}`,
+    );
+  }
+
+  const next = cloneWaveForUpdate(state);
+  next.state = "flipping";
+  next.approved_at = event.now;
+  next.approved_by = event.approved_by;
+  next.events = appendEvent(state.events, {
+    at: event.now,
+    kind: "approve",
+    summary: `approved by ${event.approved_by}; -> flipping`,
+    detail: { approved_by: event.approved_by },
+  });
+  return { ok: true, state: next };
+}
+
+function applyFlipReport(
+  state: WaveState,
+  event: Extract<WaveEvent, { kind: "flip_report" }>,
+): TransitionResult {
+  if (state.state !== "flipping") {
+    return fail(
+      "INVALID_TRANSITION",
+      `flip_report only valid in 'flipping', current=${state.state}`,
+    );
+  }
+
+  const repoIdx = state.repos.findIndex((r) => r.repo === event.repo);
+  if (repoIdx === -1) {
+    return fail("REPO_NOT_IN_WAVE", `repo ${event.repo} is not in this wave`);
+  }
+  const repoBefore = state.repos[repoIdx]!;
+  if (repoBefore.flip_status === "failed") {
+    return fail(
+      "INVALID_TRANSITION",
+      `repo ${event.repo} flip already failed (permanent)`,
+    );
+  }
+
+  const next = cloneWaveForUpdate(state);
+  const repoNext = next.repos[repoIdx]!;
+  if (event.ok) {
+    repoNext.flip_status = "done";
+    repoNext.flip_error = null;
+  } else {
+    repoNext.flip_status = "failed";
+    repoNext.flip_error = event.error ?? "flip failed (no detail)";
+  }
+
+  const anyFailed = next.repos.some((r) => r.flip_status === "failed");
+  const allDone = next.repos.every((r) => r.flip_status === "done");
+
+  let summary = `flip ${event.ok ? "ok" : "failed"}: ${event.repo}`;
+
+  if (anyFailed) {
+    next.state = "failed";
+    next.failed_at = event.now;
+    summary = `flip failed (${event.repo}); wave -> failed`;
+  } else if (allDone) {
+    next.state = "flipped";
+    next.flipped_at = event.now;
+    summary = `all repos flipped`;
+  }
+
+  next.events = appendEvent(state.events, {
+    at: event.now,
+    kind: "flip_report",
+    summary,
+    detail: { repo: event.repo, ok: event.ok },
+  });
+  return { ok: true, state: next };
+}
+
+function applyRollback(
+  state: WaveState,
+  event: Extract<WaveEvent, { kind: "rollback" }>,
+): TransitionResult {
+  if (state.state !== "flipped") {
+    return fail(
+      "INVALID_TRANSITION",
+      `rollback only valid in 'flipped', current=${state.state}`,
+    );
+  }
+  if (!state.rollback.safe && !event.force) {
+    return fail(
+      "ROLLBACK_UNSAFE",
+      `rollback refused: ${state.rollback.unsafe_reason ?? "unsafe"} (use --force to override)`,
+    );
+  }
+
+  const next = cloneWaveForUpdate(state);
+  next.state = "rolled-back";
+  next.rolled_back_at = event.now;
+  next.rolled_back_by = event.rolled_back_by;
+  // 各 repo の rolled_back_to_revision は caller (DO) が flip_from_revision を
+  // 確認した上で別途 set する想定。本 transition では state 遷移のみ。
+  next.events = appendEvent(state.events, {
+    at: event.now,
+    kind: "rollback",
+    summary: `rollback by ${event.rolled_back_by}${event.force ? " (forced)" : ""}`,
+    detail: {
+      rolled_back_by: event.rolled_back_by,
+      forced: event.force === true,
+      rollback_safe_at_time: state.rollback.safe,
+    },
+  });
+  return { ok: true, state: next };
+}
+
+function applyAbort(
+  state: WaveState,
+  event: Extract<WaveEvent, { kind: "abort" }>,
+): TransitionResult {
+  // abort は flip 前 (staging / pending-approval) のみ。flipping/flipped 後は rollback を使う。
+  if (state.state !== "staging" && state.state !== "pending-approval") {
+    return fail(
+      "INVALID_TRANSITION",
+      `abort only valid before flip, current=${state.state}`,
+    );
+  }
+
+  const next = cloneWaveForUpdate(state);
+  next.state = "aborted";
+  next.aborted_at = event.now;
+  next.events = appendEvent(state.events, {
+    at: event.now,
+    kind: "abort",
+    summary: `aborted by ${event.aborted_by}: ${event.reason}`,
+    detail: { aborted_by: event.aborted_by, reason: event.reason },
+  });
+  return { ok: true, state: next };
+}
+
+function applyFail(
+  state: WaveState,
+  event: Extract<WaveEvent, { kind: "fail" }>,
+): TransitionResult {
+  // fail は終了 state 以外ならいつでも受け付ける (operator が手動で kill する用途含む)。
+  if (isTerminal(state.state)) {
+    return fail(
+      "TERMINAL_STATE",
+      `wave already in terminal state ${state.state}`,
+    );
+  }
+  const next = cloneWaveForUpdate(state);
+  next.state = "failed";
+  next.failed_at = event.now;
+  next.events = appendEvent(state.events, {
+    at: event.now,
+    kind: "fail",
+    summary: `failed: ${event.reason}`,
+    detail: { reason: event.reason },
+  });
+  return { ok: true, state: next };
+}
+
+function applyContractApplied(
+  state: WaveState,
+  event: Extract<WaveEvent, { kind: "contract_applied" }>,
+): TransitionResult {
+  // contract_applied は flipped wave のみで意味あり (= rollback safety を倒す)。
+  // それ以外の state でも 200 で受け入れて event だけ記録する設計でも良いが、
+  // safety flag を倒す副作用が無い (= rollback 不可化が起きない) のは紛らわしい
+  // ので、現状は wave が flipped でない場合は INVALID_TRANSITION で reject。
+  if (state.state !== "flipped") {
+    return fail(
+      "INVALID_TRANSITION",
+      `contract_applied only meaningful in 'flipped', current=${state.state}`,
+    );
+  }
+  // 同 repo が wave に含まれているかは validation する (= 他 wave 向けの通知が
+  // 誤って入らないようにする)。
+  const repoIdx = state.repos.findIndex((r) => r.repo === event.repo);
+  if (repoIdx === -1) {
+    return fail("REPO_NOT_IN_WAVE", `repo ${event.repo} is not in this wave`);
+  }
+
+  // 既に unsafe なら idempotent: 何もしないが event だけ記録する。
+  // unsafe_by_migration の最初の 1 件を採用 (= 最も早く unsafe にした migration)。
+  const next = cloneWaveForUpdate(state);
+  if (next.rollback.safe) {
+    next.rollback = {
+      safe: false,
+      unsafe_reason: `contract migration applied: ${event.migration_id}`,
+      unsafe_since: event.now,
+      unsafe_by_migration: event.migration_id,
+    };
+  }
+  next.events = appendEvent(state.events, {
+    at: event.now,
+    kind: "contract_applied",
+    summary: `contract migration applied: ${event.repo}/${event.migration_id}`,
+    detail: { repo: event.repo, migration_id: event.migration_id },
+  });
+  return { ok: true, state: next };
+}
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+/** state が終了 (= 以降の遷移を受けない) state か。 */
+export function isTerminal(state: WaveStateName): boolean {
+  return state === "flipped" || state === "rolled-back" || state === "failed" || state === "aborted";
+}
+
+function fail(code: TransitionErrorCode, error: string): TransitionResult {
+  return { ok: false, code, error };
+}
+
+/**
+ * 浅い clone (= 配列 / RepoState / RollbackSafety / events は新 instance) を返す。
+ * pure transition の immutability を担保する。
+ */
+function cloneWaveForUpdate(s: WaveState): WaveState {
+  return {
+    ...s,
+    repos: s.repos.map((r) => ({ ...r })),
+    rollback: { ...s.rollback },
+    events: s.events.slice(),
+  };
+}
+
+function appendEvent(
+  events: readonly WaveEventRecord[],
+  record: WaveEventRecord,
+): WaveEventRecord[] {
+  return [...events, record];
+}

--- a/src/release-wave/types.ts
+++ b/src/release-wave/types.ts
@@ -1,0 +1,206 @@
+/**
+ * Release Wave 機構の型定義。
+ *
+ * 設計の親 issue: ippoan/ci-dashboard#137
+ *
+ * Wave の lifecycle:
+ *
+ *   start → staging → (pending-approval) → flipping → flipped
+ *                                                       │
+ *                                                       ├─ contract_applied (flag だけ flip)
+ *                                                       │
+ *                                                       └─ rollback → rolled-back
+ *
+ *   abort: staging / pending-approval から → aborted
+ *   fail:  staging / flipping から → failed
+ *
+ * 本ファイルは type のみで実行コードは持たない。state machine の遷移ロジックは
+ * `state.ts` の純粋関数 `transition()` 経由で行う。
+ */
+
+// ----------------------------------------------------------------------------
+// State
+// ----------------------------------------------------------------------------
+
+/** Wave 全体の高レベル state。state.ts の `transition()` が更新する。 */
+export type WaveStateName =
+  | "staging"
+  | "pending-approval"
+  | "flipping"
+  | "flipped"
+  | "rolled-back"
+  | "failed"
+  | "aborted";
+
+/** `flip_policy = manual-approval` か `auto` か。 */
+export type FlipPolicy = "manual-approval" | "auto";
+
+/**
+ * Per-repo の stage / flip 進捗。`pending` → `done` への単調遷移を期待するが、
+ * `failed` への遷移は permanent (= 同 wave 内で復活させない)。
+ */
+export type RepoPhaseStatus = "pending" | "done" | "failed";
+
+/** Wave に参加する 1 repo の状態。 */
+export interface RepoState {
+  /** "owner/name"。 */
+  readonly repo: string;
+  /** 本 wave 内で打つ予定の tag (`v1.42.0` 等)。 */
+  readonly target_tag: string;
+  /** 本 wave 開始時点の HEAD SHA。stage handler 起動先 commit。 */
+  readonly head_sha: string;
+
+  /** stage handler 完了 callback の進捗。 */
+  stage_status: RepoPhaseStatus;
+  /** stage 完了時に handler が返した preview URL。 */
+  preview_url: string | null;
+  /** stage 失敗時の reason。 */
+  stage_error: string | null;
+
+  /** flip handler 進捗。flip_started=true 以降のみ意味あり。 */
+  flip_status: RepoPhaseStatus;
+  /** flip 失敗時の reason。 */
+  flip_error: string | null;
+
+  /**
+   * flip 前の latest revision (ie. rollback 時に戻す先)。stage callback が
+   * platform から取って報告する。CF Workers: version id、Cloud Run: revision name。
+   */
+  flip_from_revision: string | null;
+
+  /** rollback 実行時、戻した先 revision。 */
+  rolled_back_to_revision: string | null;
+}
+
+/**
+ * rollback safety flag。`contract_applied` event で false 化する。
+ *
+ * `safe == false` 時、`release_wave_rollback` MCP tool はデフォルト refuse。
+ * `--force` で override 可だが、issue #137 の Migration linkage 節参照。
+ */
+export interface RollbackSafety {
+  safe: boolean;
+  unsafe_reason: string | null;
+  /** false 化された UTC ISO timestamp。 */
+  unsafe_since: string | null;
+  /** どの migration が unsafe に倒したか (`20260601_001_drop_legacy_token` 等)。 */
+  unsafe_by_migration: string | null;
+}
+
+/**
+ * Wave の完全な状態。DO storage に JSON で永続化する単一 record。
+ *
+ * 履歴 (events[]) も同 record に append-only で持つ。volume が増えたら
+ * R2 archive へ flush するが、初期実装では DO storage 1 record に集約して
+ * シンプルに保つ。
+ */
+export interface WaveState {
+  /** UUID-like、operator が指定 or 自動採番。 */
+  readonly wave_id: string;
+  /** 高レベル state。 */
+  state: WaveStateName;
+  /** Wave 開始時に operator が選択した policy。 */
+  readonly flip_policy: FlipPolicy;
+  /** 開始時の note (自由文)。 */
+  readonly note: string;
+  /** 参加 repo 順序固定 list。 */
+  readonly repos: RepoState[];
+
+  /** rollback 可否フラグ。 */
+  rollback: RollbackSafety;
+
+  /** 開始時 UTC ISO。 */
+  readonly started_at: string;
+  /** 各 phase 進入 timestamp (audit 用)。 */
+  staged_at: string | null;
+  approved_at: string | null;
+  approved_by: string | null;
+  flipped_at: string | null;
+  rolled_back_at: string | null;
+  rolled_back_by: string | null;
+  failed_at: string | null;
+  aborted_at: string | null;
+
+  /** 監査用イベントログ (append-only)。 */
+  events: WaveEventRecord[];
+}
+
+// ----------------------------------------------------------------------------
+// Events / Transitions
+// ----------------------------------------------------------------------------
+
+/**
+ * `transition()` に渡す入力イベント。すべて discriminated union。
+ *
+ * `now` は state.ts 側ではなく caller (DO) が `new Date().toISOString()` を
+ * 1 度だけ取って渡す。これで時刻依存をテスト可能にする。
+ */
+export type WaveEvent =
+  | { kind: "start"; now: string }
+  | {
+      kind: "stage_report";
+      now: string;
+      repo: string;
+      ok: boolean;
+      preview_url?: string | null;
+      flip_from_revision?: string | null;
+      error?: string | null;
+    }
+  | { kind: "approve"; now: string; approved_by: string }
+  | {
+      kind: "flip_report";
+      now: string;
+      repo: string;
+      ok: boolean;
+      error?: string | null;
+    }
+  | { kind: "rollback"; now: string; rolled_back_by: string; force?: boolean }
+  | { kind: "abort"; now: string; aborted_by: string; reason: string }
+  | {
+      kind: "fail";
+      now: string;
+      reason: string;
+    }
+  | {
+      kind: "contract_applied";
+      now: string;
+      repo: string;
+      migration_id: string;
+    };
+
+/** events[] に積む 1 entry。`WaveEvent` の subset に actor / outcome 付与。 */
+export interface WaveEventRecord {
+  /** UTC ISO。 */
+  readonly at: string;
+  /** kind は WaveEvent の kind を踏襲。 */
+  readonly kind: WaveEvent["kind"];
+  /** transition で変わった結果の 1 行 summary。 */
+  readonly summary: string;
+  /** 自由 detail (e.g. repo 名 / actor)。 */
+  readonly detail?: Record<string, unknown>;
+}
+
+// ----------------------------------------------------------------------------
+// Transition result
+// ----------------------------------------------------------------------------
+
+/**
+ * `transition()` の戻り値。pure / immutable: 失敗時は元 state を返さず error を
+ * 返すだけ。caller (DO) が前 state を保持して必要なら復元する。
+ */
+export type TransitionResult =
+  | { ok: true; state: WaveState }
+  | { ok: false; error: string; code: TransitionErrorCode };
+
+/** Transition 失敗時の機械可読 code。MCP tool から HTTP status に map する。 */
+export type TransitionErrorCode =
+  /** 既に終了 state なので操作不可。 */
+  | "TERMINAL_STATE"
+  /** 現 state からこの event は遷移不可。 */
+  | "INVALID_TRANSITION"
+  /** event.repo が wave.repos に含まれていない。 */
+  | "REPO_NOT_IN_WAVE"
+  /** rollback.safe = false で force=false。 */
+  | "ROLLBACK_UNSAFE"
+  /** start event だが既存 state 非 null (= 同 wave 重複開始)。 */
+  | "ALREADY_STARTED";

--- a/test/release-wave/state.test.ts
+++ b/test/release-wave/state.test.ts
@@ -65,11 +65,13 @@ describe("createWave", () => {
 // ----------------------------------------------------------------------------
 
 describe("isTerminal", () => {
-  it("classifies states correctly", () => {
+  it("classifies states correctly (flipped is NOT terminal)", () => {
+    // flipped は中間定常 state: rollback / contract_applied を受けるため
+    // terminal 扱いしない。完全終了は rolled-back / failed / aborted の 3 つ。
     expect(isTerminal("staging")).toBe(false);
     expect(isTerminal("pending-approval")).toBe(false);
     expect(isTerminal("flipping")).toBe(false);
-    expect(isTerminal("flipped")).toBe(true);
+    expect(isTerminal("flipped")).toBe(false);
     expect(isTerminal("rolled-back")).toBe(true);
     expect(isTerminal("failed")).toBe(true);
     expect(isTerminal("aborted")).toBe(true);
@@ -682,11 +684,10 @@ describe("transition: contract_applied", () => {
     if (!r.ok) expect(r.code).toBe("REPO_NOT_IN_WAVE");
   });
 
-  it("contract_applied is the only event accepted on a terminal (flipped) state", () => {
-    // flipped is treated as terminal for `isTerminal()` but transition()
-    // exposes contract_applied as the single allowed event on terminal states.
-    // Verify by ensuring rollback (also valid on flipped) still works,
-    // i.e. flipped is NOT blanket-blocked.
+  it("accepts contract_applied on flipped state (not blanket-blocked)", () => {
+    // flipped は中間定常 state なので contract_applied / rollback の両方を受ける。
+    // 旧仕様で flipped を terminal 扱いした際に rollback が TERMINAL_STATE で
+    // reject される regression があったため、このテストで覆う。
     const s = flippedWave();
     const r1 = assertOk(
       transition(s, {
@@ -697,6 +698,39 @@ describe("transition: contract_applied", () => {
       }),
     );
     expect(r1.state.rollback.safe).toBe(false);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// fail rejects on flipped (use rollback instead)
+// ----------------------------------------------------------------------------
+
+describe("transition: fail (flipped guard)", () => {
+  function flippedWave(): WaveState {
+    let s = makeWave({ flip_policy: "auto" });
+    s = assertOk(
+      transition(s, { kind: "stage_report", now: T1, repo: "ippoan/rust-alc-api", ok: true }),
+    ).state;
+    s = assertOk(
+      transition(s, { kind: "stage_report", now: T2, repo: "ippoan/auth-worker", ok: true }),
+    ).state;
+    s = assertOk(
+      transition(s, { kind: "flip_report", now: T2, repo: "ippoan/rust-alc-api", ok: true }),
+    ).state;
+    s = assertOk(
+      transition(s, { kind: "flip_report", now: T2, repo: "ippoan/auth-worker", ok: true }),
+    ).state;
+    return s;
+  }
+
+  it("rejects fail on flipped (use rollback)", () => {
+    const s = flippedWave();
+    const r = transition(s, { kind: "fail", now: T3, reason: "smoke fail" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("INVALID_TRANSITION");
+      expect(r.error).toContain("rollback");
+    }
   });
 });
 

--- a/test/release-wave/state.test.ts
+++ b/test/release-wave/state.test.ts
@@ -1,0 +1,750 @@
+import { describe, it, expect } from "vitest";
+import { createWave, isTerminal, transition } from "../../src/release-wave/state";
+import type { WaveEvent, WaveState } from "../../src/release-wave/types";
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+const T0 = "2026-05-27T10:00:00Z";
+const T1 = "2026-05-27T10:05:00Z";
+const T2 = "2026-05-27T10:10:00Z";
+const T3 = "2026-05-27T10:15:00Z";
+
+function makeWave(
+  opts: Partial<{
+    wave_id: string;
+    flip_policy: "manual-approval" | "auto";
+    repos: Array<{ repo: string; target_tag: string; head_sha: string }>;
+  }> = {},
+): WaveState {
+  return createWave({
+    wave_id: opts.wave_id ?? "wave_test_01",
+    flip_policy: opts.flip_policy ?? "manual-approval",
+    note: "test wave",
+    repos: opts.repos ?? [
+      { repo: "ippoan/rust-alc-api", target_tag: "v1.1.0", head_sha: "sha-a" },
+      { repo: "ippoan/auth-worker", target_tag: "v0.5.0", head_sha: "sha-b" },
+    ],
+    now: T0,
+  });
+}
+
+function assertOk<T extends { ok: boolean }>(r: T): Extract<T, { ok: true }> {
+  if (!r.ok) {
+    throw new Error("expected ok=true, got: " + JSON.stringify(r));
+  }
+  return r as Extract<T, { ok: true }>;
+}
+
+// ----------------------------------------------------------------------------
+// createWave
+// ----------------------------------------------------------------------------
+
+describe("createWave", () => {
+  it("creates initial state with all repos pending", () => {
+    const w = makeWave();
+    expect(w.state).toBe("staging");
+    expect(w.wave_id).toBe("wave_test_01");
+    expect(w.repos).toHaveLength(2);
+    expect(w.repos[0]!.stage_status).toBe("pending");
+    expect(w.repos[0]!.flip_status).toBe("pending");
+    expect(w.repos[0]!.preview_url).toBeNull();
+    expect(w.repos[0]!.flip_from_revision).toBeNull();
+    expect(w.rollback.safe).toBe(true);
+    expect(w.rollback.unsafe_reason).toBeNull();
+    expect(w.started_at).toBe(T0);
+    expect(w.staged_at).toBeNull();
+    expect(w.events).toHaveLength(1);
+    expect(w.events[0]!.kind).toBe("start");
+  });
+});
+
+// ----------------------------------------------------------------------------
+// isTerminal
+// ----------------------------------------------------------------------------
+
+describe("isTerminal", () => {
+  it("classifies states correctly", () => {
+    expect(isTerminal("staging")).toBe(false);
+    expect(isTerminal("pending-approval")).toBe(false);
+    expect(isTerminal("flipping")).toBe(false);
+    expect(isTerminal("flipped")).toBe(true);
+    expect(isTerminal("rolled-back")).toBe(true);
+    expect(isTerminal("failed")).toBe(true);
+    expect(isTerminal("aborted")).toBe(true);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// start event (= invalid on existing state)
+// ----------------------------------------------------------------------------
+
+describe("transition: start", () => {
+  it("rejects start on existing wave (ALREADY_STARTED)", () => {
+    const w = makeWave();
+    const r = transition(w, { kind: "start", now: T1 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe("ALREADY_STARTED");
+    }
+  });
+});
+
+// ----------------------------------------------------------------------------
+// stage_report
+// ----------------------------------------------------------------------------
+
+describe("transition: stage_report", () => {
+  it("marks single repo as done, stays in staging until all done", () => {
+    const w = makeWave();
+    const r = assertOk(
+      transition(w, {
+        kind: "stage_report",
+        now: T1,
+        repo: "ippoan/rust-alc-api",
+        ok: true,
+        preview_url: "https://preview-rust-alc-api.ippoan.org",
+        flip_from_revision: "rust-alc-api-00041-zzz",
+      }),
+    );
+    expect(r.state.state).toBe("staging");
+    expect(r.state.repos[0]!.stage_status).toBe("done");
+    expect(r.state.repos[0]!.preview_url).toBe(
+      "https://preview-rust-alc-api.ippoan.org",
+    );
+    expect(r.state.repos[0]!.flip_from_revision).toBe("rust-alc-api-00041-zzz");
+    expect(r.state.repos[1]!.stage_status).toBe("pending");
+    expect(r.state.staged_at).toBeNull();
+  });
+
+  it("transitions to pending-approval when all done (manual policy)", () => {
+    let s = makeWave({ flip_policy: "manual-approval" });
+    s = assertOk(
+      transition(s, { kind: "stage_report", now: T1, repo: "ippoan/rust-alc-api", ok: true }),
+    ).state;
+    s = assertOk(
+      transition(s, { kind: "stage_report", now: T2, repo: "ippoan/auth-worker", ok: true }),
+    ).state;
+    expect(s.state).toBe("pending-approval");
+    expect(s.staged_at).toBe(T2);
+  });
+
+  it("transitions to flipping when all done (auto policy)", () => {
+    let s = makeWave({ flip_policy: "auto" });
+    s = assertOk(
+      transition(s, { kind: "stage_report", now: T1, repo: "ippoan/rust-alc-api", ok: true }),
+    ).state;
+    s = assertOk(
+      transition(s, { kind: "stage_report", now: T2, repo: "ippoan/auth-worker", ok: true }),
+    ).state;
+    expect(s.state).toBe("flipping");
+    expect(s.staged_at).toBe(T2);
+  });
+
+  it("transitions to failed on any stage fail (does not wait for others)", () => {
+    let s = makeWave();
+    s = assertOk(
+      transition(s, {
+        kind: "stage_report",
+        now: T1,
+        repo: "ippoan/rust-alc-api",
+        ok: false,
+        error: "build failed",
+      }),
+    ).state;
+    expect(s.state).toBe("failed");
+    expect(s.failed_at).toBe(T1);
+    expect(s.repos[0]!.stage_status).toBe("failed");
+    expect(s.repos[0]!.stage_error).toBe("build failed");
+    // The other repo stays pending (= barrier wasn't passed)
+    expect(s.repos[1]!.stage_status).toBe("pending");
+  });
+
+  it("refuses re-report on already-failed repo (permanent)", () => {
+    let s = makeWave();
+    s = assertOk(
+      transition(s, {
+        kind: "stage_report",
+        now: T1,
+        repo: "ippoan/rust-alc-api",
+        ok: false,
+        error: "boom",
+      }),
+    ).state;
+    // wave is in failed state now, but even if it weren't, re-reporting failed repo should reject.
+    // Let's also test the early-state branch: construct another wave with 1 failed + 1 pending,
+    // skipping the wave-level transition to failed.
+    // Easier: directly test on the failed state, expecting TERMINAL_STATE.
+    const r = transition(s, {
+      kind: "stage_report",
+      now: T2,
+      repo: "ippoan/auth-worker",
+      ok: true,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("TERMINAL_STATE");
+  });
+
+  it("rejects stage_report outside staging state", () => {
+    const s = makeWave({ flip_policy: "manual-approval" });
+    let s1 = assertOk(
+      transition(s, { kind: "stage_report", now: T1, repo: "ippoan/rust-alc-api", ok: true }),
+    ).state;
+    s1 = assertOk(
+      transition(s1, { kind: "stage_report", now: T2, repo: "ippoan/auth-worker", ok: true }),
+    ).state;
+    // now pending-approval
+    const r = transition(s1, {
+      kind: "stage_report",
+      now: T3,
+      repo: "ippoan/rust-alc-api",
+      ok: true,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("INVALID_TRANSITION");
+  });
+
+  it("rejects unknown repo (REPO_NOT_IN_WAVE)", () => {
+    const s = makeWave();
+    const r = transition(s, {
+      kind: "stage_report",
+      now: T1,
+      repo: "ippoan/unrelated",
+      ok: true,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("REPO_NOT_IN_WAVE");
+  });
+
+  it("preserves nullable fields when missing optional inputs", () => {
+    const s = makeWave();
+    const r = assertOk(
+      transition(s, {
+        kind: "stage_report",
+        now: T1,
+        repo: "ippoan/rust-alc-api",
+        ok: true,
+        // omit preview_url / flip_from_revision
+      }),
+    );
+    expect(r.state.repos[0]!.preview_url).toBeNull();
+    expect(r.state.repos[0]!.flip_from_revision).toBeNull();
+  });
+
+  it("attempts to re-report failed repo before wave-fail propagates (permanent guard)", () => {
+    // Manually build a wave where 1 repo is failed but state is still staging — the wave
+    // transition normally moves to "failed" immediately, but cover the permanent-guard
+    // branch by constructing the intermediate state directly.
+    const s = makeWave({
+      repos: [
+        { repo: "ippoan/a", target_tag: "v1", head_sha: "1" },
+        { repo: "ippoan/b", target_tag: "v1", head_sha: "2" },
+        { repo: "ippoan/c", target_tag: "v1", head_sha: "3" },
+      ],
+    });
+    // Mutate a copy: mark only "a" failed without propagating to wave state.
+    const tweaked: WaveState = {
+      ...s,
+      repos: s.repos.map((r, i) =>
+        i === 0 ? { ...r, stage_status: "failed" as const, stage_error: "x" } : { ...r },
+      ),
+    };
+    const r = transition(tweaked, {
+      kind: "stage_report",
+      now: T1,
+      repo: "ippoan/a",
+      ok: true,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("INVALID_TRANSITION");
+  });
+});
+
+// ----------------------------------------------------------------------------
+// approve
+// ----------------------------------------------------------------------------
+
+describe("transition: approve", () => {
+  function pendingApprovalWave(): WaveState {
+    let s = makeWave({ flip_policy: "manual-approval" });
+    s = assertOk(
+      transition(s, { kind: "stage_report", now: T1, repo: "ippoan/rust-alc-api", ok: true }),
+    ).state;
+    s = assertOk(
+      transition(s, { kind: "stage_report", now: T2, repo: "ippoan/auth-worker", ok: true }),
+    ).state;
+    return s;
+  }
+
+  it("advances pending-approval -> flipping with actor recorded", () => {
+    const s = pendingApprovalWave();
+    const r = assertOk(
+      transition(s, { kind: "approve", now: T3, approved_by: "ops@example.com" }),
+    );
+    expect(r.state.state).toBe("flipping");
+    expect(r.state.approved_at).toBe(T3);
+    expect(r.state.approved_by).toBe("ops@example.com");
+  });
+
+  it("rejects approve from staging state", () => {
+    const s = makeWave();
+    const r = transition(s, { kind: "approve", now: T1, approved_by: "ops" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("INVALID_TRANSITION");
+  });
+});
+
+// ----------------------------------------------------------------------------
+// flip_report
+// ----------------------------------------------------------------------------
+
+describe("transition: flip_report", () => {
+  function flippingWave(): WaveState {
+    let s = makeWave({ flip_policy: "auto" });
+    s = assertOk(
+      transition(s, { kind: "stage_report", now: T1, repo: "ippoan/rust-alc-api", ok: true }),
+    ).state;
+    s = assertOk(
+      transition(s, { kind: "stage_report", now: T2, repo: "ippoan/auth-worker", ok: true }),
+    ).state;
+    return s;
+  }
+
+  it("marks single repo done, stays flipping until all done", () => {
+    const s = flippingWave();
+    const r = assertOk(
+      transition(s, {
+        kind: "flip_report",
+        now: T3,
+        repo: "ippoan/rust-alc-api",
+        ok: true,
+      }),
+    );
+    expect(r.state.state).toBe("flipping");
+    expect(r.state.repos[0]!.flip_status).toBe("done");
+    expect(r.state.flipped_at).toBeNull();
+  });
+
+  it("transitions to flipped when all done", () => {
+    let s = flippingWave();
+    s = assertOk(
+      transition(s, { kind: "flip_report", now: T3, repo: "ippoan/rust-alc-api", ok: true }),
+    ).state;
+    s = assertOk(
+      transition(s, { kind: "flip_report", now: T3, repo: "ippoan/auth-worker", ok: true }),
+    ).state;
+    expect(s.state).toBe("flipped");
+    expect(s.flipped_at).toBe(T3);
+  });
+
+  it("transitions to failed on any flip fail", () => {
+    const s = flippingWave();
+    const r = assertOk(
+      transition(s, {
+        kind: "flip_report",
+        now: T3,
+        repo: "ippoan/rust-alc-api",
+        ok: false,
+        error: "patch denied",
+      }),
+    );
+    expect(r.state.state).toBe("failed");
+    expect(r.state.repos[0]!.flip_status).toBe("failed");
+    expect(r.state.repos[0]!.flip_error).toBe("patch denied");
+  });
+
+  it("rejects flip_report outside flipping", () => {
+    const s = makeWave();
+    const r = transition(s, {
+      kind: "flip_report",
+      now: T1,
+      repo: "ippoan/rust-alc-api",
+      ok: true,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("INVALID_TRANSITION");
+  });
+
+  it("rejects unknown repo in flip_report", () => {
+    const s = flippingWave();
+    const r = transition(s, {
+      kind: "flip_report",
+      now: T3,
+      repo: "ippoan/unrelated",
+      ok: true,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("REPO_NOT_IN_WAVE");
+  });
+
+  it("rejects re-report on permanently failed flip", () => {
+    // construct intermediate flipping state with 1 failed repo without propagating to wave state
+    const base = flippingWave();
+    const tweaked: WaveState = {
+      ...base,
+      repos: base.repos.map((r, i) =>
+        i === 0 ? { ...r, flip_status: "failed" as const, flip_error: "x" } : { ...r },
+      ),
+    };
+    const r = transition(tweaked, {
+      kind: "flip_report",
+      now: T3,
+      repo: "ippoan/rust-alc-api",
+      ok: true,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("INVALID_TRANSITION");
+  });
+
+  it("uses default error message when ok=false and error missing", () => {
+    const s = flippingWave();
+    const r = assertOk(
+      transition(s, {
+        kind: "flip_report",
+        now: T3,
+        repo: "ippoan/rust-alc-api",
+        ok: false,
+      }),
+    );
+    expect(r.state.repos[0]!.flip_error).toBe("flip failed (no detail)");
+  });
+
+  it("uses default error message for stage when error missing", () => {
+    const s = makeWave();
+    const r = assertOk(
+      transition(s, {
+        kind: "stage_report",
+        now: T1,
+        repo: "ippoan/rust-alc-api",
+        ok: false,
+      }),
+    );
+    expect(r.state.repos[0]!.stage_error).toBe("stage failed (no detail)");
+  });
+});
+
+// ----------------------------------------------------------------------------
+// rollback
+// ----------------------------------------------------------------------------
+
+describe("transition: rollback", () => {
+  function flippedWave(): WaveState {
+    let s = makeWave({ flip_policy: "auto" });
+    s = assertOk(
+      transition(s, { kind: "stage_report", now: T1, repo: "ippoan/rust-alc-api", ok: true }),
+    ).state;
+    s = assertOk(
+      transition(s, { kind: "stage_report", now: T2, repo: "ippoan/auth-worker", ok: true }),
+    ).state;
+    s = assertOk(
+      transition(s, { kind: "flip_report", now: T2, repo: "ippoan/rust-alc-api", ok: true }),
+    ).state;
+    s = assertOk(
+      transition(s, { kind: "flip_report", now: T2, repo: "ippoan/auth-worker", ok: true }),
+    ).state;
+    return s;
+  }
+
+  it("rolls back when safe=true", () => {
+    const s = flippedWave();
+    const r = assertOk(
+      transition(s, {
+        kind: "rollback",
+        now: T3,
+        rolled_back_by: "ops@example.com",
+      }),
+    );
+    expect(r.state.state).toBe("rolled-back");
+    expect(r.state.rolled_back_at).toBe(T3);
+    expect(r.state.rolled_back_by).toBe("ops@example.com");
+  });
+
+  it("refuses rollback when unsafe and no force", () => {
+    let s = flippedWave();
+    s = assertOk(
+      transition(s, {
+        kind: "contract_applied",
+        now: T2,
+        repo: "ippoan/rust-alc-api",
+        migration_id: "20260601_001_drop",
+      }),
+    ).state;
+    const r = transition(s, {
+      kind: "rollback",
+      now: T3,
+      rolled_back_by: "ops",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("ROLLBACK_UNSAFE");
+  });
+
+  it("allows rollback when unsafe + force=true", () => {
+    let s = flippedWave();
+    s = assertOk(
+      transition(s, {
+        kind: "contract_applied",
+        now: T2,
+        repo: "ippoan/rust-alc-api",
+        migration_id: "20260601_001_drop",
+      }),
+    ).state;
+    const r = assertOk(
+      transition(s, {
+        kind: "rollback",
+        now: T3,
+        rolled_back_by: "ops",
+        force: true,
+      }),
+    );
+    expect(r.state.state).toBe("rolled-back");
+    // event detail should record forced=true and the safety status at the time
+    const last = r.state.events[r.state.events.length - 1]!;
+    expect(last.kind).toBe("rollback");
+    expect(last.detail).toMatchObject({ forced: true, rollback_safe_at_time: false });
+  });
+
+  it("rejects rollback from non-flipped state", () => {
+    const s = makeWave();
+    const r = transition(s, {
+      kind: "rollback",
+      now: T1,
+      rolled_back_by: "ops",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("INVALID_TRANSITION");
+  });
+});
+
+// ----------------------------------------------------------------------------
+// abort
+// ----------------------------------------------------------------------------
+
+describe("transition: abort", () => {
+  it("aborts from staging", () => {
+    const s = makeWave();
+    const r = assertOk(
+      transition(s, {
+        kind: "abort",
+        now: T1,
+        aborted_by: "ops",
+        reason: "ci broken",
+      }),
+    );
+    expect(r.state.state).toBe("aborted");
+    expect(r.state.aborted_at).toBe(T1);
+  });
+
+  it("aborts from pending-approval", () => {
+    let s = makeWave({ flip_policy: "manual-approval" });
+    s = assertOk(
+      transition(s, { kind: "stage_report", now: T1, repo: "ippoan/rust-alc-api", ok: true }),
+    ).state;
+    s = assertOk(
+      transition(s, { kind: "stage_report", now: T2, repo: "ippoan/auth-worker", ok: true }),
+    ).state;
+    const r = assertOk(
+      transition(s, {
+        kind: "abort",
+        now: T3,
+        aborted_by: "ops",
+        reason: "preview unhealthy",
+      }),
+    );
+    expect(r.state.state).toBe("aborted");
+  });
+
+  it("rejects abort from flipping", () => {
+    let s = makeWave({ flip_policy: "auto" });
+    s = assertOk(
+      transition(s, { kind: "stage_report", now: T1, repo: "ippoan/rust-alc-api", ok: true }),
+    ).state;
+    s = assertOk(
+      transition(s, { kind: "stage_report", now: T2, repo: "ippoan/auth-worker", ok: true }),
+    ).state;
+    // now flipping
+    const r = transition(s, {
+      kind: "abort",
+      now: T3,
+      aborted_by: "ops",
+      reason: "too late",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("INVALID_TRANSITION");
+  });
+});
+
+// ----------------------------------------------------------------------------
+// fail
+// ----------------------------------------------------------------------------
+
+describe("transition: fail", () => {
+  it("fails wave from any non-terminal state", () => {
+    const s = makeWave();
+    const r = assertOk(transition(s, { kind: "fail", now: T1, reason: "boom" }));
+    expect(r.state.state).toBe("failed");
+    expect(r.state.failed_at).toBe(T1);
+  });
+
+  it("rejects fail on already-failed wave (terminal)", () => {
+    let s = makeWave();
+    s = assertOk(transition(s, { kind: "fail", now: T1, reason: "boom" })).state;
+    const r = transition(s, { kind: "fail", now: T2, reason: "again" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("TERMINAL_STATE");
+  });
+});
+
+// ----------------------------------------------------------------------------
+// contract_applied
+// ----------------------------------------------------------------------------
+
+describe("transition: contract_applied", () => {
+  function flippedWave(): WaveState {
+    let s = makeWave({ flip_policy: "auto" });
+    s = assertOk(
+      transition(s, { kind: "stage_report", now: T1, repo: "ippoan/rust-alc-api", ok: true }),
+    ).state;
+    s = assertOk(
+      transition(s, { kind: "stage_report", now: T2, repo: "ippoan/auth-worker", ok: true }),
+    ).state;
+    s = assertOk(
+      transition(s, { kind: "flip_report", now: T2, repo: "ippoan/rust-alc-api", ok: true }),
+    ).state;
+    s = assertOk(
+      transition(s, { kind: "flip_report", now: T2, repo: "ippoan/auth-worker", ok: true }),
+    ).state;
+    return s;
+  }
+
+  it("flips rollback.safe to false on first contract_applied", () => {
+    const s = flippedWave();
+    const r = assertOk(
+      transition(s, {
+        kind: "contract_applied",
+        now: T3,
+        repo: "ippoan/rust-alc-api",
+        migration_id: "20260601_001_drop",
+      }),
+    );
+    expect(r.state.rollback.safe).toBe(false);
+    expect(r.state.rollback.unsafe_since).toBe(T3);
+    expect(r.state.rollback.unsafe_by_migration).toBe("20260601_001_drop");
+    expect(r.state.rollback.unsafe_reason).toContain("20260601_001_drop");
+  });
+
+  it("is idempotent on subsequent contract_applied (keeps first migration_id)", () => {
+    let s = flippedWave();
+    s = assertOk(
+      transition(s, {
+        kind: "contract_applied",
+        now: T2,
+        repo: "ippoan/rust-alc-api",
+        migration_id: "first",
+      }),
+    ).state;
+    s = assertOk(
+      transition(s, {
+        kind: "contract_applied",
+        now: T3,
+        repo: "ippoan/auth-worker",
+        migration_id: "second",
+      }),
+    ).state;
+    expect(s.rollback.unsafe_by_migration).toBe("first");
+    expect(s.rollback.unsafe_since).toBe(T2);
+    // both events recorded
+    const contractEvents = s.events.filter((e) => e.kind === "contract_applied");
+    expect(contractEvents).toHaveLength(2);
+  });
+
+  it("rejects contract_applied outside flipped state", () => {
+    const s = makeWave();
+    const r = transition(s, {
+      kind: "contract_applied",
+      now: T1,
+      repo: "ippoan/rust-alc-api",
+      migration_id: "m",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("INVALID_TRANSITION");
+  });
+
+  it("rejects unknown repo", () => {
+    const s = flippedWave();
+    const r = transition(s, {
+      kind: "contract_applied",
+      now: T3,
+      repo: "ippoan/unrelated",
+      migration_id: "m",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe("REPO_NOT_IN_WAVE");
+  });
+
+  it("contract_applied is the only event accepted on a terminal (flipped) state", () => {
+    // flipped is treated as terminal for `isTerminal()` but transition()
+    // exposes contract_applied as the single allowed event on terminal states.
+    // Verify by ensuring rollback (also valid on flipped) still works,
+    // i.e. flipped is NOT blanket-blocked.
+    const s = flippedWave();
+    const r1 = assertOk(
+      transition(s, {
+        kind: "contract_applied",
+        now: T3,
+        repo: "ippoan/rust-alc-api",
+        migration_id: "m",
+      }),
+    );
+    expect(r1.state.rollback.safe).toBe(false);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// immutability + events log
+// ----------------------------------------------------------------------------
+
+describe("immutability and events", () => {
+  it("does not mutate the input state object", () => {
+    const s = makeWave();
+    const beforeRepos = s.repos[0]!.stage_status;
+    const beforeEvents = s.events.length;
+    transition(s, { kind: "stage_report", now: T1, repo: "ippoan/rust-alc-api", ok: true });
+    expect(s.repos[0]!.stage_status).toBe(beforeRepos);
+    expect(s.events.length).toBe(beforeEvents);
+  });
+
+  it("appends an event record per accepted transition", () => {
+    let s = makeWave();
+    const before = s.events.length;
+    s = assertOk(
+      transition(s, { kind: "stage_report", now: T1, repo: "ippoan/rust-alc-api", ok: true }),
+    ).state;
+    expect(s.events.length).toBe(before + 1);
+    expect(s.events[s.events.length - 1]!.kind).toBe("stage_report");
+  });
+
+  it("does not append events on rejected transitions", () => {
+    const s = makeWave();
+    const before = s.events.length;
+    const r = transition(s, {
+      kind: "stage_report",
+      now: T1,
+      repo: "ippoan/unrelated",
+      ok: true,
+    });
+    expect(r.ok).toBe(false);
+    expect(s.events.length).toBe(before);
+  });
+
+  it("type-narrows error result", () => {
+    const s = makeWave();
+    const r = transition(s, { kind: "start", now: T1 } satisfies WaveEvent);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      // ensure shape of error result
+      expect(typeof r.error).toBe("string");
+      expect(typeof r.code).toBe("string");
+    }
+  });
+});


### PR DESCRIPTION
## 概要

Phase 3a: Release Wave 機構の **純粋 state machine** を追加。DO / HTTP / MCP に依存せず、`(state, event) → next state | error` だけを export する。Phase 3 の他レイヤ (DO `ReleaseWaveHub`、8 MCP tools、admin UI、CF Access) はこの state machine の上に積む。

## 関連 issue

Refs ippoan/ci-dashboard#137

## ファイル

| path | 役割 |
|---|---|
| `src/release-wave/types.ts` | `WaveState` / `WaveEvent` / `RollbackSafety` / `TransitionResult` 等の型定義 |
| `src/release-wave/state.ts` | `createWave()` + `transition(state, event)` の pure functions |
| `test/release-wave/state.test.ts` | ~30 ケース網羅 unit test |

## State machine

```
       createWave()                            contract_applied  ↓
            │                                                    ↓
            ▼                                                    ↓
       ┌──────────┐                                              ↓
       │ staging  │                                              ↓
       └────┬─────┘                                              ↓
            │ all repos stage=done                               ↓
            │                                                    ↓
   ┌────────┴───────────────┐                                    ↓
   │                        │                                    ↓
   policy=auto          policy=manual-approval                   ↓
   │                        │                                    ↓
   │                        ▼                                    ↓
   │             ┌─────────────────────┐                         ↓
   │             │ pending-approval    │                         ↓
   │             └────────┬────────────┘                         ↓
   │                      │ approve                              ↓
   └───────────┬──────────┘                                      ↓
               │                                                 ↓
               ▼                                                 ↓
        ┌──────────┐                                             ↓
        │ flipping │                                             ↓
        └────┬─────┘                                             ↓
             │ all flip=done                                     ↓
             │                                                   ↓
             ▼                                                   ↓
       ┌──────────┐ ←──── contract_applied (rollback.safe=false)─┘
       │ flipped  │
       └────┬─────┘
            │ rollback (refuse if !safe, --force overrides)
            ▼
       ┌────────────┐
       │ rolled-back│
       └────────────┘

stage_report fail / flip_report fail / fail → failed
abort (staging/pending-approval のみ)      → aborted
```

## 設計ポイント

- **pure**: 入力 state は immutable (output で shallow clone)、`event.now` で時刻注入
- **rollback safety flag**: `contract_applied` event で `rollback.safe = false`。`release_wave_rollback` MCP は default refuse、`--force` で override (issue #137 の決定通り)
- **永続化なし**: storage / DB アクセスは含まず、DO 層 (次 PR) に閉じる
- **events log**: 全 transition を append-only で記録 (audit + UI 表示用)
- **不正遷移は機械可読 code 付き**: `INVALID_TRANSITION` / `REPO_NOT_IN_WAVE` / `ROLLBACK_UNSAFE` / `TERMINAL_STATE` / `ALREADY_STARTED`

## 後続 PR (Phase 3 内)

1. **Phase 3b**: DO `ReleaseWaveHub` 追加 + `wrangler.jsonc` migration v2 + DO storage 経由統合テスト
2. **Phase 3c**: MCP tools 8 個 (`release_wave_*`) を `src/mcp/tools/release-wave.ts` に追加
3. **Phase 3d**: HTTP endpoint `/mcp/release_wave_contract_applied` (GitHub Actions 通知)
4. **Phase 3e**: Admin UI ページ + CF Access wildcard for `preview-*.ippoan.org`

## 動作確認

- [x] `tsc --noEmit` で本 PR 追加ファイルに型エラー無し (pre-existing な `worker-configuration.d.ts` 未生成エラーは別問題)
- [ ] vitest 実行は CI で確認 (`@ippoan/auth-client-worker` の private package install が必要なため local 不可)
- [x] 型定義の immutability 検証 (`readonly` 修飾、event handler 内 `cloneWaveForUpdate()` 経路)

## メモ

- `events[]` は将来 R2 archive へ flush する余地を残してあるが、初期実装は DO storage 1 record に集約する方針 (issue #137 KV 不要セクション参照)
- 同一 wave 内の `start` 重複は `ALREADY_STARTED` で reject。`createWave()` は DO 側で「同 wave_id の record が無い」確認後に呼ぶ前提

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm4uPMVQZHWm5eFurYMJif)_