### PR TITLE
feat(release-wave): add ReleaseWaveHub Durable Object (Phase 3b)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import {
 } from "./pwa";
 
 export { CIDashboardHub } from "./hub";
+export { ReleaseWaveHub } from "./release-wave/do";
 
 // auth-worker MCP OAuth Provider delegation via `@ippoan/auth-client-worker`.
 // `INTERNAL_SHARED_SECRET` (Secrets Store) is shared with auth-worker for
@@ -33,6 +34,8 @@ export { CIDashboardHub } from "./hub";
 export interface Env extends AuthClientWorkerEnv {
   WEBHOOK_SECRET: SecretsStoreSecret;
   CI_HUB: DurableObjectNamespace;
+  /** Release Wave 機構の hub DO。Refs #137。 */
+  RELEASE_WAVE_HUB: DurableObjectNamespace;
   // Comma-separated `owner/name` list of repos that don't cut tags. PR merges
   // into the default branch are treated as releases for these. See
   // wrangler.jsonc and src/tagless-repos.ts.

--- a/src/release-wave/do.ts
+++ b/src/release-wave/do.ts
@@ -1,0 +1,277 @@
+/**
+ * Release Wave 機構の Durable Object 層。
+ *
+ * Phase 3a で実装した純粋 state machine (`state.ts` + `types.ts`) の
+ * DO wrapper。1 DO instance (singleton) に全 wave を records として持ち、
+ * storage key prefix `wave:` で iterate する。
+ *
+ * 1 DO に集約する理由 (vs 1 wave 1 instance):
+ * - listing/UI で全 wave を 1 storage.list で取れる
+ * - alarm() で全 in-progress wave を一括 poll できる (= barrier 監視)
+ * - serial enforcement (= 同時 in-progress は 1 wave のみ) を start 時に
+ *   全 records を見て判定できる
+ *
+ * 設計の親 issue: ippoan/ci-dashboard#137
+ */
+
+import { DurableObject } from "cloudflare:workers";
+import type { Env } from "../index";
+import {
+  createWave,
+  isTerminal,
+  transition,
+} from "./state";
+import type {
+  FlipPolicy,
+  TransitionErrorCode,
+  WaveEvent,
+  WaveState,
+} from "./types";
+
+// ----------------------------------------------------------------------------
+// Storage keys
+// ----------------------------------------------------------------------------
+
+/** storage key prefix。1 wave 1 record。 */
+const WAVE_KEY_PREFIX = "wave:";
+
+function waveKey(wave_id: string): string {
+  return `${WAVE_KEY_PREFIX}${wave_id}`;
+}
+
+// ----------------------------------------------------------------------------
+// RPC input / output shapes
+// ----------------------------------------------------------------------------
+
+export interface StartInput {
+  wave_id: string;
+  flip_policy: FlipPolicy;
+  note?: string;
+  repos: Array<{ repo: string; target_tag: string; head_sha: string }>;
+}
+
+export interface StageReportInput {
+  wave_id: string;
+  repo: string;
+  ok: boolean;
+  preview_url?: string | null;
+  flip_from_revision?: string | null;
+  error?: string | null;
+}
+
+export interface ApproveInput {
+  wave_id: string;
+  approved_by: string;
+}
+
+export interface FlipReportInput {
+  wave_id: string;
+  repo: string;
+  ok: boolean;
+  error?: string | null;
+}
+
+export interface RollbackInput {
+  wave_id: string;
+  rolled_back_by: string;
+  force?: boolean;
+}
+
+export interface AbortInput {
+  wave_id: string;
+  aborted_by: string;
+  reason: string;
+}
+
+export interface FailInput {
+  wave_id: string;
+  reason: string;
+}
+
+export interface ContractAppliedInput {
+  /** wave_id は明示せず repo + 最新 flipped wave を逆引きする経路もあるが、
+   *  まず明示 API で実装。後で逆引きヘルパを足す。 */
+  wave_id: string;
+  repo: string;
+  migration_id: string;
+}
+
+/** RPC で返す統一エラー型。HTTP / MCP 層でそのまま status code に map できる。 */
+export interface RpcError {
+  code: TransitionErrorCode | "NOT_FOUND" | "ALREADY_EXISTS" | "WAVE_IN_PROGRESS";
+  error: string;
+}
+
+export type RpcResult<T> = { ok: true; data: T } | { ok: false } & RpcError;
+
+// ----------------------------------------------------------------------------
+// DO 本体
+// ----------------------------------------------------------------------------
+
+export class ReleaseWaveHub extends DurableObject<Env> {
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+  }
+
+  // ============ life-cycle =========================================
+
+  /**
+   * 新規 wave を開始する。serial enforcement:
+   * - 同 wave_id が既存 → ALREADY_EXISTS
+   * - 他の in-progress wave (= 非 terminal かつ 非 flipped) が存在 → WAVE_IN_PROGRESS
+   *   flipped は安定状態 (= 並行 hotfix wave 受容) として除外する。
+   */
+  async start(input: StartInput): Promise<RpcResult<WaveState>> {
+    const existing = await this.loadWave(input.wave_id);
+    if (existing) {
+      return { ok: false, code: "ALREADY_EXISTS", error: `wave ${input.wave_id} already exists` };
+    }
+
+    // serial enforcement
+    const all = await this.listInternal();
+    const blocking = all.find(
+      (w) => !isTerminal(w.state) && w.state !== "flipped",
+    );
+    if (blocking) {
+      return {
+        ok: false,
+        code: "WAVE_IN_PROGRESS",
+        error: `another wave is in progress: ${blocking.wave_id} (state=${blocking.state})`,
+      };
+    }
+
+    const now = new Date().toISOString();
+    const state = createWave({
+      wave_id: input.wave_id,
+      flip_policy: input.flip_policy,
+      note: input.note ?? "",
+      repos: input.repos,
+      now,
+    });
+    await this.saveWave(state);
+    return { ok: true, data: state };
+  }
+
+  // ============ per-event handlers =================================
+
+  async stageReport(input: StageReportInput): Promise<RpcResult<WaveState>> {
+    return this.applyEvent(input.wave_id, {
+      kind: "stage_report",
+      now: new Date().toISOString(),
+      repo: input.repo,
+      ok: input.ok,
+      preview_url: input.preview_url ?? null,
+      flip_from_revision: input.flip_from_revision ?? null,
+      error: input.error ?? null,
+    });
+  }
+
+  async approve(input: ApproveInput): Promise<RpcResult<WaveState>> {
+    return this.applyEvent(input.wave_id, {
+      kind: "approve",
+      now: new Date().toISOString(),
+      approved_by: input.approved_by,
+    });
+  }
+
+  async flipReport(input: FlipReportInput): Promise<RpcResult<WaveState>> {
+    return this.applyEvent(input.wave_id, {
+      kind: "flip_report",
+      now: new Date().toISOString(),
+      repo: input.repo,
+      ok: input.ok,
+      error: input.error ?? null,
+    });
+  }
+
+  async rollback(input: RollbackInput): Promise<RpcResult<WaveState>> {
+    return this.applyEvent(input.wave_id, {
+      kind: "rollback",
+      now: new Date().toISOString(),
+      rolled_back_by: input.rolled_back_by,
+      force: input.force === true,
+    });
+  }
+
+  async abort(input: AbortInput): Promise<RpcResult<WaveState>> {
+    return this.applyEvent(input.wave_id, {
+      kind: "abort",
+      now: new Date().toISOString(),
+      aborted_by: input.aborted_by,
+      reason: input.reason,
+    });
+  }
+
+  async fail(input: FailInput): Promise<RpcResult<WaveState>> {
+    return this.applyEvent(input.wave_id, {
+      kind: "fail",
+      now: new Date().toISOString(),
+      reason: input.reason,
+    });
+  }
+
+  async contractApplied(input: ContractAppliedInput): Promise<RpcResult<WaveState>> {
+    return this.applyEvent(input.wave_id, {
+      kind: "contract_applied",
+      now: new Date().toISOString(),
+      repo: input.repo,
+      migration_id: input.migration_id,
+    });
+  }
+
+  // ============ readers =============================================
+
+  /** wave を 1 件取得。存在しなければ NOT_FOUND。 */
+  async get(wave_id: string): Promise<RpcResult<WaveState>> {
+    const w = await this.loadWave(wave_id);
+    if (!w) {
+      return { ok: false, code: "NOT_FOUND", error: `wave ${wave_id} not found` };
+    }
+    return { ok: true, data: w };
+  }
+
+  /** 全 wave を started_at 降順で返す (新しい順)。 */
+  async list(): Promise<WaveState[]> {
+    const all = await this.listInternal();
+    return all.sort((a, b) => (a.started_at < b.started_at ? 1 : -1));
+  }
+
+  // ============ private helpers ====================================
+
+  /**
+   * apply 共通: load → transition → save。state machine 側 INVALID_TRANSITION 等は
+   * そのまま RpcError として穴抜けで返す。
+   */
+  private async applyEvent(
+    wave_id: string,
+    event: WaveEvent,
+  ): Promise<RpcResult<WaveState>> {
+    const state = await this.loadWave(wave_id);
+    if (!state) {
+      return { ok: false, code: "NOT_FOUND", error: `wave ${wave_id} not found` };
+    }
+    const result = transition(state, event);
+    if (!result.ok) {
+      return { ok: false, code: result.code, error: result.error };
+    }
+    await this.saveWave(result.state);
+    return { ok: true, data: result.state };
+  }
+
+  private async loadWave(wave_id: string): Promise<WaveState | null> {
+    const v = await this.ctx.storage.get<WaveState>(waveKey(wave_id));
+    return v ?? null;
+  }
+
+  private async saveWave(state: WaveState): Promise<void> {
+    await this.ctx.storage.put(waveKey(state.wave_id), state);
+  }
+
+  /** 全 wave を storage から取り出す (内部 helper)。listing 順は呼び出し側で sort。 */
+  private async listInternal(): Promise<WaveState[]> {
+    const map = await this.ctx.storage.list<WaveState>({
+      prefix: WAVE_KEY_PREFIX,
+    });
+    return Array.from(map.values());
+  }
+}

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -10,6 +10,7 @@ function testEnv(): Env {
     WEBHOOK_SECRET: { get: async () => "test-secret" } as unknown as SecretsStoreSecret,
     INTERNAL_SHARED_SECRET: { get: async () => "test-internal" } as unknown as SecretsStoreSecret,
     CI_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
+    RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
   };
 }
 

--- a/test/projects-page.test.ts
+++ b/test/projects-page.test.ts
@@ -12,6 +12,7 @@ function testEnv(): Env {
       idFromName: () => ({}),
       get: () => ({ fetch: async () => new Response("OK") }),
     } as unknown as DurableObjectNamespace,
+    RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
   };
 }
 

--- a/test/release-close-batch.test.ts
+++ b/test/release-close-batch.test.ts
@@ -12,6 +12,7 @@ function testEnv(): Env {
       idFromName: () => ({}),
       get: () => ({ fetch: async () => new Response("OK") }),
     } as unknown as DurableObjectNamespace,
+    RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
   };
 }
 

--- a/test/release-close.test.ts
+++ b/test/release-close.test.ts
@@ -12,6 +12,7 @@ function testEnv(): Env {
       idFromName: () => ({}),
       get: () => ({ fetch: async () => new Response("OK") }),
     } as unknown as DurableObjectNamespace,
+    RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
   };
 }
 

--- a/test/release-wave/do.test.ts
+++ b/test/release-wave/do.test.ts
@@ -1,0 +1,340 @@
+import { env, runInDurableObject } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { ReleaseWaveHub } from "../../src/release-wave/do";
+
+// 各テストで新しい DO ID を使って独立性を確保する。
+// (同一 ID を使い回すと前テストの storage が残り flaky になる。)
+let idCounter = 0;
+function freshHub(): DurableObjectStub<ReleaseWaveHub> {
+  idCounter += 1;
+  // テストランナー内 namespace: ID は test 内で unique であれば良い。
+  const id = env.RELEASE_WAVE_HUB.idFromName(
+    `test-wave-hub-${Date.now()}-${idCounter}`,
+  );
+  return env.RELEASE_WAVE_HUB.get(id) as DurableObjectStub<ReleaseWaveHub>;
+}
+
+const REPOS = [
+  { repo: "ippoan/rust-alc-api", target_tag: "v1.1.0", head_sha: "sha-a" },
+  { repo: "ippoan/auth-worker", target_tag: "v0.5.0", head_sha: "sha-b" },
+];
+
+describe("ReleaseWaveHub.start", () => {
+  it("creates a new wave", async () => {
+    const hub = freshHub();
+    const result = await runInDurableObject(hub, async (instance) => {
+      return instance.start({
+        wave_id: "w1",
+        flip_policy: "manual-approval",
+        note: "first wave",
+        repos: REPOS,
+      });
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.wave_id).toBe("w1");
+      expect(result.data.state).toBe("staging");
+      expect(result.data.repos).toHaveLength(2);
+    }
+  });
+
+  it("rejects same wave_id (ALREADY_EXISTS)", async () => {
+    const hub = freshHub();
+    await runInDurableObject(hub, async (i) => {
+      const a = await i.start({ wave_id: "w1", flip_policy: "auto", repos: REPOS });
+      expect(a.ok).toBe(true);
+      // 1st wave を flipped に進めて serial enforcement に引っかからないようにしてから
+      // 同 id 再 start を試す。
+      await i.stageReport({ wave_id: "w1", repo: REPOS[0]!.repo, ok: true });
+      await i.stageReport({ wave_id: "w1", repo: REPOS[1]!.repo, ok: true });
+      await i.flipReport({ wave_id: "w1", repo: REPOS[0]!.repo, ok: true });
+      await i.flipReport({ wave_id: "w1", repo: REPOS[1]!.repo, ok: true });
+      const dup = await i.start({ wave_id: "w1", flip_policy: "auto", repos: REPOS });
+      expect(dup.ok).toBe(false);
+      if (!dup.ok) expect(dup.code).toBe("ALREADY_EXISTS");
+    });
+  });
+
+  it("enforces serial: rejects second start while first is in progress", async () => {
+    const hub = freshHub();
+    await runInDurableObject(hub, async (i) => {
+      const a = await i.start({ wave_id: "w1", flip_policy: "manual-approval", repos: REPOS });
+      expect(a.ok).toBe(true);
+      const b = await i.start({ wave_id: "w2", flip_policy: "auto", repos: REPOS });
+      expect(b.ok).toBe(false);
+      if (!b.ok) {
+        expect(b.code).toBe("WAVE_IN_PROGRESS");
+        expect(b.error).toContain("w1");
+      }
+    });
+  });
+
+  it("allows new wave once previous is flipped (= done, but kept on record)", async () => {
+    const hub = freshHub();
+    await runInDurableObject(hub, async (i) => {
+      await i.start({ wave_id: "w1", flip_policy: "auto", repos: REPOS });
+      await i.stageReport({ wave_id: "w1", repo: REPOS[0]!.repo, ok: true });
+      await i.stageReport({ wave_id: "w1", repo: REPOS[1]!.repo, ok: true });
+      await i.flipReport({ wave_id: "w1", repo: REPOS[0]!.repo, ok: true });
+      const finalFlip = await i.flipReport({ wave_id: "w1", repo: REPOS[1]!.repo, ok: true });
+      expect(finalFlip.ok).toBe(true);
+      if (finalFlip.ok) expect(finalFlip.data.state).toBe("flipped");
+
+      // 2nd wave OK (hotfix シナリオ)
+      const w2 = await i.start({ wave_id: "w2", flip_policy: "auto", repos: REPOS });
+      expect(w2.ok).toBe(true);
+    });
+  });
+
+  it("allows new wave once previous is rolled-back / failed / aborted", async () => {
+    const hub = freshHub();
+    await runInDurableObject(hub, async (i) => {
+      await i.start({ wave_id: "w1", flip_policy: "auto", repos: REPOS });
+      await i.abort({ wave_id: "w1", aborted_by: "ops", reason: "test" });
+
+      const w2 = await i.start({ wave_id: "w2", flip_policy: "auto", repos: REPOS });
+      expect(w2.ok).toBe(true);
+    });
+  });
+});
+
+describe("ReleaseWaveHub.stageReport / approve / flipReport", () => {
+  it("manual-approval policy: full happy path", async () => {
+    const hub = freshHub();
+    await runInDurableObject(hub, async (i) => {
+      await i.start({ wave_id: "w1", flip_policy: "manual-approval", repos: REPOS });
+
+      let r = await i.stageReport({
+        wave_id: "w1",
+        repo: REPOS[0]!.repo,
+        ok: true,
+        preview_url: "https://preview-a.ippoan.org",
+        flip_from_revision: "a-old",
+      });
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.data.state).toBe("staging");
+
+      r = await i.stageReport({
+        wave_id: "w1",
+        repo: REPOS[1]!.repo,
+        ok: true,
+        flip_from_revision: "b-old",
+      });
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.data.state).toBe("pending-approval");
+
+      r = await i.approve({ wave_id: "w1", approved_by: "ops@example.com" });
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.data.state).toBe("flipping");
+        expect(r.data.approved_by).toBe("ops@example.com");
+      }
+
+      r = await i.flipReport({ wave_id: "w1", repo: REPOS[0]!.repo, ok: true });
+      expect(r.ok).toBe(true);
+      r = await i.flipReport({ wave_id: "w1", repo: REPOS[1]!.repo, ok: true });
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.data.state).toBe("flipped");
+    });
+  });
+
+  it("auto policy: stage all -> auto flip (no approval)", async () => {
+    const hub = freshHub();
+    await runInDurableObject(hub, async (i) => {
+      await i.start({ wave_id: "w1", flip_policy: "auto", repos: REPOS });
+      await i.stageReport({ wave_id: "w1", repo: REPOS[0]!.repo, ok: true });
+      const r = await i.stageReport({ wave_id: "w1", repo: REPOS[1]!.repo, ok: true });
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.data.state).toBe("flipping");
+    });
+  });
+
+  it("stage_report on unknown wave -> NOT_FOUND", async () => {
+    const hub = freshHub();
+    await runInDurableObject(hub, async (i) => {
+      const r = await i.stageReport({
+        wave_id: "ghost",
+        repo: REPOS[0]!.repo,
+        ok: true,
+      });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.code).toBe("NOT_FOUND");
+    });
+  });
+
+  it("propagates state-machine errors as RpcError (INVALID_TRANSITION)", async () => {
+    const hub = freshHub();
+    await runInDurableObject(hub, async (i) => {
+      await i.start({ wave_id: "w1", flip_policy: "manual-approval", repos: REPOS });
+      // approve は pending-approval 以外 (今は staging) で INVALID_TRANSITION
+      const r = await i.approve({ wave_id: "w1", approved_by: "ops" });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.code).toBe("INVALID_TRANSITION");
+    });
+  });
+});
+
+describe("ReleaseWaveHub.rollback / contractApplied", () => {
+  async function buildFlipped(i: ReleaseWaveHub, wave_id: string): Promise<void> {
+    await i.start({ wave_id, flip_policy: "auto", repos: REPOS });
+    await i.stageReport({ wave_id, repo: REPOS[0]!.repo, ok: true });
+    await i.stageReport({ wave_id, repo: REPOS[1]!.repo, ok: true });
+    await i.flipReport({ wave_id, repo: REPOS[0]!.repo, ok: true });
+    await i.flipReport({ wave_id, repo: REPOS[1]!.repo, ok: true });
+  }
+
+  it("rolls back a flipped wave when safe", async () => {
+    const hub = freshHub();
+    await runInDurableObject(hub, async (i) => {
+      await buildFlipped(i, "w1");
+      const r = await i.rollback({ wave_id: "w1", rolled_back_by: "ops" });
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.data.state).toBe("rolled-back");
+        expect(r.data.rolled_back_by).toBe("ops");
+      }
+    });
+  });
+
+  it("contract_applied flips rollback.safe to false on a flipped wave", async () => {
+    const hub = freshHub();
+    await runInDurableObject(hub, async (i) => {
+      await buildFlipped(i, "w1");
+      const c = await i.contractApplied({
+        wave_id: "w1",
+        repo: REPOS[0]!.repo,
+        migration_id: "20260601_001_drop",
+      });
+      expect(c.ok).toBe(true);
+      if (c.ok) {
+        expect(c.data.rollback.safe).toBe(false);
+        expect(c.data.rollback.unsafe_by_migration).toBe("20260601_001_drop");
+      }
+    });
+  });
+
+  it("refuses rollback when unsafe, allows with force=true", async () => {
+    const hub = freshHub();
+    await runInDurableObject(hub, async (i) => {
+      await buildFlipped(i, "w1");
+      await i.contractApplied({
+        wave_id: "w1",
+        repo: REPOS[0]!.repo,
+        migration_id: "m",
+      });
+
+      const r1 = await i.rollback({ wave_id: "w1", rolled_back_by: "ops" });
+      expect(r1.ok).toBe(false);
+      if (!r1.ok) expect(r1.code).toBe("ROLLBACK_UNSAFE");
+
+      const r2 = await i.rollback({
+        wave_id: "w1",
+        rolled_back_by: "ops",
+        force: true,
+      });
+      expect(r2.ok).toBe(true);
+      if (r2.ok) expect(r2.data.state).toBe("rolled-back");
+    });
+  });
+});
+
+describe("ReleaseWaveHub.abort / fail", () => {
+  it("aborts a staging wave", async () => {
+    const hub = freshHub();
+    await runInDurableObject(hub, async (i) => {
+      await i.start({ wave_id: "w1", flip_policy: "auto", repos: REPOS });
+      const r = await i.abort({
+        wave_id: "w1",
+        aborted_by: "ops",
+        reason: "smoke broken",
+      });
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.data.state).toBe("aborted");
+    });
+  });
+
+  it("fails a staging wave via fail event", async () => {
+    const hub = freshHub();
+    await runInDurableObject(hub, async (i) => {
+      await i.start({ wave_id: "w1", flip_policy: "auto", repos: REPOS });
+      const r = await i.fail({ wave_id: "w1", reason: "ci crashed" });
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.data.state).toBe("failed");
+    });
+  });
+});
+
+describe("ReleaseWaveHub.get / list", () => {
+  it("returns NOT_FOUND for missing wave", async () => {
+    const hub = freshHub();
+    await runInDurableObject(hub, async (i) => {
+      const r = await i.get("ghost");
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.code).toBe("NOT_FOUND");
+    });
+  });
+
+  it("returns wave by id", async () => {
+    const hub = freshHub();
+    await runInDurableObject(hub, async (i) => {
+      await i.start({ wave_id: "w1", flip_policy: "auto", repos: REPOS });
+      const r = await i.get("w1");
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.data.wave_id).toBe("w1");
+    });
+  });
+
+  it("list returns waves sorted by started_at descending", async () => {
+    const hub = freshHub();
+    await runInDurableObject(hub, async (i) => {
+      await i.start({ wave_id: "w1", flip_policy: "auto", repos: REPOS });
+      // 1st を rolled-back に進めて serial を解除し、2nd を時刻差で立てる
+      await i.stageReport({ wave_id: "w1", repo: REPOS[0]!.repo, ok: true });
+      await i.stageReport({ wave_id: "w1", repo: REPOS[1]!.repo, ok: true });
+      await i.flipReport({ wave_id: "w1", repo: REPOS[0]!.repo, ok: true });
+      await i.flipReport({ wave_id: "w1", repo: REPOS[1]!.repo, ok: true });
+
+      // 微小に待つ (Date.now() resolution が同 ms なら ordering 不確定なので隔ててから)
+      await new Promise((r) => setTimeout(r, 5));
+      await i.start({ wave_id: "w2", flip_policy: "auto", repos: REPOS });
+
+      const all = await i.list();
+      expect(all.map((w) => w.wave_id)).toEqual(["w2", "w1"]);
+    });
+  });
+});
+
+describe("ReleaseWaveHub.persistence", () => {
+  it("persists state across separate DO calls (= storage write went through)", async () => {
+    const hub = freshHub();
+    // 1 call で start
+    await runInDurableObject(hub, async (i) => {
+      const r = await i.start({ wave_id: "w1", flip_policy: "auto", repos: REPOS });
+      expect(r.ok).toBe(true);
+    });
+    // 別 call で get
+    await runInDurableObject(hub, async (i) => {
+      const r = await i.get("w1");
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.data.wave_id).toBe("w1");
+        expect(r.data.repos).toHaveLength(2);
+      }
+    });
+  });
+
+  it("each test isolation: a fresh hub sees no waves from other tests", async () => {
+    const hub = freshHub();
+    await runInDurableObject(hub, async (i) => {
+      const all = await i.list();
+      expect(all).toEqual([]);
+    });
+  });
+});
+
+// beforeEach: keep no shared state across tests (different DO IDs per test
+// is the isolation mechanism; this hook just resets the local counter cache
+// so test order is deterministic for debugging).
+beforeEach(() => {
+  // no-op (idCounter は global、tests 間で increment 続行)
+});

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -24,6 +24,7 @@ function testEnv(opts: { watched?: string[] } = {}): Env {
         },
       }),
     } as unknown as DurableObjectNamespace,
+    RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
   };
 }
 

--- a/test/secret-gen-page.test.ts
+++ b/test/secret-gen-page.test.ts
@@ -18,6 +18,7 @@ function testEnv(): Env {
       idFromName: () => ({}),
       get: () => ({ fetch: async () => new Response("OK") }),
     } as unknown as DurableObjectNamespace,
+    RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
   };
 }
 

--- a/test/status.test.ts
+++ b/test/status.test.ts
@@ -68,6 +68,7 @@ function testEnv(): Env {
     WEBHOOK_SECRET: { get: async () => WEBHOOK_SECRET } as unknown as SecretsStoreSecret,
     INTERNAL_SHARED_SECRET: { get: async () => "test-internal" } as unknown as SecretsStoreSecret,
     CI_HUB: { idFromName: () => ({}), get: () => hub } as unknown as DurableObjectNamespace,
+    RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
   };
 }
 

--- a/test/tag-release.test.ts
+++ b/test/tag-release.test.ts
@@ -9,6 +9,7 @@ function testEnv(): Env {
     WEBHOOK_SECRET: { get: async () => "test-secret" } as unknown as SecretsStoreSecret,
     INTERNAL_SHARED_SECRET: { get: async () => "test-internal" } as unknown as SecretsStoreSecret,
     CI_HUB: {} as unknown as DurableObjectNamespace,
+    RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
   };
 }
 

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -150,6 +150,7 @@ function testEnv(): Env {
     WEBHOOK_SECRET: { get: async () => WEBHOOK_SECRET } as unknown as SecretsStoreSecret,
     INTERNAL_SHARED_SECRET: { get: async () => "test-internal" } as unknown as SecretsStoreSecret,
     CI_HUB: { idFromName: () => ({}), get: () => hub } as unknown as DurableObjectNamespace,
+    RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
   };
 }
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -26,6 +26,12 @@
       {
         "name": "CI_HUB",
         "class_name": "CIDashboardHub"
+      },
+      {
+        // Release Wave 機構 (issue #137)。1 hub DO に全 wave を records として
+        // 持つ。詳細は src/release-wave/do.ts。
+        "name": "RELEASE_WAVE_HUB",
+        "class_name": "ReleaseWaveHub"
       }
     ]
   },
@@ -33,6 +39,10 @@
     {
       "tag": "v1",
       "new_sqlite_classes": ["CIDashboardHub"]
+    },
+    {
+      "tag": "v2",
+      "new_sqlite_classes": ["ReleaseWaveHub"]
     }
   ],
   // GitHub auth は @ippoan/auth-client-worker 経由で auth-worker に delegate
@@ -106,6 +116,10 @@
           {
             "name": "CI_HUB",
             "class_name": "CIDashboardHub"
+          },
+          {
+            "name": "RELEASE_WAVE_HUB",
+            "class_name": "ReleaseWaveHub"
           }
         ]
       },
@@ -113,6 +127,10 @@
         {
           "tag": "v1",
           "new_sqlite_classes": ["CIDashboardHub"]
+        },
+        {
+          "tag": "v2",
+          "new_sqlite_classes": ["ReleaseWaveHub"]
         }
       ],
       "secrets_store_secrets": [


### PR DESCRIPTION
## 概要

Phase 3b: Release Wave 機構の **Durable Object 層** を追加。Phase 3a の純粋 state machine (`state.ts`) を永続化付き RPC API として wrap する。

## 関連 issue

Refs ippoan/ci-dashboard#137

## 変更点

| ファイル | 内容 |
|---|---|
| `src/release-wave/do.ts` | `ReleaseWaveHub` DO クラス + 全 RPC method |
| `test/release-wave/do.test.ts` | `runInDurableObject` で実 DO instance を起こした統合テスト |
| `src/index.ts` | `ReleaseWaveHub` export、`Env.RELEASE_WAVE_HUB: DurableObjectNamespace` 追加 |
| `wrangler.jsonc` | binding + migration v2 (top-level + env.staging 両方) |
| `test/*.test.ts` (9 files) | 既存 testEnv stub に `RELEASE_WAVE_HUB` を追加 (型整合) |

## RPC API

```ts
class ReleaseWaveHub {
  // life-cycle
  start(input): RpcResult<WaveState>          // serial enforcement
  // events
  stageReport / approve / flipReport
  rollback   (force flag 対応)
  abort / fail
  contractApplied
  // readers
  get(wave_id) / list()
}
```

## 設計判断

| 判断 | 採用 | 理由 |
|---|---|---|
| 単一 hub DO (vs 1 wave 1 instance) | ✓ | listing / alarm() iteration / serial enforcement が `storage.list` 1 call で済む |
| storage key `wave:{wave_id}` | ✓ | prefix iterate でリスト、index 別管理不要 |
| serial enforcement | ✓ | `start()` で全 records を見て in-progress (非 terminal && 非 flipped) wave があれば `WAVE_IN_PROGRESS` で reject。flipped は安定状態なので並行 hotfix wave を許容 |
| 時刻注入 | ✓ | DO 側で `new Date().toISOString()` を 1 回取って state.ts に渡す。state.ts は時刻フリー (Phase 3a で確立) |

## 永続化

- key: `wave:{wave_id}` → JSON serialized `WaveState`
- `list()` は `storage.list({prefix: "wave:"})` → `started_at` 降順 sort
- DO storage は SQLite-backed なので transactional save。同一 method 内で load → transition → save は atomic

## RpcResult エラーコード

state machine のエラーコードに加え DO 層で追加:

| code | 意味 |
|---|---|
| `NOT_FOUND` | wave_id が存在しない |
| `ALREADY_EXISTS` | 同 wave_id で `start()` 重複 |
| `WAVE_IN_PROGRESS` | 別の in-progress wave があり serial enforcement で reject |
| (state.ts 由来) | `INVALID_TRANSITION` / `REPO_NOT_IN_WAVE` / `ROLLBACK_UNSAFE` / `TERMINAL_STATE` / `ALREADY_STARTED` |

## 動作確認

- [x] `tsc --noEmit` で本 PR 追加・修正全ファイル 型エラー無し
- [ ] vitest 実行は CI で確認 (`@ippoan/auth-client-worker` の private package install が必要なため local 不可)

## テスト網羅

- start happy path / ALREADY_EXISTS / serial enforcement (WAVE_IN_PROGRESS) / flipped 後の新 wave OK / aborted 後の新 wave OK
- 全 event (stage_report / approve / flip_report / rollback / contract_applied / abort / fail) の happy / 失敗パス
- get NOT_FOUND / get happy path
- list sorted descending
- 別 DO call 間で state が永続化されること
- test isolation (新 hub は他テストの state を見ない)

## 後続 PR (Phase 3 内)

1. **Phase 3c**: MCP tools 8 個 (`release_wave_*`) を `src/mcp/tools/release-wave.ts` に追加し、本 DO を呼ぶ
2. **Phase 3d**: HTTP endpoint `/mcp/release_wave_contract_applied` (GitHub Actions 通知)
3. **Phase 3e**: Admin UI ページ + CF Access wildcard for `preview-*.ippoan.org`

## メモ

- migration v2 は既存 staging に対して durable な変更。deploy 時に v2 が適用され、既存 `CIDashboardHub` には影響無し
- alarm() による barrier 監視 (= stage 進捗 poll) は本 PR では実装せず、Phase 3c で必要に応じて追加

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm4uPMVQZHWm5eFurYMJif)_