### PR TITLE
feat(release-wave): add contract_applied HTTP webhook (Phase 3d)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { handleRecheck } from "./recheck";
 import { handleSecretGenPage } from "./secret-gen-page";
 import { handleTagRelease } from "./tag-release";
 import { handleMcpRequest } from "./mcp/server";
+import { handleContractAppliedWebhook } from "./release-wave/webhook";
 import {
   handlePwaManifest,
   handlePwaServiceWorker,
@@ -36,6 +37,11 @@ export interface Env extends AuthClientWorkerEnv {
   CI_HUB: DurableObjectNamespace;
   /** Release Wave 機構の hub DO。Refs #137。 */
   RELEASE_WAVE_HUB: DurableObjectNamespace;
+  /**
+   * GitHub Actions step が `/webhooks/release-wave/contract-applied` を叩く
+   * 際の shared secret (Secrets Store)。Refs #137 Phase 3d。
+   */
+  RELEASE_WAVE_WEBHOOK_SECRET: SecretsStoreSecret;
   // Comma-separated `owner/name` list of repos that don't cut tags. PR merges
   // into the default branch are treated as releases for these. See
   // wrangler.jsonc and src/tagless-repos.ts.
@@ -165,5 +171,12 @@ app.get("/oauth/callback", (c) => handleOAuthCallback(c.req.raw, c.env, OAUTH_OP
 
 // MCP endpoint (Streamable HTTP)
 app.all("/mcp", (c) => handleMcpRequest(c.req.raw, c.env));
+
+// Release Wave: contract migration 適用通知 webhook (Refs #137 Phase 3d)。
+// GitHub Actions step が curl で叩く。MCP 経路と機能等価だが、OAuth 不要の
+// shared secret (`RELEASE_WAVE_WEBHOOK_SECRET`) で済む。
+app.post("/webhooks/release-wave/contract-applied", (c) =>
+  handleContractAppliedWebhook(c.req.raw, c.env),
+);
 
 export default app;

--- a/src/release-wave/do.ts
+++ b/src/release-wave/do.ts
@@ -97,12 +97,28 @@ export interface ContractAppliedInput {
 }
 
 /** RPC で返す統一エラー型。HTTP / MCP 層でそのまま status code に map できる。 */
+export type RpcErrorCode =
+  | TransitionErrorCode
+  | "NOT_FOUND"
+  | "ALREADY_EXISTS"
+  | "WAVE_IN_PROGRESS";
+
 export interface RpcError {
-  code: TransitionErrorCode | "NOT_FOUND" | "ALREADY_EXISTS" | "WAVE_IN_PROGRESS";
+  code: RpcErrorCode;
   error: string;
 }
 
-export type RpcResult<T> = { ok: true; data: T } | { ok: false } & RpcError;
+/**
+ * 全 RPC method 共通の結果型。
+ *
+ * 注意: `| ({ ok: false } & RpcError)` と書くと operator precedence で
+ * narrowing が壊れる (= caller 側 `if (result.ok)` の後で result.data に
+ * アクセスしても TS が false 分岐に詰まる)。明示的 object literal で
+ * 両分岐を書く形に統一する。
+ */
+export type RpcResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; code: RpcErrorCode; error: string };
 
 // ----------------------------------------------------------------------------
 // DO 本体

--- a/src/release-wave/webhook.ts
+++ b/src/release-wave/webhook.ts
@@ -85,11 +85,15 @@ export async function handleContractAppliedWebhook(
   }
   const parsed = requestSchema.safeParse(rawBody);
   if (!parsed.success) {
+    // zod 4 の `error.issues` を読みつつ、フォーマット差異で fail しないよう
+    // `error.message` も含めて返す (= テスト assertion でも path 名でも文言
+    // でも match できる)。
+    const issuesText = parsed.error.issues
+      .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
+      .join("; ");
     return jsonResponse(400, {
       code: "BAD_REQUEST",
-      error: parsed.error.issues
-        .map((i) => `${i.path.join(".")}: ${i.message}`)
-        .join("; "),
+      error: issuesText || parsed.error.message || "validation failed",
     });
   }
 

--- a/src/release-wave/webhook.ts
+++ b/src/release-wave/webhook.ts
@@ -1,0 +1,119 @@
+/**
+ * GitHub Actions step からの contract migration 適用通知を受ける webhook。
+ *
+ * MCP 経路 (`release_wave_contract_applied` tool) は OAuth (auth-worker
+ * 経由) を必要とし、Actions 側で実装が重い。本 webhook は shared secret
+ * 認証のシンプルな HTTP endpoint で、Actions step が curl で叩く想定。
+ *
+ * 認証:
+ *   X-Release-Wave-Webhook-Secret header の constant-time 比較。
+ *   Secrets Store binding `RELEASE_WAVE_WEBHOOK_SECRET` から値取得。
+ *
+ * Body:
+ *   {
+ *     "wave_id": "wave_2026_05_27_01",
+ *     "repo": "ippoan/rust-alc-api",
+ *     "migration_id": "20260601_001_drop_legacy_token"
+ *   }
+ *
+ * 成功時 200 + wave 現状 JSON、失敗時 4xx + { code, error }。
+ *
+ * 設計の親 issue: ippoan/ci-dashboard#137 "release_wave_contract_applied MCP tool 仕様"
+ */
+
+import { z } from "zod";
+import type { Env } from "../index";
+import type { ReleaseWaveHub, RpcResult } from "./do";
+import type { WaveState } from "./types";
+
+const requestSchema = z.object({
+  wave_id: z.string().min(1),
+  repo: z.string().min(1),
+  migration_id: z.string().min(1),
+});
+
+/** constant-time string compare (= timing attack 防止)。 */
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  // Web Crypto に直接 ConstantTimeCompare は無いので XOR sum で代替。
+  // 長さ check を分けたうえで 1 文字ずつ XOR 累算するので timing は均一。
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body, null, 2), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * POST /webhooks/release-wave/contract-applied を処理する。
+ * 全エラーは JSON body で返す (Actions step が parse できるよう)。
+ */
+export async function handleContractAppliedWebhook(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  if (request.method !== "POST") {
+    return jsonResponse(405, { code: "METHOD_NOT_ALLOWED", error: "use POST" });
+  }
+
+  // 1) Secret check
+  const provided = request.headers.get("X-Release-Wave-Webhook-Secret") ?? "";
+  const expected = await env.RELEASE_WAVE_WEBHOOK_SECRET.get();
+  if (!expected) {
+    return jsonResponse(500, {
+      code: "SECRET_NOT_CONFIGURED",
+      error: "RELEASE_WAVE_WEBHOOK_SECRET is not bound",
+    });
+  }
+  if (!constantTimeEqual(provided, expected)) {
+    return jsonResponse(401, { code: "UNAUTHORIZED", error: "invalid webhook secret" });
+  }
+
+  // 2) Body parse + validate
+  let rawBody: unknown;
+  try {
+    rawBody = await request.json();
+  } catch {
+    return jsonResponse(400, { code: "BAD_JSON", error: "request body is not valid JSON" });
+  }
+  const parsed = requestSchema.safeParse(rawBody);
+  if (!parsed.success) {
+    return jsonResponse(400, {
+      code: "BAD_REQUEST",
+      error: parsed.error.issues
+        .map((i) => `${i.path.join(".")}: ${i.message}`)
+        .join("; "),
+    });
+  }
+
+  // 3) Call DO。Workers RPC は戻り値を Disposable で intersect するため、
+  //    TS の discriminated-union narrowing が崩れる。as cast で復元する。
+  const id = env.RELEASE_WAVE_HUB.idFromName("singleton");
+  const stub = env.RELEASE_WAVE_HUB.get(id) as DurableObjectStub<ReleaseWaveHub>;
+  const result = (await stub.contractApplied({
+    wave_id: parsed.data.wave_id,
+    repo: parsed.data.repo,
+    migration_id: parsed.data.migration_id,
+  })) as RpcResult<WaveState>;
+
+  if (result.ok) {
+    return jsonResponse(200, { ok: true, state: result.data });
+  }
+  // DO の RpcError code を HTTP status に map
+  const httpStatus =
+    result.code === "NOT_FOUND" ? 404
+      : result.code === "REPO_NOT_IN_WAVE" ? 404
+      : 409; // INVALID_TRANSITION / TERMINAL_STATE / etc.
+  return jsonResponse(httpStatus, {
+    ok: false,
+    code: result.code,
+    error: result.error,
+  });
+}

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -11,6 +11,7 @@ function testEnv(): Env {
     INTERNAL_SHARED_SECRET: { get: async () => "test-internal" } as unknown as SecretsStoreSecret,
     CI_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
     RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
+    RELEASE_WAVE_WEBHOOK_SECRET: { get: async () => "test-webhook-secret" } as unknown as SecretsStoreSecret,
   };
 }
 

--- a/test/projects-page.test.ts
+++ b/test/projects-page.test.ts
@@ -13,6 +13,7 @@ function testEnv(): Env {
       get: () => ({ fetch: async () => new Response("OK") }),
     } as unknown as DurableObjectNamespace,
     RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
+    RELEASE_WAVE_WEBHOOK_SECRET: { get: async () => "test-webhook-secret" } as unknown as SecretsStoreSecret,
   };
 }
 

--- a/test/release-close-batch.test.ts
+++ b/test/release-close-batch.test.ts
@@ -13,6 +13,7 @@ function testEnv(): Env {
       get: () => ({ fetch: async () => new Response("OK") }),
     } as unknown as DurableObjectNamespace,
     RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
+    RELEASE_WAVE_WEBHOOK_SECRET: { get: async () => "test-webhook-secret" } as unknown as SecretsStoreSecret,
   };
 }
 

--- a/test/release-close.test.ts
+++ b/test/release-close.test.ts
@@ -13,6 +13,7 @@ function testEnv(): Env {
       get: () => ({ fetch: async () => new Response("OK") }),
     } as unknown as DurableObjectNamespace,
     RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
+    RELEASE_WAVE_WEBHOOK_SECRET: { get: async () => "test-webhook-secret" } as unknown as SecretsStoreSecret,
   };
 }
 

--- a/test/release-wave/webhook.test.ts
+++ b/test/release-wave/webhook.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi } from "vitest";
+import { handleContractAppliedWebhook } from "../../src/release-wave/webhook";
+import type { Env } from "../../src/index";
+import type { ReleaseWaveHub } from "../../src/release-wave/do";
+
+// 各 test で hub method の呼び出しと secret 値を切替えられる fake env を作る。
+function fakeEnv(opts: {
+  secret?: string | null;
+  contractAppliedReturn?:
+    | { ok: true; data: unknown }
+    | { ok: false; code: string; error: string };
+}): {
+  env: Env;
+  spy: ReturnType<typeof vi.fn>;
+} {
+  const spy = vi.fn().mockResolvedValue(
+    opts.contractAppliedReturn ?? {
+      ok: true,
+      data: { wave_id: "w1", state: "flipped" },
+    },
+  );
+  const hub = { contractApplied: spy } as unknown as ReleaseWaveHub;
+  const env = {
+    RELEASE_WAVE_HUB: {
+      idFromName: () => ({}),
+      get: () => hub,
+    },
+    RELEASE_WAVE_WEBHOOK_SECRET: {
+      get: async () =>
+        opts.secret === undefined ? "expected-secret" : opts.secret,
+    },
+  } as unknown as Env;
+  return { env, spy };
+}
+
+function jsonRequest(opts: {
+  method?: string;
+  body?: unknown;
+  secret?: string | null;
+}): Request {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (opts.secret !== null && opts.secret !== undefined) {
+    headers["X-Release-Wave-Webhook-Secret"] = opts.secret;
+  }
+  return new Request("https://ci-dashboard.ippoan.org/webhooks/release-wave/contract-applied", {
+    method: opts.method ?? "POST",
+    headers,
+    body: typeof opts.body === "string" ? opts.body : JSON.stringify(opts.body),
+  });
+}
+
+describe("handleContractAppliedWebhook", () => {
+  it("rejects non-POST with 405", async () => {
+    const { env } = fakeEnv({});
+    const resp = await handleContractAppliedWebhook(
+      jsonRequest({ method: "GET", secret: "expected-secret", body: {} }),
+      env,
+    );
+    expect(resp.status).toBe(405);
+    const body = (await resp.json()) as { code: string };
+    expect(body.code).toBe("METHOD_NOT_ALLOWED");
+  });
+
+  it("returns 500 when secret binding is missing", async () => {
+    const { env } = fakeEnv({ secret: null });
+    const resp = await handleContractAppliedWebhook(
+      jsonRequest({
+        secret: "anything",
+        body: {
+          wave_id: "w1",
+          repo: "ippoan/a",
+          migration_id: "m",
+        },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(500);
+    const body = (await resp.json()) as { code: string };
+    expect(body.code).toBe("SECRET_NOT_CONFIGURED");
+  });
+
+  it("rejects with 401 on missing header", async () => {
+    const { env } = fakeEnv({});
+    const resp = await handleContractAppliedWebhook(
+      jsonRequest({
+        secret: null, // do not set header
+        body: { wave_id: "w1", repo: "ippoan/a", migration_id: "m" },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(401);
+    const body = (await resp.json()) as { code: string };
+    expect(body.code).toBe("UNAUTHORIZED");
+  });
+
+  it("rejects with 401 on wrong header value", async () => {
+    const { env } = fakeEnv({});
+    const resp = await handleContractAppliedWebhook(
+      jsonRequest({
+        secret: "wrong-secret",
+        body: { wave_id: "w1", repo: "ippoan/a", migration_id: "m" },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(401);
+  });
+
+  it("rejects with 401 on different-length header (constant-time path)", async () => {
+    const { env } = fakeEnv({});
+    const resp = await handleContractAppliedWebhook(
+      jsonRequest({
+        secret: "short",
+        body: { wave_id: "w1", repo: "ippoan/a", migration_id: "m" },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(401);
+  });
+
+  it("rejects with 400 on non-JSON body", async () => {
+    const { env } = fakeEnv({});
+    const resp = await handleContractAppliedWebhook(
+      jsonRequest({ secret: "expected-secret", body: "not json {" }),
+      env,
+    );
+    expect(resp.status).toBe(400);
+    const body = (await resp.json()) as { code: string };
+    expect(body.code).toBe("BAD_JSON");
+  });
+
+  it("rejects with 400 on missing fields", async () => {
+    const { env } = fakeEnv({});
+    const resp = await handleContractAppliedWebhook(
+      jsonRequest({ secret: "expected-secret", body: { wave_id: "w1" } }),
+      env,
+    );
+    expect(resp.status).toBe(400);
+    const body = (await resp.json()) as { code: string; error: string };
+    expect(body.code).toBe("BAD_REQUEST");
+    expect(body.error).toContain("repo");
+    expect(body.error).toContain("migration_id");
+  });
+
+  it("succeeds (200) when secret OK and DO returns ok", async () => {
+    const { env, spy } = fakeEnv({});
+    const resp = await handleContractAppliedWebhook(
+      jsonRequest({
+        secret: "expected-secret",
+        body: {
+          wave_id: "wave_2026_05_27_01",
+          repo: "ippoan/rust-alc-api",
+          migration_id: "20260601_001_drop",
+        },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { ok: boolean; state: unknown };
+    expect(body.ok).toBe(true);
+    expect(spy).toHaveBeenCalledWith({
+      wave_id: "wave_2026_05_27_01",
+      repo: "ippoan/rust-alc-api",
+      migration_id: "20260601_001_drop",
+    });
+  });
+
+  it("maps INVALID_TRANSITION to 409", async () => {
+    const { env } = fakeEnv({
+      contractAppliedReturn: {
+        ok: false,
+        code: "INVALID_TRANSITION",
+        error: "wave is staging",
+      },
+    });
+    const resp = await handleContractAppliedWebhook(
+      jsonRequest({
+        secret: "expected-secret",
+        body: {
+          wave_id: "w1",
+          repo: "ippoan/a",
+          migration_id: "m",
+        },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(409);
+    const body = (await resp.json()) as { code: string };
+    expect(body.code).toBe("INVALID_TRANSITION");
+  });
+
+  it("maps NOT_FOUND to 404", async () => {
+    const { env } = fakeEnv({
+      contractAppliedReturn: {
+        ok: false,
+        code: "NOT_FOUND",
+        error: "no such wave",
+      },
+    });
+    const resp = await handleContractAppliedWebhook(
+      jsonRequest({
+        secret: "expected-secret",
+        body: { wave_id: "ghost", repo: "ippoan/a", migration_id: "m" },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(404);
+  });
+
+  it("maps REPO_NOT_IN_WAVE to 404", async () => {
+    const { env } = fakeEnv({
+      contractAppliedReturn: {
+        ok: false,
+        code: "REPO_NOT_IN_WAVE",
+        error: "repo not in wave",
+      },
+    });
+    const resp = await handleContractAppliedWebhook(
+      jsonRequest({
+        secret: "expected-secret",
+        body: { wave_id: "w1", repo: "ippoan/unrelated", migration_id: "m" },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(404);
+  });
+});

--- a/test/release-wave/webhook.test.ts
+++ b/test/release-wave/webhook.test.ts
@@ -44,11 +44,18 @@ function jsonRequest(opts: {
   if (opts.secret !== null && opts.secret !== undefined) {
     headers["X-Release-Wave-Webhook-Secret"] = opts.secret;
   }
-  return new Request("https://ci-dashboard.ippoan.org/webhooks/release-wave/contract-applied", {
-    method: opts.method ?? "POST",
-    headers,
-    body: typeof opts.body === "string" ? opts.body : JSON.stringify(opts.body),
-  });
+  const method = opts.method ?? "POST";
+  // GET/HEAD with body は Request constructor が TypeError を投げるので、
+  // body は POST のみで attach する (= method check の test では body 不要)。
+  const init: RequestInit = { method, headers };
+  if (method !== "GET" && method !== "HEAD" && opts.body !== undefined) {
+    init.body =
+      typeof opts.body === "string" ? opts.body : JSON.stringify(opts.body);
+  }
+  return new Request(
+    "https://ci-dashboard.ippoan.org/webhooks/release-wave/contract-applied",
+    init,
+  );
 }
 
 describe("handleContractAppliedWebhook", () => {

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -25,6 +25,7 @@ function testEnv(opts: { watched?: string[] } = {}): Env {
       }),
     } as unknown as DurableObjectNamespace,
     RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
+    RELEASE_WAVE_WEBHOOK_SECRET: { get: async () => "test-webhook-secret" } as unknown as SecretsStoreSecret,
   };
 }
 

--- a/test/secret-gen-page.test.ts
+++ b/test/secret-gen-page.test.ts
@@ -19,6 +19,7 @@ function testEnv(): Env {
       get: () => ({ fetch: async () => new Response("OK") }),
     } as unknown as DurableObjectNamespace,
     RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
+    RELEASE_WAVE_WEBHOOK_SECRET: { get: async () => "test-webhook-secret" } as unknown as SecretsStoreSecret,
   };
 }
 

--- a/test/status.test.ts
+++ b/test/status.test.ts
@@ -69,6 +69,7 @@ function testEnv(): Env {
     INTERNAL_SHARED_SECRET: { get: async () => "test-internal" } as unknown as SecretsStoreSecret,
     CI_HUB: { idFromName: () => ({}), get: () => hub } as unknown as DurableObjectNamespace,
     RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
+    RELEASE_WAVE_WEBHOOK_SECRET: { get: async () => "test-webhook-secret" } as unknown as SecretsStoreSecret,
   };
 }
 

--- a/test/tag-release.test.ts
+++ b/test/tag-release.test.ts
@@ -10,6 +10,7 @@ function testEnv(): Env {
     INTERNAL_SHARED_SECRET: { get: async () => "test-internal" } as unknown as SecretsStoreSecret,
     CI_HUB: {} as unknown as DurableObjectNamespace,
     RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
+    RELEASE_WAVE_WEBHOOK_SECRET: { get: async () => "test-webhook-secret" } as unknown as SecretsStoreSecret,
   };
 }
 

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -151,6 +151,7 @@ function testEnv(): Env {
     INTERNAL_SHARED_SECRET: { get: async () => "test-internal" } as unknown as SecretsStoreSecret,
     CI_HUB: { idFromName: () => ({}), get: () => hub } as unknown as DurableObjectNamespace,
     RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
+    RELEASE_WAVE_WEBHOOK_SECRET: { get: async () => "test-webhook-secret" } as unknown as SecretsStoreSecret,
   };
 }
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -68,6 +68,17 @@
       "binding": "WEBHOOK_SECRET",
       "store_id": "bd7bc91a3e5f4111add4acf6cb4b8733",
       "secret_name": "webhook-secret-ci-dashboard"
+    },
+    // Release Wave webhook (`/webhooks/release-wave/contract-applied`) の
+    // shared secret。GitHub Actions step が `X-Release-Wave-Webhook-Secret`
+    // header に同値を入れて叩く。各 caller repo は GitHub org secret として
+    // 同値を持つ。値は GCP Secret Manager `release-wave-webhook-secret` を
+    // single source of truth とし、両所に投入する (= secrets-rotate-pipe 経路
+    // で同期)。Refs #137 Phase 3d。
+    {
+      "binding": "RELEASE_WAVE_WEBHOOK_SECRET",
+      "store_id": "bd7bc91a3e5f4111add4acf6cb4b8733",
+      "secret_name": "release-wave-webhook-secret"
     }
   ],
   // ci-workflows/secret-verify-gcp.yml が読む宣言。GCP Secret Manager 上に
@@ -78,7 +89,8 @@
   "secrets": {
     "required": [
       "JWT_FOR_CI_DASHBOARD",
-      "webhook-secret-ci-dashboard"
+      "webhook-secret-ci-dashboard",
+      "release-wave-webhook-secret"
     ]
   },
   // staging を実運用 env として扱う (secrets-inventory と同じパターン)。
@@ -134,6 +146,11 @@
         }
       ],
       "secrets_store_secrets": [
+        {
+          "binding": "RELEASE_WAVE_WEBHOOK_SECRET",
+          "store_id": "bd7bc91a3e5f4111add4acf6cb4b8733",
+          "secret_name": "release-wave-webhook-secret"
+        },
         {
           "binding": "INTERNAL_SHARED_SECRET",
           "store_id": "bd7bc91a3e5f4111add4acf6cb4b8733",


### PR DESCRIPTION
## 概要

Phase 3d: GitHub Actions step が **OAuth なし** で contract migration 適用を ci-dashboard に通知できる HTTP webhook を追加。MCP 経路 (`release_wave_contract_applied` tool) と機能等価だが shared secret 認証で済むため curl 1 行で叩ける。

## 関連 issue

Refs ippoan/ci-dashboard#137

## エンドポイント

```
POST /webhooks/release-wave/contract-applied
X-Release-Wave-Webhook-Secret: <shared secret>
Content-Type: application/json

{
  "wave_id":      "wave_2026_05_27_01",
  "repo":         "ippoan/rust-alc-api",
  "migration_id": "20260601_001_drop_legacy_token"
}
```

### Response

| status | body | 意味 |
|---|---|---|
| 200 | `{ ok: true, state: <WaveState> }` | 通知受理、rollback.safe を false に更新 (or idempotent) |
| 400 | `{ code: "BAD_JSON" \| "BAD_REQUEST", error }` | body parse/validate 失敗 |
| 401 | `{ code: "UNAUTHORIZED", error }` | secret 不一致 (constant-time 比較) |
| 404 | `{ code: "NOT_FOUND" \| "REPO_NOT_IN_WAVE", error }` | wave or repo 不在 |
| 409 | `{ code: "INVALID_TRANSITION" \| ..., error }` | state machine 拒否 (e.g. wave が staging のまま) |
| 500 | `{ code: "SECRET_NOT_CONFIGURED" }` | binding 不在 |

## 認証

- Secrets Store binding `RELEASE_WAVE_WEBHOOK_SECRET`
- constant-time 文字列比較 (timing attack 防止)
- 値は GCP Secret Manager `release-wave-webhook-secret` を single source of truth として、各 caller repo の GitHub org secret にも同値投入 (secrets-rotate-pipe 経路で同期予定)

## GitHub Actions step (caller 側) 想定

```yaml
- name: notify ci-dashboard on contract migration
  if: contains(steps.migrate.outputs.applied_phases, 'contract')
  env:
    WEBHOOK_SECRET: ${{ secrets.RELEASE_WAVE_WEBHOOK_SECRET }}
  run: |
    curl -fsS -X POST https://ci-dashboard.ippoan.org/webhooks/release-wave/contract-applied \
      -H "X-Release-Wave-Webhook-Secret: $WEBHOOK_SECRET" \
      -H "Content-Type: application/json" \
      -d '{"wave_id":"...","repo":"${{ github.repository }}","migration_id":"..."}'
```

## 変更点

| ファイル | 内容 |
|---|---|
| `src/release-wave/webhook.ts` (新規) | `handleContractAppliedWebhook(request, env)` |
| `src/release-wave/do.ts` | `RpcResult<T>` 型を明示 object literal の 2 分岐に書き直し (operator precedence bug fix、narrowing 復活) |
| `src/index.ts` | binding 型 + ルート追加 |
| `wrangler.jsonc` | `RELEASE_WAVE_WEBHOOK_SECRET` Secrets Store binding (top-level + env.staging)、`secrets.required` に `release-wave-webhook-secret` 追加 |
| `test/release-wave/webhook.test.ts` (新規) | 11 ケース (auth / parse / DO 連携 / RpcError → HTTP status map) |
| `test/*.test.ts` (9 files) | 既存 testEnv stub に `RELEASE_WAVE_WEBHOOK_SECRET` 追加 (型整合) |

## 設計判断

| 判断 | 採用 | 理由 |
|---|---|---|
| OAuth ではなく shared secret | ✓ | Actions OIDC → binding_jwt grant の auth-worker 対応待ちが Phase 3d をブロックするのを避ける。将来 OIDC 経路ができたら追加し、shared secret は backward compat で残せる |
| MCP tool と並存 | ✓ | MCP 経由は CLI/IDE から、HTTP webhook は Actions から、それぞれ adapter として残す。内部 DO 呼び出しは同じ |
| RpcError code を HTTP status に map | ✓ | NOT_FOUND/REPO_NOT_IN_WAVE→404、その他 transition error→409、auth/parse→4xx、binding 不在→500 |

## 動作確認

- [x] `tsc --noEmit` で本 PR 追加・修正全ファイル 型エラー無し (pre-existing な auth-client-worker resolution エラーは別問題)
- [x] `RpcResult` narrowing bug fix で as RpcResult<WaveState> cast 経路を確立
- [ ] vitest 実行は CI で確認 (`@ippoan/auth-client-worker` の private package install が必要なため local 不可)

## メモ

- 次フェーズ (3e) で admin UI + CF Access wildcard を追加してこの Phase 3 が完結
- 既存 webhook (`/webhook` for GitHub) とは独立した secret / path にしてある (= 同 endpoint に rotate を引きずらない)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm4uPMVQZHWm5eFurYMJif)_