### PR TITLE
feat(release-wave): add 8 MCP tools wrapping ReleaseWaveHub DO (Phase 3c)

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
-import type { AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
+import type { Env } from "../index";
 import { registerActionsTools } from "./tools/actions";
 import { registerPullsTools } from "./tools/pulls";
 import { registerReleasesTools } from "./tools/releases";
@@ -9,8 +9,9 @@ import { registerRepositoryTools } from "./tools/repository";
 import { registerCommitsTools } from "./tools/commits";
 import { registerIssuesTools } from "./tools/issues";
 import { registerProjectsTools } from "./tools/projects";
+import { registerReleaseWaveTools } from "./tools/release-wave";
 
-function createMcpServer(env: AuthClientWorkerEnv): McpServer {
+function createMcpServer(env: Env): McpServer {
   const server = new McpServer({
     name: "ci-dashboard",
     version: "1.0.0",
@@ -24,11 +25,16 @@ function createMcpServer(env: AuthClientWorkerEnv): McpServer {
   registerCommitsTools(server, env);
   registerIssuesTools(server, env);
   registerProjectsTools(server, env);
+  // Release Wave tools (issue #137 Phase 3c)。`RELEASE_WAVE_HUB` binding を
+  // 使うため Env 型で受ける必要があり、createMcpServer の env 型を Env に
+  // widen した。既存 tools は AuthClientWorkerEnv の subset を見るだけなので
+  // Env (extends) を渡しても互換。
+  registerReleaseWaveTools(server, env);
 
   return server;
 }
 
-export async function handleMcpRequest(request: Request, env: AuthClientWorkerEnv): Promise<Response> {
+export async function handleMcpRequest(request: Request, env: Env): Promise<Response> {
   const server = createMcpServer(env);
   const transport = new WebStandardStreamableHTTPServerTransport({
     sessionIdGenerator: undefined, // stateless

--- a/src/mcp/tools/release-wave.ts
+++ b/src/mcp/tools/release-wave.ts
@@ -1,0 +1,313 @@
+/**
+ * Release Wave 機構の MCP tools (8 個)。
+ *
+ * 設計の親 issue: ippoan/ci-dashboard#137
+ *
+ * 各 tool は ReleaseWaveHub DO の RPC を 1:1 で呼び出す薄い wrapper。
+ * 認証は MCP server 側 (auth-worker introspect) で済んでいる前提。
+ * scope は全 tool 共通で `mcp.write` (read 系の status だけ `mcp.read` でも
+ * 十分だが現状 scope 細分化していないので一律 mcp.write)。
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { Env } from "../../index";
+import type { ReleaseWaveHub } from "../../release-wave/do";
+import type { WaveState } from "../../release-wave/types";
+
+// ----------------------------------------------------------------------------
+// Hub helper
+// ----------------------------------------------------------------------------
+
+/** 単一 hub instance を取得 (= 全 wave が同 DO instance に集約)。 */
+function hubStub(env: Env): DurableObjectStub<ReleaseWaveHub> {
+  const id = env.RELEASE_WAVE_HUB.idFromName("singleton");
+  return env.RELEASE_WAVE_HUB.get(id) as DurableObjectStub<ReleaseWaveHub>;
+}
+
+/**
+ * RpcResult → MCP response 形式に変換する共通ヘルパ。
+ *
+ * - 成功時: `WaveState` を JSON 整形して content text に乗せる
+ * - 失敗時: `isError: true` で `{ code, error }` を返す。MCP client (= operator
+ *   や Claude Code) は code を読んで分岐できる
+ */
+function formatRpcResult(
+  result: { ok: true; data: WaveState } | { ok: false; code: string; error: string },
+): { content: Array<{ type: "text"; text: string }>; isError?: boolean } {
+  if (result.ok) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(result.data, null, 2),
+        },
+      ],
+    };
+  }
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({ code: result.code, error: result.error }, null, 2),
+      },
+    ],
+    isError: true,
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Tool registration
+// ----------------------------------------------------------------------------
+
+export function registerReleaseWaveTools(server: McpServer, env: Env): void {
+  // ============================================================
+  // release_wave_start
+  // ============================================================
+  server.registerTool(
+    "release_wave_start",
+    {
+      description:
+        "Start a new release wave coordinating multiple repos. Stages each repo, optionally gates on admin approval, then flips traffic atomically. Refs ippoan/ci-dashboard#137.",
+      inputSchema: {
+        wave_id: z
+          .string()
+          .min(1)
+          .describe("Unique wave identifier (e.g. 'wave_2026_05_27_01')"),
+        flip_policy: z
+          .enum(["manual-approval", "auto"])
+          .describe(
+            "manual-approval: wait for admin approval after stage; auto: flip as soon as all stage complete",
+          ),
+        note: z.string().optional().describe("Free-form note (e.g. release theme)"),
+        repos: z
+          .array(
+            z.object({
+              repo: z.string().describe("owner/name (e.g. 'ippoan/rust-alc-api')"),
+              target_tag: z
+                .string()
+                .describe("Tag to be cut for this wave (e.g. 'v1.42.0')"),
+              head_sha: z.string().describe("HEAD SHA at wave start"),
+            }),
+          )
+          .min(1)
+          .describe("Repos participating in this wave"),
+      },
+      annotations: { readOnlyHint: false },
+    },
+    async ({ wave_id, flip_policy, note, repos }) => {
+      const result = await hubStub(env).start({
+        wave_id,
+        flip_policy,
+        note: note ?? "",
+        repos,
+      });
+      return formatRpcResult(result);
+    },
+  );
+
+  // ============================================================
+  // release_wave_stage
+  // ============================================================
+  server.registerTool(
+    "release_wave_stage",
+    {
+      description:
+        "Callback from a repo's release-wave handler reporting stage completion. ok=true means staged successfully (with preview_url & flip_from_revision); ok=false fails the whole wave. Refs ippoan/ci-dashboard#137.",
+      inputSchema: {
+        wave_id: z.string().min(1),
+        repo: z.string().describe("owner/name reporting the stage result"),
+        ok: z.boolean(),
+        preview_url: z
+          .string()
+          .url()
+          .optional()
+          .describe("Admin-only preview URL (CF Access gated). Set when ok=true."),
+        flip_from_revision: z
+          .string()
+          .optional()
+          .describe(
+            "Pre-flip latest revision (= rollback target). Set when ok=true.",
+          ),
+        error: z.string().optional().describe("Error detail when ok=false."),
+      },
+      annotations: { readOnlyHint: false },
+    },
+    async ({ wave_id, repo, ok, preview_url, flip_from_revision, error }) => {
+      const result = await hubStub(env).stageReport({
+        wave_id,
+        repo,
+        ok,
+        preview_url: preview_url ?? null,
+        flip_from_revision: flip_from_revision ?? null,
+        error: error ?? null,
+      });
+      return formatRpcResult(result);
+    },
+  );
+
+  // ============================================================
+  // release_wave_status
+  // ============================================================
+  server.registerTool(
+    "release_wave_status",
+    {
+      description:
+        "Get the current state of a wave (state machine status, repo progress, rollback safety flag, audit events).",
+      inputSchema: {
+        wave_id: z.string().min(1),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    async ({ wave_id }) => {
+      const result = await hubStub(env).get(wave_id);
+      return formatRpcResult(result);
+    },
+  );
+
+  // ============================================================
+  // release_wave_approve
+  // ============================================================
+  server.registerTool(
+    "release_wave_approve",
+    {
+      description:
+        "Admin approves a pending-approval wave to proceed to flipping. Required for manual-approval policy.",
+      inputSchema: {
+        wave_id: z.string().min(1),
+        approved_by: z
+          .string()
+          .min(1)
+          .describe(
+            "Email or identifier of the admin approving (recorded in audit trail)",
+          ),
+      },
+      annotations: { readOnlyHint: false },
+    },
+    async ({ wave_id, approved_by }) => {
+      const result = await hubStub(env).approve({ wave_id, approved_by });
+      return formatRpcResult(result);
+    },
+  );
+
+  // ============================================================
+  // release_wave_flip
+  // ============================================================
+  // 注: 親 issue では `release_wave_flip` = "operator override (admin 不在時
+  // force flip)" と書かれているが、Phase 3b の DO には override に該当する
+  // 状態遷移が無い (= 純粋 state machine の transition list にも含まれない)。
+  //
+  // 一方で「各 repo handler が flip 完了を ci-dashboard に通知する経路」が
+  // tool として欠けていると wave が flipped 状態に進めないので、ここでは
+  // **per-repo flip callback** として実装する (`release_wave_stage` の flip
+  // 版)。operator override は将来別 tool として追加検討。
+  server.registerTool(
+    "release_wave_flip",
+    {
+      description:
+        "Callback from a repo's release-wave handler reporting flip completion. All repos done -> wave state becomes 'flipped'. Refs ippoan/ci-dashboard#137.",
+      inputSchema: {
+        wave_id: z.string().min(1),
+        repo: z.string().describe("owner/name reporting flip result"),
+        ok: z.boolean(),
+        error: z.string().optional().describe("Error detail when ok=false"),
+      },
+      annotations: { readOnlyHint: false },
+    },
+    async ({ wave_id, repo, ok, error }) => {
+      const result = await hubStub(env).flipReport({
+        wave_id,
+        repo,
+        ok,
+        error: error ?? null,
+      });
+      return formatRpcResult(result);
+    },
+  );
+
+  // ============================================================
+  // release_wave_rollback
+  // ============================================================
+  server.registerTool(
+    "release_wave_rollback",
+    {
+      description:
+        "Roll back a flipped wave to pre-flip revisions. Default refuses if rollback.safe=false (contract migration applied) — pass force=true to override (operator accepts manual DB recovery).",
+      inputSchema: {
+        wave_id: z.string().min(1),
+        rolled_back_by: z
+          .string()
+          .min(1)
+          .describe("Email or identifier of the operator triggering rollback"),
+        force: z
+          .boolean()
+          .optional()
+          .describe(
+            "When rollback.safe=false (post-contract), force=true permits rollback at operator's discretion. Default false (refuse).",
+          ),
+      },
+      annotations: { readOnlyHint: false },
+    },
+    async ({ wave_id, rolled_back_by, force }) => {
+      const result = await hubStub(env).rollback({
+        wave_id,
+        rolled_back_by,
+        force: force === true,
+      });
+      return formatRpcResult(result);
+    },
+  );
+
+  // ============================================================
+  // release_wave_abort
+  // ============================================================
+  server.registerTool(
+    "release_wave_abort",
+    {
+      description:
+        "Abort an in-progress wave before flipping. Valid only in staging / pending-approval states. After flip use rollback instead.",
+      inputSchema: {
+        wave_id: z.string().min(1),
+        aborted_by: z.string().min(1),
+        reason: z.string().min(1).describe("Free-form reason recorded in audit"),
+      },
+      annotations: { readOnlyHint: false },
+    },
+    async ({ wave_id, aborted_by, reason }) => {
+      const result = await hubStub(env).abort({ wave_id, aborted_by, reason });
+      return formatRpcResult(result);
+    },
+  );
+
+  // ============================================================
+  // release_wave_contract_applied
+  // ============================================================
+  server.registerTool(
+    "release_wave_contract_applied",
+    {
+      description:
+        "Notification from a repo's migration deploy that a 'contract' phase migration was applied. Flips wave.rollback.safe to false (= rollback refused without --force). Called from GitHub Actions step.",
+      inputSchema: {
+        wave_id: z.string().min(1),
+        repo: z
+          .string()
+          .describe(
+            "owner/name of the repo whose contract migration was applied",
+          ),
+        migration_id: z
+          .string()
+          .min(1)
+          .describe("Migration file ID (e.g. '20260601_001_drop_legacy_token')"),
+      },
+      annotations: { readOnlyHint: false },
+    },
+    async ({ wave_id, repo, migration_id }) => {
+      const result = await hubStub(env).contractApplied({
+        wave_id,
+        repo,
+        migration_id,
+      });
+      return formatRpcResult(result);
+    },
+  );
+}

--- a/test/mcp/release-wave.test.ts
+++ b/test/mcp/release-wave.test.ts
@@ -1,0 +1,382 @@
+/**
+ * Phase 3c の MCP tools (`registerReleaseWaveTools`) を、fake McpServer +
+ * fake DO stub で薄くテストする。
+ *
+ * 深い state machine / DO 挙動は state.test.ts / do.test.ts で検証済みなので
+ * 本テストの目的は wiring 確認だけ:
+ *  - 各 tool が想定の DO method を呼ぶ
+ *  - input 引数が DO RPC に正しく渡る
+ *  - DO 戻り値が MCP response 形式 (`content[].text` JSON / `isError`) に
+ *    そのまま map される
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { registerReleaseWaveTools } from "../../src/mcp/tools/release-wave";
+import type { Env } from "../../src/index";
+import type { ReleaseWaveHub } from "../../src/release-wave/do";
+
+// ----------------------------------------------------------------------------
+// Fake McpServer: registerTool だけを capture する。
+// ----------------------------------------------------------------------------
+
+type ToolHandler = (
+  input: Record<string, unknown>,
+) => Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}>;
+
+interface RegisteredTool {
+  name: string;
+  config: { description?: string; inputSchema?: unknown };
+  handler: ToolHandler;
+}
+
+function fakeMcpServer(): {
+  registerTool: (
+    name: string,
+    config: RegisteredTool["config"],
+    handler: ToolHandler,
+  ) => void;
+  tools: Map<string, RegisteredTool>;
+} {
+  const tools = new Map<string, RegisteredTool>();
+  return {
+    registerTool(name, config, handler) {
+      tools.set(name, { name, config, handler });
+    },
+    tools,
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Fake env + DO stub
+// ----------------------------------------------------------------------------
+
+/** ReleaseWaveHub の各 RPC method を vitest spy で差し替えた fake stub。 */
+function fakeHub(): {
+  hub: ReleaseWaveHub;
+  spies: Record<string, ReturnType<typeof vi.fn>>;
+} {
+  const spies = {
+    start: vi.fn(),
+    stageReport: vi.fn(),
+    approve: vi.fn(),
+    flipReport: vi.fn(),
+    rollback: vi.fn(),
+    abort: vi.fn(),
+    fail: vi.fn(),
+    contractApplied: vi.fn(),
+    get: vi.fn(),
+    list: vi.fn(),
+  };
+  return { hub: spies as unknown as ReleaseWaveHub, spies };
+}
+
+function fakeEnv(hub: ReleaseWaveHub): Env {
+  const namespace = {
+    idFromName: () => ({}),
+    get: () => hub,
+  } as unknown as DurableObjectNamespace;
+  return {
+    RELEASE_WAVE_HUB: namespace,
+  } as unknown as Env;
+}
+
+// ----------------------------------------------------------------------------
+// Helper: register + retrieve tool
+// ----------------------------------------------------------------------------
+
+function setup(): {
+  tools: Map<string, RegisteredTool>;
+  spies: ReturnType<typeof fakeHub>["spies"];
+} {
+  const { hub, spies } = fakeHub();
+  const env = fakeEnv(hub);
+  const server = fakeMcpServer();
+  registerReleaseWaveTools(
+    server as unknown as Parameters<typeof registerReleaseWaveTools>[0],
+    env,
+  );
+  return { tools: server.tools, spies };
+}
+
+const STUB_OK = { ok: true, data: { wave_id: "w1", state: "staging" } } as const;
+const STUB_ERR = {
+  ok: false,
+  code: "INVALID_TRANSITION" as const,
+  error: "boom",
+};
+
+// ----------------------------------------------------------------------------
+// Registration
+// ----------------------------------------------------------------------------
+
+describe("registerReleaseWaveTools registration", () => {
+  it("registers exactly 8 tools with expected names", () => {
+    const { tools } = setup();
+    expect(Array.from(tools.keys()).sort()).toEqual(
+      [
+        "release_wave_abort",
+        "release_wave_approve",
+        "release_wave_contract_applied",
+        "release_wave_flip",
+        "release_wave_rollback",
+        "release_wave_stage",
+        "release_wave_start",
+        "release_wave_status",
+      ].sort(),
+    );
+  });
+
+  it("status tool is marked readOnly", () => {
+    const { tools } = setup();
+    const t = tools.get("release_wave_status")!;
+    // McpServer types annotations as part of config; surface check
+    expect(
+      (t.config as { annotations?: { readOnlyHint?: boolean } }).annotations
+        ?.readOnlyHint,
+    ).toBe(true);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Wiring per tool
+// ----------------------------------------------------------------------------
+
+describe("release_wave_start", () => {
+  it("calls hub.start with raw inputs and formats success", async () => {
+    const { tools, spies } = setup();
+    spies.start.mockResolvedValue(STUB_OK);
+    const r = await tools.get("release_wave_start")!.handler({
+      wave_id: "w1",
+      flip_policy: "auto",
+      note: "ship it",
+      repos: [{ repo: "ippoan/a", target_tag: "v1.0.0", head_sha: "abc" }],
+    });
+    expect(spies.start).toHaveBeenCalledWith({
+      wave_id: "w1",
+      flip_policy: "auto",
+      note: "ship it",
+      repos: [{ repo: "ippoan/a", target_tag: "v1.0.0", head_sha: "abc" }],
+    });
+    expect(r.isError).toBeUndefined();
+    expect(r.content[0]!.text).toContain('"wave_id"');
+  });
+
+  it("formats RpcError as isError + JSON code/error", async () => {
+    const { tools, spies } = setup();
+    spies.start.mockResolvedValue({
+      ok: false,
+      code: "WAVE_IN_PROGRESS",
+      error: "another wave running",
+    });
+    const r = await tools.get("release_wave_start")!.handler({
+      wave_id: "w2",
+      flip_policy: "auto",
+      repos: [{ repo: "ippoan/a", target_tag: "v1", head_sha: "x" }],
+    });
+    expect(r.isError).toBe(true);
+    const parsed = JSON.parse(r.content[0]!.text);
+    expect(parsed.code).toBe("WAVE_IN_PROGRESS");
+    expect(parsed.error).toContain("running");
+  });
+
+  it("defaults note to '' when omitted", async () => {
+    const { tools, spies } = setup();
+    spies.start.mockResolvedValue(STUB_OK);
+    await tools.get("release_wave_start")!.handler({
+      wave_id: "w1",
+      flip_policy: "auto",
+      repos: [{ repo: "ippoan/a", target_tag: "v1", head_sha: "x" }],
+    });
+    expect(spies.start).toHaveBeenCalledWith(
+      expect.objectContaining({ note: "" }),
+    );
+  });
+});
+
+describe("release_wave_stage", () => {
+  it("passes optional fields through, nullifying when missing", async () => {
+    const { tools, spies } = setup();
+    spies.stageReport.mockResolvedValue(STUB_OK);
+    await tools.get("release_wave_stage")!.handler({
+      wave_id: "w1",
+      repo: "ippoan/a",
+      ok: true,
+    });
+    expect(spies.stageReport).toHaveBeenCalledWith({
+      wave_id: "w1",
+      repo: "ippoan/a",
+      ok: true,
+      preview_url: null,
+      flip_from_revision: null,
+      error: null,
+    });
+  });
+
+  it("passes explicit optional values", async () => {
+    const { tools, spies } = setup();
+    spies.stageReport.mockResolvedValue(STUB_OK);
+    await tools.get("release_wave_stage")!.handler({
+      wave_id: "w1",
+      repo: "ippoan/a",
+      ok: false,
+      error: "build failed",
+    });
+    expect(spies.stageReport).toHaveBeenCalledWith(
+      expect.objectContaining({ ok: false, error: "build failed" }),
+    );
+  });
+});
+
+describe("release_wave_status", () => {
+  it("calls hub.get with wave_id", async () => {
+    const { tools, spies } = setup();
+    spies.get.mockResolvedValue(STUB_OK);
+    await tools.get("release_wave_status")!.handler({ wave_id: "w1" });
+    expect(spies.get).toHaveBeenCalledWith("w1");
+  });
+
+  it("propagates NOT_FOUND as isError", async () => {
+    const { tools, spies } = setup();
+    spies.get.mockResolvedValue({
+      ok: false,
+      code: "NOT_FOUND",
+      error: "no such wave",
+    });
+    const r = await tools.get("release_wave_status")!.handler({
+      wave_id: "ghost",
+    });
+    expect(r.isError).toBe(true);
+    expect(JSON.parse(r.content[0]!.text).code).toBe("NOT_FOUND");
+  });
+});
+
+describe("release_wave_approve", () => {
+  it("forwards approved_by", async () => {
+    const { tools, spies } = setup();
+    spies.approve.mockResolvedValue(STUB_OK);
+    await tools.get("release_wave_approve")!.handler({
+      wave_id: "w1",
+      approved_by: "ops@example.com",
+    });
+    expect(spies.approve).toHaveBeenCalledWith({
+      wave_id: "w1",
+      approved_by: "ops@example.com",
+    });
+  });
+});
+
+describe("release_wave_flip", () => {
+  it("calls flipReport (= per-repo flip callback, not operator override)", async () => {
+    const { tools, spies } = setup();
+    spies.flipReport.mockResolvedValue(STUB_OK);
+    await tools.get("release_wave_flip")!.handler({
+      wave_id: "w1",
+      repo: "ippoan/a",
+      ok: true,
+    });
+    expect(spies.flipReport).toHaveBeenCalledWith({
+      wave_id: "w1",
+      repo: "ippoan/a",
+      ok: true,
+      error: null,
+    });
+  });
+});
+
+describe("release_wave_rollback", () => {
+  it("defaults force to false", async () => {
+    const { tools, spies } = setup();
+    spies.rollback.mockResolvedValue(STUB_OK);
+    await tools.get("release_wave_rollback")!.handler({
+      wave_id: "w1",
+      rolled_back_by: "ops",
+    });
+    expect(spies.rollback).toHaveBeenCalledWith({
+      wave_id: "w1",
+      rolled_back_by: "ops",
+      force: false,
+    });
+  });
+
+  it("passes force=true when provided", async () => {
+    const { tools, spies } = setup();
+    spies.rollback.mockResolvedValue(STUB_OK);
+    await tools.get("release_wave_rollback")!.handler({
+      wave_id: "w1",
+      rolled_back_by: "ops",
+      force: true,
+    });
+    expect(spies.rollback).toHaveBeenCalledWith(
+      expect.objectContaining({ force: true }),
+    );
+  });
+
+  it("propagates ROLLBACK_UNSAFE as isError", async () => {
+    const { tools, spies } = setup();
+    spies.rollback.mockResolvedValue({
+      ok: false,
+      code: "ROLLBACK_UNSAFE",
+      error: "contract migration applied",
+    });
+    const r = await tools.get("release_wave_rollback")!.handler({
+      wave_id: "w1",
+      rolled_back_by: "ops",
+    });
+    expect(r.isError).toBe(true);
+    expect(JSON.parse(r.content[0]!.text).code).toBe("ROLLBACK_UNSAFE");
+  });
+});
+
+describe("release_wave_abort", () => {
+  it("forwards aborted_by + reason", async () => {
+    const { tools, spies } = setup();
+    spies.abort.mockResolvedValue(STUB_OK);
+    await tools.get("release_wave_abort")!.handler({
+      wave_id: "w1",
+      aborted_by: "ops",
+      reason: "smoke broken",
+    });
+    expect(spies.abort).toHaveBeenCalledWith({
+      wave_id: "w1",
+      aborted_by: "ops",
+      reason: "smoke broken",
+    });
+  });
+});
+
+describe("release_wave_contract_applied", () => {
+  it("forwards repo + migration_id", async () => {
+    const { tools, spies } = setup();
+    spies.contractApplied.mockResolvedValue(STUB_OK);
+    await tools.get("release_wave_contract_applied")!.handler({
+      wave_id: "w1",
+      repo: "ippoan/rust-alc-api",
+      migration_id: "20260601_001_drop",
+    });
+    expect(spies.contractApplied).toHaveBeenCalledWith({
+      wave_id: "w1",
+      repo: "ippoan/rust-alc-api",
+      migration_id: "20260601_001_drop",
+    });
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Generic error path (1 経路で代表)
+// ----------------------------------------------------------------------------
+
+describe("error formatting", () => {
+  it("isError true when DO returns ok=false (regardless of code)", async () => {
+    const { tools, spies } = setup();
+    spies.abort.mockResolvedValue(STUB_ERR);
+    const r = await tools.get("release_wave_abort")!.handler({
+      wave_id: "w1",
+      aborted_by: "ops",
+      reason: "test",
+    });
+    expect(r.isError).toBe(true);
+  });
+});


### PR DESCRIPTION
## 概要

Phase 3c: Release Wave 機構の **8 MCP tool** を追加。Phase 3b の `ReleaseWaveHub` DO を 1:1 でラップする薄い MCP wrapper。

## 関連 issue

Refs ippoan/ci-dashboard#137

## 追加 tool 一覧

| tool | DO method | 用途 |
|---|---|---|
| `release_wave_start` | `start` | 新規 wave 開始 (serial enforcement) |
| `release_wave_stage` | `stageReport` | repo handler からの stage 完了 callback |
| `release_wave_status` | `get` | wave 現状取得 (`readOnlyHint: true`) |
| `release_wave_approve` | `approve` | admin 承認 (pending-approval → flipping) |
| `release_wave_flip` (*) | `flipReport` | repo handler からの flip 完了 callback |
| `release_wave_rollback` | `rollback` | 旧 revision 戻し (`--force` で unsafe override) |
| `release_wave_abort` | `abort` | flip 前の中止 |
| `release_wave_contract_applied` | `contractApplied` | GitHub Actions step からの contract 通知 |

### (*) `release_wave_flip` の解釈について

issue では `release_wave_flip` を **"operator override (admin 不在時 force flip)"** と書いているが、Phase 3b の DO に override に該当する state transition が無い (= 純粋 state machine の event list にも含まれない)。一方で各 repo の **flip 完了 callback** が tools から欠けると wave が `flipped` 状態に進めない。

折衷案として、本 PR では `release_wave_flip` を **per-repo flip callback** (= DO の `flipReport`) として実装した。operator override は将来別 tool として追加検討。

## 変更点

- `src/mcp/tools/release-wave.ts` (新規) — 8 tool + `formatRpcResult` ヘルパ
- `src/mcp/server.ts`:
  - `createMcpServer` / `handleMcpRequest` の env 型を `AuthClientWorkerEnv` → `Env` に widen (`RELEASE_WAVE_HUB` binding 使用のため)
  - 既存 tools は subset しか参照しないので互換 (`Env extends AuthClientWorkerEnv`)
  - `registerReleaseWaveTools(server, env)` を末尾に追加
- `test/mcp/release-wave.test.ts` (新規) — fake McpServer + fake DO stub で wiring smoke test

## 設計

```
MCP client (Claude Code, operator UI, GitHub Actions)
    │
    ▼  HTTP / SSE (auth-worker JWT)
ci-dashboard handleMcpRequest()
    │
    ▼  registered tools
release_wave_* tool handler
    │
    ▼  RPC
RELEASE_WAVE_HUB.idFromName("singleton").get(id)
    │
    ▼  hub.start() / hub.stageReport() / ...
ReleaseWaveHub DO
    │
    ▼  transition(state, event)
pure state machine (Phase 3a)
```

## 動作確認

- [x] `tsc --noEmit` で本 PR 追加・修正全ファイル 型エラー無し
- [ ] vitest 実行は CI で確認 (`@ippoan/auth-client-worker` の private package install が必要なため local 不可)

## テスト網羅

- registration: 8 tool が想定 name で登録されること、`release_wave_status` だけ `readOnlyHint: true`
- wiring per tool: 各 tool が想定の DO method を正しい引数で呼ぶこと
- optional 引数: null 化されて DO に渡る (`preview_url` / `flip_from_revision` / `error` / `force`)
- error formatting: DO の `RpcError` が MCP の `isError: true` + JSON `{code, error}` に変換されること

## 後続 PR (Phase 3 内)

1. **Phase 3d**: HTTP endpoint `/mcp/release_wave_contract_applied` を MCP 経由でなく直接受ける経路 (GitHub Actions step が叩く)。MCP は OAuth が必要だが Actions step は binding_jwt 経路で直叩きが望ましい
2. **Phase 3e**: Admin UI ページ (`/release-wave/<wave_id>`) + CF Access wildcard for `preview-*.ippoan.org`

## メモ

- 全 tool は scope `mcp.write` (現状 scope 細分化していないため一律)。`release_wave_status` は意味的には read だが scope 分けは将来課題
- `release_wave_flip` を operator override に再定義したい場合は、state.ts に新 transition `force_flip` を追加 → DO `forceFlip` method → tool wiring の変更で対応可能

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm4uPMVQZHWm5eFurYMJif)_