### PR TITLE
feat(release-wave): add admin UI + Cloudflare Access docs (Phase 3e)

### DIFF
--- a/docs/release-wave.md
+++ b/docs/release-wave.md
@@ -1,0 +1,209 @@
+# Release Wave 機構 — 運用ガイド
+
+設計の親 issue: [ippoan/ci-dashboard#137](https://github.com/ippoan/ci-dashboard/issues/137)
+
+ci-dashboard 内に実装した Release Wave 機構の **operator 向け運用ガイド**。
+コード設計は issue #137 の本文を参照。本ドキュメントは Phase 3a〜3e 完了後の
+日常運用 + ワンタイム setup (CF Access wildcard 等) をカバーする。
+
+---
+
+## アーキテクチャ全体図
+
+```
+operator (Cloudflare Access edge gate)
+    │
+    ├─ Admin UI: GET /release-wave, /release-wave/:wave_id
+    │   └─ Action buttons: POST /api/release-wave/:wave_id/{approve|rollback|abort}
+    │
+    └─ MCP tools (Claude Code, OAuth via auth-worker):
+        release_wave_start / _stage / _status / _approve / _flip /
+        _rollback / _abort / _contract_applied
+
+GitHub Actions step (= release-wave-handler reusable):
+    │
+    └─ HTTP webhook (shared secret):
+        POST /webhooks/release-wave/contract-applied
+
+           ↓ (どちらの経路も)
+
+      ReleaseWaveHub DO (1 singleton)
+      ├─ storage: wave:{wave_id} JSON records
+      └─ pure state machine (state.ts) で transition
+
+           ↓ (state=flipping / rollback 時)
+
+      release-wave-gcp (Cloud Run proxy):
+        /cloudrun/flip-traffic
+        /cloudrun/rollback
+        /cloudrun/stage-check
+```
+
+---
+
+## Cloudflare Access setup (ワンタイム)
+
+Admin UI (`/release-wave`) は ci-dashboard 全体に被さる Cloudflare Access の
+edge gate に保護を任せている。`/releases` ページと同じトラストモデル。
+
+### 既存 ci-dashboard.ippoan.org Access policy
+
+ci-dashboard worker の Custom Domain `ci-dashboard.ippoan.org` には既に
+Cloudflare Access Application が付いている前提 (= `/issues` `/projects`
+`/releases` を operator が見るためのもの)。
+
+policy はおおむね:
+
+| 項目 | 値 |
+|---|---|
+| Application name | `ci-dashboard` |
+| Application domain | `ci-dashboard.ippoan.org` |
+| Session duration | 24h |
+| Allow policy | `email == m.tama.ramu@gmail.com` (+ 必要なら他 admin email) |
+| IdP | Google OAuth (既存 SSO) |
+
+Release Wave 機構導入で **追加 setup は不要**。既存の Access Application が
+そのまま `/release-wave` `/api/release-wave/*` も保護する。
+
+### preview-*.ippoan.org wildcard (新規追加が必要)
+
+issue #137 の "Admin Preview Gate" セクションで計画されている、staged
+revision にアクセスするための preview hostname 群を gate するための
+**別の Access Application** を 1 個追加する。
+
+| 項目 | 値 |
+|---|---|
+| Application name | `release-wave-preview` |
+| Application domain | `preview-*.ippoan.org` (wildcard) |
+| Session duration | 24h |
+| Allow policy | `email == m.tama.ramu@gmail.com` (admin allowlist) |
+| IdP | Google OAuth (既存 SSO) |
+
+実 setup 手順 (Cloudflare dashboard):
+
+1. **Zero Trust** → **Access** → **Applications** → **Add an application**
+2. Type: `Self-hosted`
+3. Application name: `release-wave-preview`
+4. Session duration: `24 hours`
+5. Application domain:
+   - Subdomain: `preview-*`
+   - Domain: `ippoan.org`
+   - Path: `(empty)`
+6. **Policies** → **Add a policy**
+   - Policy name: `admins`
+   - Action: `Allow`
+   - Include: `Emails` → `m.tama.ramu@gmail.com`
+7. Save
+
+これで `preview-rust-alc-api.ippoan.org` `preview-auth.ippoan.org` 等の
+hostname に operator がブラウザでアクセスすると Google OAuth に転送 →
+allowlist 一致確認 → staged revision に到達、という流れになる。
+
+各 hostname の DNS / Worker route 配線は release-wave-handler (Phase 4 で
+ci-workflows reusable として実装) 側で stage 時に動的に作る。
+
+### Terraform module 化 (将来)
+
+issue #137 の open question 9 で挙げた「CF Access policy を Terraform で
+管理するか」は **今のところ手動 setup**。CI/CD パイプラインの一部に組み込
+みたくなったら `cloudflare_access_application` リソースを使ったモジュール
+を ci-workflows 内に作る。
+
+---
+
+## MCP tool 経由の運用 (Claude Code / 他 MCP client)
+
+`https://ci-dashboard.ippoan.org/mcp` に OAuth (auth-worker delegation) で
+ログインすると以下 8 tool が叩ける:
+
+| tool | 用途 |
+|---|---|
+| `release_wave_start` | 新規 wave 開始 |
+| `release_wave_stage` | repo handler からの stage 完了 callback |
+| `release_wave_status` | 現状取得 (read-only) |
+| `release_wave_approve` | admin 承認 (pending-approval → flipping) |
+| `release_wave_flip` | repo handler からの flip 完了 callback |
+| `release_wave_rollback` | 旧 revision 戻し (`--force` で unsafe override) |
+| `release_wave_abort` | flip 前の中止 |
+| `release_wave_contract_applied` | GitHub Actions step からの contract 通知 |
+
+Admin UI ボタンと MCP tool は同じ DO RPC を呼ぶので **どちらから操作しても
+同じ結果**。Admin UI は人間 operator 用 (= 視覚的なステート確認 + ワンクリック
+action)、MCP tool は自動化 / IDE 統合用。
+
+---
+
+## GitHub Actions step 経由の運用 (contract migration 通知)
+
+caller repo (e.g. `rust-alc-api`) の migration deploy workflow に以下 step を
+追加:
+
+```yaml
+- name: notify ci-dashboard on contract migration
+  if: contains(steps.migrate.outputs.applied_phases, 'contract')
+  env:
+    WEBHOOK_SECRET: ${{ secrets.RELEASE_WAVE_WEBHOOK_SECRET }}
+  run: |
+    curl -fsS -X POST https://ci-dashboard.ippoan.org/webhooks/release-wave/contract-applied \
+      -H "X-Release-Wave-Webhook-Secret: $WEBHOOK_SECRET" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "wave_id":      "${{ github.event.client_payload.wave_id }}",
+        "repo":         "${{ github.repository }}",
+        "migration_id": "${{ steps.migrate.outputs.contract_migration_id }}"
+      }'
+```
+
+- `RELEASE_WAVE_WEBHOOK_SECRET` (SCREAMING_SNAKE_CASE) は GitHub org secret
+  として投入済。値の source of truth は GCP Secret Manager
+  `release-wave-webhook-secret` (kebab-case)
+- 通知失敗 (= 4xx/5xx) は step fail にしてあえて deploy を止める設計
+  (= rollback safety flag が flip しない状態で contract が走るのを防ぐ)
+
+---
+
+## 日常運用フロー
+
+### 通常の wave (= 失敗なし)
+
+1. operator が `release_wave_start` MCP tool で wave 開始 (`flip_policy:
+   "manual-approval"` 推奨)
+2. 各 repo の release-wave-handler が tag を打ち、stage deploy を実行 →
+   `release_wave_stage` で callback (preview_url + flip_from_revision)
+3. 全 repo staged → wave が `pending-approval` 遷移
+4. operator が preview URL を `preview-*.ippoan.org` でブラウザ確認 (CF Access
+   経由で Google OAuth)
+5. Admin UI で **Approve & Flip** ボタン押下 (or MCP `release_wave_approve`)
+6. 各 repo handler が flip 実行 → `release_wave_flip` callback
+7. 全 repo flipped → wave が `flipped` 遷移
+8. operator が contract migration を別 PR で deploy → migration step が
+   `/webhooks/release-wave/contract-applied` に通知 → `rollback.safe` が
+   `false` に flip
+
+### 失敗 / rollback
+
+- **flip 前 (staging / pending-approval)**: **Abort** ボタン (or MCP
+  `release_wave_abort`) で中止
+- **flip 後 (rollback.safe=true)**: **Rollback** ボタン (or MCP
+  `release_wave_rollback`) で旧 revision に戻す
+- **flip 後 (rollback.safe=false)**: rollback はデフォルト refuse。Admin UI
+  には警告と `(force)` ラベル付きボタンが出るので、operator が DB を手動
+  復旧する覚悟があれば押す (= force=true を裏で渡す)
+
+### Wave 進行中の serial enforcement
+
+- 1 wave が `staging` / `pending-approval` / `flipping` のうちに 2 つ目の
+  wave を `start` しようとすると `WAVE_IN_PROGRESS` で reject される
+- 1 wave が `flipped` 以降は新 wave 可 (= hotfix wave をすぐ走らせるパターン)
+
+---
+
+## トラブルシューティング
+
+| 症状 | 原因の可能性 | 対応 |
+|---|---|---|
+| MCP tool が `WAVE_IN_PROGRESS` を返す | 別 wave が in-progress | `release_wave_status` で確認、必要なら abort/rollback |
+| Admin UI で button が disabled | 現 state でその操作が無効 | hover の title 説明を確認、別 button を使う |
+| 通知 webhook が 401 | secret 不一致 / 古い rotation 値 | secrets-rotate-pipe で 3 所同期再投入 |
+| preview-*.ippoan.org が 403 | CF Access policy 未追加 / email allowlist 外 | 本ドキュメントの "preview-* wildcard" セクション参照 |
+| flip 後 rollback が refuse | contract migration 適用済 | Admin UI の警告を確認、必要なら force 押下 (DB 手動復旧前提) |

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,15 @@ import { handleTagRelease } from "./tag-release";
 import { handleMcpRequest } from "./mcp/server";
 import { handleContractAppliedWebhook } from "./release-wave/webhook";
 import {
+  handleReleaseWaveListPage,
+  handleReleaseWaveDetailPage,
+} from "./release-wave/page";
+import {
+  handleReleaseWaveApprove,
+  handleReleaseWaveRollback,
+  handleReleaseWaveAbort,
+} from "./release-wave/api";
+import {
   handlePwaManifest,
   handlePwaServiceWorker,
   handlePwaIcon,
@@ -177,6 +186,25 @@ app.all("/mcp", (c) => handleMcpRequest(c.req.raw, c.env));
 // shared secret (`RELEASE_WAVE_WEBHOOK_SECRET`) で済む。
 app.post("/webhooks/release-wave/contract-applied", (c) =>
   handleContractAppliedWebhook(c.req.raw, c.env),
+);
+
+// Release Wave admin UI (Refs #137 Phase 3e)。
+// Auth は ci-dashboard 全体に被さる Cloudflare Access (Google OAuth + email
+// allowlist) edge gate に委譲。/releases ページと同じトラストモデル。
+app.get("/release-wave", (c) => handleReleaseWaveListPage(c.env));
+app.get("/release-wave/:wave_id", (c) =>
+  handleReleaseWaveDetailPage(c.env, c.req.param("wave_id")),
+);
+// Action buttons (state 遷移を起こす side-effectful POST)。完了後は
+// 303 で詳細ページに redirect する。
+app.post("/api/release-wave/:wave_id/approve", (c) =>
+  handleReleaseWaveApprove(c.req.raw, c.env, c.req.param("wave_id")),
+);
+app.post("/api/release-wave/:wave_id/rollback", (c) =>
+  handleReleaseWaveRollback(c.req.raw, c.env, c.req.param("wave_id")),
+);
+app.post("/api/release-wave/:wave_id/abort", (c) =>
+  handleReleaseWaveAbort(c.req.raw, c.env, c.req.param("wave_id")),
 );
 
 export default app;

--- a/src/nav-tabs.ts
+++ b/src/nav-tabs.ts
@@ -6,7 +6,13 @@
 // pages self-contained (no external stylesheet to fetch) and avoid the
 // CSS-classname coupling problem if pages grow apart later.
 
-export type TabKey = "dashboard" | "issues" | "projects" | "releases" | "secret-gen";
+export type TabKey =
+  | "dashboard"
+  | "issues"
+  | "projects"
+  | "releases"
+  | "release-wave"
+  | "secret-gen";
 
 interface TabDef {
   key: TabKey | "branch-protection" | "gcp-secrets" | "security-inventory";
@@ -30,6 +36,7 @@ const TABS: ReadonlyArray<TabDef> = [
   { key: "issues",     href: "/issues",     label: "📋 Open Issues" },
   { key: "projects",   href: "/projects",   label: "🗂️ Projects" },
   { key: "releases",   href: "/releases",   label: "🏷️ Releases" },
+  { key: "release-wave", href: "/release-wave", label: "🌊 Release Waves" },
   { key: "secret-gen", href: "/secret-gen", label: "🔐 Secret Generator" },
   {
     key: "branch-protection",

--- a/src/release-wave/api.ts
+++ b/src/release-wave/api.ts
@@ -1,0 +1,140 @@
+/**
+ * Release Wave admin UI の action button が叩く form-POST endpoint。
+ *
+ * 認証は Cloudflare Access edge で担保される (= /releases, /api/release-close
+ * と同じトラストモデル)。本ファイルでは追加 auth check は持たない。
+ * 操作者の email は `Cf-Access-Authenticated-User-Email` header から取得し、
+ * audit trail に記録する。header 不在時 (= dev mode) は "operator" 既定値。
+ *
+ * 設計の親 issue: ippoan/ci-dashboard#137 Phase 3e
+ */
+
+import type { Env } from "../index";
+import type { ReleaseWaveHub, RpcResult } from "./do";
+import type { WaveState } from "./types";
+
+function hubStub(env: Env): DurableObjectStub<ReleaseWaveHub> {
+  const id = env.RELEASE_WAVE_HUB.idFromName("singleton");
+  return env.RELEASE_WAVE_HUB.get(id) as DurableObjectStub<ReleaseWaveHub>;
+}
+
+/** CF Access が転送する authenticated user email を取り出す。dev fallback。 */
+function actorEmail(req: Request): string {
+  const v = req.headers.get("Cf-Access-Authenticated-User-Email");
+  return (v && v.trim()) || "operator";
+}
+
+/** action 完了後、詳細ページに 303 redirect。 */
+function redirectToDetail(wave_id: string): Response {
+  return new Response(null, {
+    status: 303,
+    headers: { Location: `/release-wave/${encodeURIComponent(wave_id)}` },
+  });
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body, null, 2), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function rpcErrorToHttpStatus(code: string): number {
+  if (code === "NOT_FOUND" || code === "REPO_NOT_IN_WAVE") return 404;
+  return 409;
+}
+
+// ----------------------------------------------------------------------------
+// POST /api/release-wave/:wave_id/approve
+// ----------------------------------------------------------------------------
+
+export async function handleReleaseWaveApprove(
+  req: Request,
+  env: Env,
+  wave_id: string,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return jsonResponse(405, { code: "METHOD_NOT_ALLOWED", error: "use POST" });
+  }
+  const result = (await hubStub(env).approve({
+    wave_id,
+    approved_by: actorEmail(req),
+  })) as RpcResult<WaveState>;
+  if (!result.ok) {
+    return jsonResponse(rpcErrorToHttpStatus(result.code), {
+      code: result.code,
+      error: result.error,
+    });
+  }
+  return redirectToDetail(wave_id);
+}
+
+// ----------------------------------------------------------------------------
+// POST /api/release-wave/:wave_id/rollback
+// ----------------------------------------------------------------------------
+
+export async function handleReleaseWaveRollback(
+  req: Request,
+  env: Env,
+  wave_id: string,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return jsonResponse(405, { code: "METHOD_NOT_ALLOWED", error: "use POST" });
+  }
+  // form body 内 `force=true` で unsafe override を許可する経路。
+  // UI 側 (page.ts) で rollback.safe=false の wave 詳細ボタンに force input
+  // を自動付与している。明示 force 無しなら DO が ROLLBACK_UNSAFE で reject。
+  let force = false;
+  try {
+    const form = await req.formData();
+    force = String(form.get("force") ?? "") === "true";
+  } catch {
+    // form-data 以外 (e.g. fetch from JS) は空 form として扱う
+  }
+  const result = (await hubStub(env).rollback({
+    wave_id,
+    rolled_back_by: actorEmail(req),
+    force,
+  })) as RpcResult<WaveState>;
+  if (!result.ok) {
+    return jsonResponse(rpcErrorToHttpStatus(result.code), {
+      code: result.code,
+      error: result.error,
+    });
+  }
+  return redirectToDetail(wave_id);
+}
+
+// ----------------------------------------------------------------------------
+// POST /api/release-wave/:wave_id/abort
+// ----------------------------------------------------------------------------
+
+export async function handleReleaseWaveAbort(
+  req: Request,
+  env: Env,
+  wave_id: string,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return jsonResponse(405, { code: "METHOD_NOT_ALLOWED", error: "use POST" });
+  }
+  let reason = "aborted via admin UI";
+  try {
+    const form = await req.formData();
+    const r = String(form.get("reason") ?? "").trim();
+    if (r) reason = r;
+  } catch {
+    // form-data 以外は default reason
+  }
+  const result = (await hubStub(env).abort({
+    wave_id,
+    aborted_by: actorEmail(req),
+    reason,
+  })) as RpcResult<WaveState>;
+  if (!result.ok) {
+    return jsonResponse(rpcErrorToHttpStatus(result.code), {
+      code: result.code,
+      error: result.error,
+    });
+  }
+  return redirectToDetail(wave_id);
+}

--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -1,0 +1,361 @@
+/**
+ * Release Wave admin UI (HTML server-side rendering)。
+ *
+ * 設計の親 issue: ippoan/ci-dashboard#137 Phase 3e
+ *
+ * 認証は Cloudflare Access edge (= ci-dashboard.ippoan.org 全体に被さる
+ * Google OAuth + email allowlist) で担保される前提。本ファイル内で追加の
+ * auth check は持たない (= /releases や /issues と同じトラストモデル)。
+ *
+ * 提供する 2 ページ:
+ *   GET /release-wave            → 全 wave 一覧
+ *   GET /release-wave/<wave_id>  → 1 wave の詳細 + action ボタン
+ */
+
+import type { Env } from "../index";
+import type { ReleaseWaveHub, RpcResult } from "./do";
+import type { WaveState, WaveStateName } from "./types";
+import { renderTabs, TAB_STYLES } from "../nav-tabs";
+
+// ----------------------------------------------------------------------------
+// Small HTML helpers
+// ----------------------------------------------------------------------------
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+/** state name → 表示色 (CSS hex)。 */
+function stateColor(state: WaveStateName): string {
+  switch (state) {
+    case "staging":
+      return "#9aa0a6"; // gray
+    case "pending-approval":
+      return "#f29900"; // amber
+    case "flipping":
+      return "#1a73e8"; // blue
+    case "flipped":
+      return "#188038"; // green
+    case "rolled-back":
+      return "#a142f4"; // purple
+    case "failed":
+      return "#d93025"; // red
+    case "aborted":
+      return "#5f6368"; // dark gray
+  }
+}
+
+function htmlResponse(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+const COMMON_STYLES = `
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif; background: #f8f9fa; color: #202124;
+    margin: 0; padding: 20px; }
+  h1, h2, h3 { margin-top: 0; }
+  a { color: #1a73e8; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  table { border-collapse: collapse; width: 100%; background: #fff; margin: 8px 0; }
+  th, td { padding: 8px 12px; text-align: left; border-bottom: 1px solid #e8eaed; }
+  th { background: #f1f3f4; font-weight: 600; font-size: 13px; color: #5f6368; }
+  td { font-size: 14px; }
+  .container { max-width: 1100px; margin: 0 auto; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 10px;
+    color: #fff; font-size: 12px; font-weight: 600; }
+  .empty { padding: 24px; color: #5f6368; text-align: center; font-style: italic; }
+  .actions { margin: 12px 0; }
+  .actions form { display: inline-block; margin-right: 8px; }
+  .actions button { background: #1a73e8; color: #fff; border: none;
+    padding: 8px 16px; border-radius: 4px; cursor: pointer; font-size: 14px;
+    font-weight: 500; }
+  .actions button.danger { background: #d93025; }
+  .actions button.warn { background: #f29900; }
+  .actions button:disabled { background: #dadce0; cursor: not-allowed; }
+  pre { background: #f1f3f4; padding: 12px; border-radius: 4px; overflow: auto;
+    font-size: 12px; line-height: 1.5; }
+  .section { background: #fff; padding: 16px 20px; margin: 16px 0;
+    border-radius: 8px; box-shadow: 0 1px 2px rgba(0,0,0,0.04); }
+  .nav { color: #5f6368; font-size: 13px; margin-bottom: 12px; }
+  .breadcrumb a { color: #5f6368; }
+  .meta { color: #5f6368; font-size: 13px; }
+  .unsafe { background: #fce8e6; border: 1px solid #d93025; padding: 8px 12px;
+    border-radius: 4px; margin: 8px 0; color: #a50e0e; font-size: 13px; }
+  .ok { color: #188038; }
+  .err { color: #d93025; }
+  .pending { color: #9aa0a6; }
+`;
+
+// ----------------------------------------------------------------------------
+// Hub access
+// ----------------------------------------------------------------------------
+
+function hubStub(env: Env): DurableObjectStub<ReleaseWaveHub> {
+  const id = env.RELEASE_WAVE_HUB.idFromName("singleton");
+  return env.RELEASE_WAVE_HUB.get(id) as DurableObjectStub<ReleaseWaveHub>;
+}
+
+// ----------------------------------------------------------------------------
+// GET /release-wave  →  全 wave 一覧
+// ----------------------------------------------------------------------------
+
+export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
+  const waves = (await hubStub(env).list()) as WaveState[];
+
+  const rows = waves.length === 0
+    ? `<tr><td colspan="5" class="empty">No release waves yet.</td></tr>`
+    : waves
+        .map((w) => {
+          const repos = w.repos.map((r) => escapeHtml(r.repo)).join(", ");
+          return `
+            <tr>
+              <td><a href="/release-wave/${encodeURIComponent(w.wave_id)}">${escapeHtml(w.wave_id)}</a></td>
+              <td><span class="badge" style="background:${stateColor(w.state)}">${escapeHtml(w.state)}</span></td>
+              <td class="meta">${escapeHtml(w.started_at)}</td>
+              <td class="meta">${escapeHtml(w.flip_policy)}</td>
+              <td class="meta">${repos}</td>
+            </tr>`;
+        })
+        .join("");
+
+  const html = `<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <title>Release Waves</title>
+  <style>${COMMON_STYLES}${TAB_STYLES}</style>
+</head>
+<body>
+  <div class="container">
+    ${renderTabs("release-wave")}
+    <h1>Release Waves</h1>
+    <p class="meta">
+      Cross-repo coordinated release flows. Refs
+      <a href="https://github.com/ippoan/ci-dashboard/issues/137">#137</a>.
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th>Wave ID</th>
+          <th>State</th>
+          <th>Started At</th>
+          <th>Flip Policy</th>
+          <th>Repos</th>
+        </tr>
+      </thead>
+      <tbody>${rows}</tbody>
+    </table>
+  </div>
+</body>
+</html>`;
+
+  return htmlResponse(html);
+}
+
+// ----------------------------------------------------------------------------
+// GET /release-wave/<wave_id>  →  詳細 + action buttons
+// ----------------------------------------------------------------------------
+
+export async function handleReleaseWaveDetailPage(
+  env: Env,
+  wave_id: string,
+): Promise<Response> {
+  const result = (await hubStub(env).get(wave_id)) as RpcResult<WaveState>;
+  if (!result.ok) {
+    if (result.code === "NOT_FOUND") {
+      return htmlResponse(notFoundHtml(wave_id), 404);
+    }
+    return htmlResponse(errorHtml(result.code, result.error), 500);
+  }
+  const w = result.data;
+
+  // ---- Actions (state-dependent) ----
+  const canApprove = w.state === "pending-approval";
+  const canRollback = w.state === "flipped";
+  const canAbort = w.state === "staging" || w.state === "pending-approval";
+
+  const rollbackDisabledNote = !w.rollback.safe
+    ? `<div class="unsafe">
+         Rollback is <strong>unsafe</strong> (${escapeHtml(w.rollback.unsafe_reason ?? "")}).
+         The button below will pass <code>force=true</code> — manual DB recovery
+         is your responsibility.
+       </div>`
+    : "";
+
+  const actionsBlock = `
+    <div class="actions">
+      <form method="post" action="/api/release-wave/${encodeURIComponent(w.wave_id)}/approve">
+        <button type="submit" ${canApprove ? "" : "disabled"}
+          title="Approve a pending-approval wave to proceed to flipping">
+          Approve &amp; Flip
+        </button>
+      </form>
+      <form method="post" action="/api/release-wave/${encodeURIComponent(w.wave_id)}/rollback">
+        ${!w.rollback.safe ? `<input type="hidden" name="force" value="true">` : ""}
+        <button type="submit" class="danger" ${canRollback ? "" : "disabled"}
+          title="Roll the wave back to pre-flip revisions">
+          Rollback${!w.rollback.safe ? " (force)" : ""}
+        </button>
+      </form>
+      <form method="post" action="/api/release-wave/${encodeURIComponent(w.wave_id)}/abort">
+        <button type="submit" class="warn" ${canAbort ? "" : "disabled"}
+          title="Abort before flip (valid in staging / pending-approval only)">
+          Abort
+        </button>
+      </form>
+    </div>
+    ${rollbackDisabledNote}
+  `;
+
+  // ---- Repos table ----
+  const reposRows = w.repos
+    .map((r) => {
+      const stageCell = r.stage_status === "done"
+        ? `<span class="ok">done</span>`
+        : r.stage_status === "failed"
+        ? `<span class="err">failed</span>`
+        : `<span class="pending">pending</span>`;
+      const flipCell = r.flip_status === "done"
+        ? `<span class="ok">done</span>`
+        : r.flip_status === "failed"
+        ? `<span class="err">failed</span>`
+        : `<span class="pending">pending</span>`;
+      const previewCell = r.preview_url
+        ? `<a href="${escapeHtml(r.preview_url)}" target="_blank" rel="noopener">${escapeHtml(r.preview_url)}</a>`
+        : `<span class="meta">—</span>`;
+      const rollbackTargetCell = r.flip_from_revision
+        ? escapeHtml(r.flip_from_revision)
+        : `<span class="meta">—</span>`;
+      const errCell = r.stage_error || r.flip_error
+        ? `<span class="err">${escapeHtml(r.stage_error ?? r.flip_error ?? "")}</span>`
+        : `<span class="meta">—</span>`;
+      return `
+        <tr>
+          <td>${escapeHtml(r.repo)}</td>
+          <td>${escapeHtml(r.target_tag)}</td>
+          <td>${stageCell}</td>
+          <td>${flipCell}</td>
+          <td>${previewCell}</td>
+          <td class="meta">${rollbackTargetCell}</td>
+          <td>${errCell}</td>
+        </tr>`;
+    })
+    .join("");
+
+  // ---- Events timeline (newest first) ----
+  const eventsHtml = w.events
+    .slice()
+    .reverse()
+    .map((e) => {
+      return `<li><span class="meta">${escapeHtml(e.at)}</span> &mdash; <strong>${escapeHtml(e.kind)}</strong>: ${escapeHtml(e.summary)}</li>`;
+    })
+    .join("");
+
+  const rollbackSafetyHtml = w.rollback.safe
+    ? `<p class="ok">rollback.safe = <strong>true</strong> (no contract migration applied yet)</p>`
+    : `<p class="err">rollback.safe = <strong>false</strong></p>
+       <p class="meta">unsafe_reason: ${escapeHtml(w.rollback.unsafe_reason ?? "")}</p>
+       <p class="meta">unsafe_since: ${escapeHtml(w.rollback.unsafe_since ?? "")}</p>
+       <p class="meta">unsafe_by_migration: ${escapeHtml(w.rollback.unsafe_by_migration ?? "")}</p>`;
+
+  const html = `<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <title>Wave ${escapeHtml(w.wave_id)} &mdash; ci-dashboard</title>
+  <style>${COMMON_STYLES}${TAB_STYLES}</style>
+</head>
+<body>
+  <div class="container">
+    ${renderTabs("release-wave")}
+    <div class="nav breadcrumb">
+      <a href="/release-wave">Release Waves</a> &raquo; ${escapeHtml(w.wave_id)}
+    </div>
+    <h1>
+      ${escapeHtml(w.wave_id)}
+      <span class="badge" style="background:${stateColor(w.state)}">${escapeHtml(w.state)}</span>
+    </h1>
+    <p class="meta">
+      flip_policy: <strong>${escapeHtml(w.flip_policy)}</strong> &middot;
+      started_at: ${escapeHtml(w.started_at)}
+      ${w.note ? ` &middot; note: ${escapeHtml(w.note)}` : ""}
+    </p>
+
+    <div class="section">
+      <h2>Actions</h2>
+      ${actionsBlock}
+    </div>
+
+    <div class="section">
+      <h2>Rollback Safety</h2>
+      ${rollbackSafetyHtml}
+    </div>
+
+    <div class="section">
+      <h2>Repos</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Repo</th>
+            <th>Target Tag</th>
+            <th>Stage</th>
+            <th>Flip</th>
+            <th>Preview URL</th>
+            <th>Rollback Target</th>
+            <th>Error</th>
+          </tr>
+        </thead>
+        <tbody>${reposRows}</tbody>
+      </table>
+    </div>
+
+    <div class="section">
+      <h2>Events</h2>
+      <ul>${eventsHtml}</ul>
+    </div>
+
+    <div class="section">
+      <h2>Raw State (JSON)</h2>
+      <pre>${escapeHtml(JSON.stringify(w, null, 2))}</pre>
+    </div>
+  </div>
+</body>
+</html>`;
+
+  return htmlResponse(html);
+}
+
+// ----------------------------------------------------------------------------
+// 404 / 500 HTML
+// ----------------------------------------------------------------------------
+
+function notFoundHtml(wave_id: string): string {
+  return `<!doctype html>
+<html lang="ja">
+<head><meta charset="utf-8"><title>Wave not found</title><style>${COMMON_STYLES}</style></head>
+<body><div class="container">
+  <div class="nav breadcrumb">
+    <a href="/">ci-dashboard</a> &raquo; <a href="/release-wave">Release Waves</a> &raquo; (not found)
+  </div>
+  <h1>Wave not found</h1>
+  <p>No wave with id <code>${escapeHtml(wave_id)}</code> exists in the hub.</p>
+</div></body></html>`;
+}
+
+function errorHtml(code: string, error: string): string {
+  return `<!doctype html>
+<html lang="ja">
+<head><meta charset="utf-8"><title>Error</title><style>${COMMON_STYLES}</style></head>
+<body><div class="container">
+  <h1>Error</h1>
+  <p><strong>${escapeHtml(code)}</strong>: ${escapeHtml(error)}</p>
+</div></body></html>`;
+}

--- a/test/release-wave/api.test.ts
+++ b/test/release-wave/api.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  handleReleaseWaveApprove,
+  handleReleaseWaveRollback,
+  handleReleaseWaveAbort,
+} from "../../src/release-wave/api";
+import type { Env } from "../../src/index";
+import type { ReleaseWaveHub } from "../../src/release-wave/do";
+
+function fakeEnv(spyOverrides: Partial<Record<string, ReturnType<typeof vi.fn>>> = {}): {
+  env: Env;
+  spies: Record<string, ReturnType<typeof vi.fn>>;
+} {
+  const spies = {
+    approve: spyOverrides.approve ?? vi.fn().mockResolvedValue({ ok: true, data: { wave_id: "w1" } }),
+    rollback: spyOverrides.rollback ?? vi.fn().mockResolvedValue({ ok: true, data: { wave_id: "w1" } }),
+    abort: spyOverrides.abort ?? vi.fn().mockResolvedValue({ ok: true, data: { wave_id: "w1" } }),
+  };
+  const hub = spies as unknown as ReleaseWaveHub;
+  const env = {
+    RELEASE_WAVE_HUB: {
+      idFromName: () => ({}),
+      get: () => hub,
+    },
+  } as unknown as Env;
+  return { env, spies };
+}
+
+function postRequest(
+  path: string,
+  opts: {
+    formBody?: Record<string, string>;
+    actorEmail?: string;
+  } = {},
+): Request {
+  const headers: Record<string, string> = {};
+  if (opts.actorEmail) {
+    headers["Cf-Access-Authenticated-User-Email"] = opts.actorEmail;
+  }
+  let body: string | undefined;
+  if (opts.formBody) {
+    const params = new URLSearchParams();
+    for (const [k, v] of Object.entries(opts.formBody)) params.set(k, v);
+    body = params.toString();
+    headers["Content-Type"] = "application/x-www-form-urlencoded";
+  }
+  return new Request(`https://ci-dashboard.ippoan.org${path}`, {
+    method: "POST",
+    headers,
+    body,
+  });
+}
+
+// ============================================================================
+// /api/release-wave/:wave_id/approve
+// ============================================================================
+
+describe("handleReleaseWaveApprove", () => {
+  it("calls hub.approve with CF Access email", async () => {
+    const { env, spies } = fakeEnv();
+    const req = postRequest("/api/release-wave/w1/approve", {
+      actorEmail: "ops@example.com",
+    });
+    const resp = await handleReleaseWaveApprove(req, env, "w1");
+    expect(resp.status).toBe(303);
+    expect(resp.headers.get("Location")).toBe("/release-wave/w1");
+    expect(spies.approve).toHaveBeenCalledWith({
+      wave_id: "w1",
+      approved_by: "ops@example.com",
+    });
+  });
+
+  it("falls back to 'operator' when CF Access header missing", async () => {
+    const { env, spies } = fakeEnv();
+    const req = postRequest("/api/release-wave/w1/approve", {});
+    await handleReleaseWaveApprove(req, env, "w1");
+    expect(spies.approve).toHaveBeenCalledWith({
+      wave_id: "w1",
+      approved_by: "operator",
+    });
+  });
+
+  it("returns 405 on non-POST", async () => {
+    const { env } = fakeEnv();
+    const req = new Request("https://ci-dashboard.ippoan.org/api/release-wave/w1/approve", {
+      method: "GET",
+    });
+    const resp = await handleReleaseWaveApprove(req, env, "w1");
+    expect(resp.status).toBe(405);
+  });
+
+  it("maps NOT_FOUND to 404", async () => {
+    const { env } = fakeEnv({
+      approve: vi.fn().mockResolvedValue({
+        ok: false,
+        code: "NOT_FOUND",
+        error: "no wave",
+      }),
+    });
+    const req = postRequest("/api/release-wave/ghost/approve", {
+      actorEmail: "x@y",
+    });
+    const resp = await handleReleaseWaveApprove(req, env, "ghost");
+    expect(resp.status).toBe(404);
+  });
+
+  it("maps INVALID_TRANSITION to 409", async () => {
+    const { env } = fakeEnv({
+      approve: vi.fn().mockResolvedValue({
+        ok: false,
+        code: "INVALID_TRANSITION",
+        error: "state is staging",
+      }),
+    });
+    const req = postRequest("/api/release-wave/w1/approve", {
+      actorEmail: "x@y",
+    });
+    const resp = await handleReleaseWaveApprove(req, env, "w1");
+    expect(resp.status).toBe(409);
+  });
+});
+
+// ============================================================================
+// /api/release-wave/:wave_id/rollback
+// ============================================================================
+
+describe("handleReleaseWaveRollback", () => {
+  it("rolls back without force when form omits it", async () => {
+    const { env, spies } = fakeEnv();
+    const req = postRequest("/api/release-wave/w1/rollback", {
+      actorEmail: "ops@x",
+    });
+    const resp = await handleReleaseWaveRollback(req, env, "w1");
+    expect(resp.status).toBe(303);
+    expect(spies.rollback).toHaveBeenCalledWith({
+      wave_id: "w1",
+      rolled_back_by: "ops@x",
+      force: false,
+    });
+  });
+
+  it("rolls back with force=true when form has it", async () => {
+    const { env, spies } = fakeEnv();
+    const req = postRequest("/api/release-wave/w1/rollback", {
+      actorEmail: "ops@x",
+      formBody: { force: "true" },
+    });
+    await handleReleaseWaveRollback(req, env, "w1");
+    expect(spies.rollback).toHaveBeenCalledWith(
+      expect.objectContaining({ force: true }),
+    );
+  });
+
+  it("returns 405 on GET", async () => {
+    const { env } = fakeEnv();
+    const req = new Request("https://ci-dashboard.ippoan.org/api/release-wave/w1/rollback", {
+      method: "GET",
+    });
+    const resp = await handleReleaseWaveRollback(req, env, "w1");
+    expect(resp.status).toBe(405);
+  });
+
+  it("maps ROLLBACK_UNSAFE to 409", async () => {
+    const { env } = fakeEnv({
+      rollback: vi.fn().mockResolvedValue({
+        ok: false,
+        code: "ROLLBACK_UNSAFE",
+        error: "contract applied",
+      }),
+    });
+    const req = postRequest("/api/release-wave/w1/rollback", {
+      actorEmail: "ops@x",
+    });
+    const resp = await handleReleaseWaveRollback(req, env, "w1");
+    expect(resp.status).toBe(409);
+    const body = (await resp.json()) as { code: string };
+    expect(body.code).toBe("ROLLBACK_UNSAFE");
+  });
+
+  it("treats empty body as no force (= safe path)", async () => {
+    const { env, spies } = fakeEnv();
+    const req = new Request("https://ci-dashboard.ippoan.org/api/release-wave/w1/rollback", {
+      method: "POST",
+      // no body, no Content-Type
+    });
+    await handleReleaseWaveRollback(req, env, "w1");
+    expect(spies.rollback).toHaveBeenCalledWith(
+      expect.objectContaining({ force: false }),
+    );
+  });
+});
+
+// ============================================================================
+// /api/release-wave/:wave_id/abort
+// ============================================================================
+
+describe("handleReleaseWaveAbort", () => {
+  it("uses default reason when form omits it", async () => {
+    const { env, spies } = fakeEnv();
+    const req = postRequest("/api/release-wave/w1/abort", {
+      actorEmail: "ops@x",
+    });
+    const resp = await handleReleaseWaveAbort(req, env, "w1");
+    expect(resp.status).toBe(303);
+    expect(spies.abort).toHaveBeenCalledWith({
+      wave_id: "w1",
+      aborted_by: "ops@x",
+      reason: "aborted via admin UI",
+    });
+  });
+
+  it("uses provided reason when form has it", async () => {
+    const { env, spies } = fakeEnv();
+    const req = postRequest("/api/release-wave/w1/abort", {
+      actorEmail: "ops@x",
+      formBody: { reason: "smoke broken" },
+    });
+    await handleReleaseWaveAbort(req, env, "w1");
+    expect(spies.abort).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "smoke broken" }),
+    );
+  });
+
+  it("returns 405 on GET", async () => {
+    const { env } = fakeEnv();
+    const req = new Request("https://ci-dashboard.ippoan.org/api/release-wave/w1/abort", {
+      method: "GET",
+    });
+    const resp = await handleReleaseWaveAbort(req, env, "w1");
+    expect(resp.status).toBe(405);
+  });
+
+  it("maps INVALID_TRANSITION to 409 (e.g. abort after flip)", async () => {
+    const { env } = fakeEnv({
+      abort: vi.fn().mockResolvedValue({
+        ok: false,
+        code: "INVALID_TRANSITION",
+        error: "wave is flipped, use rollback",
+      }),
+    });
+    const req = postRequest("/api/release-wave/w1/abort", {
+      actorEmail: "ops@x",
+    });
+    const resp = await handleReleaseWaveAbort(req, env, "w1");
+    expect(resp.status).toBe(409);
+  });
+});

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -1,0 +1,381 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  handleReleaseWaveListPage,
+  handleReleaseWaveDetailPage,
+} from "../../src/release-wave/page";
+import type { Env } from "../../src/index";
+import type { ReleaseWaveHub } from "../../src/release-wave/do";
+import type { WaveState } from "../../src/release-wave/types";
+
+function fakeEnv(opts: {
+  listReturn?: WaveState[];
+  getReturn?:
+    | { ok: true; data: WaveState }
+    | { ok: false; code: string; error: string };
+}): Env {
+  const hub = {
+    list: vi.fn().mockResolvedValue(opts.listReturn ?? []),
+    get: vi.fn().mockResolvedValue(
+      opts.getReturn ?? {
+        ok: false,
+        code: "NOT_FOUND",
+        error: "no wave",
+      },
+    ),
+  } as unknown as ReleaseWaveHub;
+  return {
+    RELEASE_WAVE_HUB: {
+      idFromName: () => ({}),
+      get: () => hub,
+    },
+  } as unknown as Env;
+}
+
+function makeWave(over: Partial<WaveState> = {}): WaveState {
+  const now = "2026-05-27T10:00:00Z";
+  return {
+    wave_id: "wave_test_01",
+    state: "staging",
+    flip_policy: "manual-approval",
+    note: "test",
+    repos: [
+      {
+        repo: "ippoan/rust-alc-api",
+        target_tag: "v1.1.0",
+        head_sha: "abc",
+        stage_status: "pending",
+        preview_url: null,
+        stage_error: null,
+        flip_status: "pending",
+        flip_error: null,
+        flip_from_revision: null,
+        rolled_back_to_revision: null,
+      },
+    ],
+    rollback: {
+      safe: true,
+      unsafe_reason: null,
+      unsafe_since: null,
+      unsafe_by_migration: null,
+    },
+    started_at: now,
+    staged_at: null,
+    approved_at: null,
+    approved_by: null,
+    flipped_at: null,
+    rolled_back_at: null,
+    rolled_back_by: null,
+    failed_at: null,
+    aborted_at: null,
+    events: [
+      {
+        at: now,
+        kind: "start",
+        summary: "wave started",
+        detail: { repos: ["ippoan/rust-alc-api"] },
+      },
+    ],
+    ...over,
+  };
+}
+
+// ============================================================================
+// /release-wave list page
+// ============================================================================
+
+describe("handleReleaseWaveListPage", () => {
+  it("renders empty state when no waves", async () => {
+    const env = fakeEnv({ listReturn: [] });
+    const resp = await handleReleaseWaveListPage(env);
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("Content-Type")).toContain("text/html");
+    const html = await resp.text();
+    expect(html).toContain("Release Waves");
+    expect(html).toContain("No release waves yet");
+  });
+
+  it("lists each wave with state badge + detail link", async () => {
+    const env = fakeEnv({
+      listReturn: [
+        makeWave({ wave_id: "w1", state: "flipped" }),
+        makeWave({ wave_id: "w2", state: "staging" }),
+      ],
+    });
+    const resp = await handleReleaseWaveListPage(env);
+    const html = await resp.text();
+    expect(html).toContain("w1");
+    expect(html).toContain("w2");
+    expect(html).toContain("/release-wave/w1");
+    expect(html).toContain("/release-wave/w2");
+    expect(html).toContain("flipped");
+    expect(html).toContain("staging");
+  });
+
+  it("escapes HTML special chars in wave_id / repo", async () => {
+    const env = fakeEnv({
+      listReturn: [makeWave({ wave_id: "evil<script>" })],
+    });
+    const resp = await handleReleaseWaveListPage(env);
+    const html = await resp.text();
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("evil&lt;script&gt;");
+  });
+});
+
+// ============================================================================
+// /release-wave/<wave_id> detail page
+// ============================================================================
+
+describe("handleReleaseWaveDetailPage", () => {
+  it("renders 404 when wave not found", async () => {
+    const env = fakeEnv({
+      getReturn: { ok: false, code: "NOT_FOUND", error: "no wave" },
+    });
+    const resp = await handleReleaseWaveDetailPage(env, "ghost");
+    expect(resp.status).toBe(404);
+    const html = await resp.text();
+    expect(html).toContain("Wave not found");
+    expect(html).toContain("ghost");
+  });
+
+  it("renders 500 on other RPC errors", async () => {
+    const env = fakeEnv({
+      getReturn: { ok: false, code: "BOOM", error: "internal" },
+    });
+    const resp = await handleReleaseWaveDetailPage(env, "w1");
+    expect(resp.status).toBe(500);
+    const html = await resp.text();
+    expect(html).toContain("BOOM");
+  });
+
+  it("renders full detail page when wave found", async () => {
+    const env = fakeEnv({
+      getReturn: { ok: true, data: makeWave({ wave_id: "w1" }) },
+    });
+    const resp = await handleReleaseWaveDetailPage(env, "w1");
+    expect(resp.status).toBe(200);
+    const html = await resp.text();
+    expect(html).toContain("w1");
+    expect(html).toContain("Actions");
+    expect(html).toContain("Rollback Safety");
+    expect(html).toContain("Repos");
+    expect(html).toContain("Events");
+    expect(html).toContain("Raw State");
+  });
+
+  it("approve button enabled only in pending-approval", async () => {
+    // pending-approval → enabled
+    const r1 = await handleReleaseWaveDetailPage(
+      fakeEnv({
+        getReturn: {
+          ok: true,
+          data: makeWave({ state: "pending-approval" }),
+        },
+      }),
+      "w1",
+    );
+    const html1 = await r1.text();
+    // 該当 button block を抽出 (form action with /approve)
+    const m1 = html1.match(/<form[^>]*\/approve[^>]*>[\s\S]*?<\/form>/);
+    expect(m1).toBeTruthy();
+    expect(m1![0]).not.toContain("disabled");
+
+    // staging → disabled
+    const r2 = await handleReleaseWaveDetailPage(
+      fakeEnv({
+        getReturn: { ok: true, data: makeWave({ state: "staging" }) },
+      }),
+      "w1",
+    );
+    const html2 = await r2.text();
+    const m2 = html2.match(/<form[^>]*\/approve[^>]*>[\s\S]*?<\/form>/);
+    expect(m2![0]).toContain("disabled");
+  });
+
+  it("rollback button enabled only in flipped + warning when unsafe", async () => {
+    // flipped + safe → enabled, no force input
+    const r1 = await handleReleaseWaveDetailPage(
+      fakeEnv({
+        getReturn: { ok: true, data: makeWave({ state: "flipped" }) },
+      }),
+      "w1",
+    );
+    const html1 = await r1.text();
+    const m1 = html1.match(/<form[^>]*\/rollback[^>]*>[\s\S]*?<\/form>/);
+    expect(m1).toBeTruthy();
+    expect(m1![0]).not.toContain("disabled");
+    expect(m1![0]).not.toContain('name="force"');
+
+    // flipped + unsafe → enabled, force input present, warning shown
+    const r2 = await handleReleaseWaveDetailPage(
+      fakeEnv({
+        getReturn: {
+          ok: true,
+          data: makeWave({
+            state: "flipped",
+            rollback: {
+              safe: false,
+              unsafe_reason: "contract applied",
+              unsafe_since: "2026-05-27T11:00:00Z",
+              unsafe_by_migration: "20260601_001_drop",
+            },
+          }),
+        },
+      }),
+      "w1",
+    );
+    const html2 = await r2.text();
+    expect(html2).toContain("Rollback is <strong>unsafe</strong>");
+    expect(html2).toContain('name="force"');
+    expect(html2).toContain('value="true"');
+    expect(html2).toContain("contract applied");
+
+    // staging → rollback disabled
+    const r3 = await handleReleaseWaveDetailPage(
+      fakeEnv({
+        getReturn: { ok: true, data: makeWave({ state: "staging" }) },
+      }),
+      "w1",
+    );
+    const html3 = await r3.text();
+    const m3 = html3.match(/<form[^>]*\/rollback[^>]*>[\s\S]*?<\/form>/);
+    expect(m3![0]).toContain("disabled");
+  });
+
+  it("abort button enabled in staging / pending-approval, disabled elsewhere", async () => {
+    for (const state of ["staging", "pending-approval"] as const) {
+      const r = await handleReleaseWaveDetailPage(
+        fakeEnv({ getReturn: { ok: true, data: makeWave({ state }) } }),
+        "w1",
+      );
+      const html = await r.text();
+      const m = html.match(/<form[^>]*\/abort[^>]*>[\s\S]*?<\/form>/);
+      expect(m![0]).not.toContain("disabled");
+    }
+    for (const state of ["flipping", "flipped", "rolled-back", "failed"] as const) {
+      const r = await handleReleaseWaveDetailPage(
+        fakeEnv({ getReturn: { ok: true, data: makeWave({ state }) } }),
+        "w1",
+      );
+      const html = await r.text();
+      const m = html.match(/<form[^>]*\/abort[^>]*>[\s\S]*?<\/form>/);
+      expect(m![0]).toContain("disabled");
+    }
+  });
+
+  it("renders rollback safety status correctly", async () => {
+    // safe=true
+    const r1 = await handleReleaseWaveDetailPage(
+      fakeEnv({
+        getReturn: { ok: true, data: makeWave({ state: "flipped" }) },
+      }),
+      "w1",
+    );
+    expect(await r1.text()).toContain("rollback.safe = <strong>true</strong>");
+
+    // safe=false
+    const r2 = await handleReleaseWaveDetailPage(
+      fakeEnv({
+        getReturn: {
+          ok: true,
+          data: makeWave({
+            state: "flipped",
+            rollback: {
+              safe: false,
+              unsafe_reason: "contract migration applied: 20260601_001_drop",
+              unsafe_since: "2026-05-27T11:00:00Z",
+              unsafe_by_migration: "20260601_001_drop",
+            },
+          }),
+        },
+      }),
+      "w1",
+    );
+    const html2 = await r2.text();
+    expect(html2).toContain("rollback.safe = <strong>false</strong>");
+    expect(html2).toContain("20260601_001_drop");
+  });
+
+  it("shows repo stage / flip statuses with color classes", async () => {
+    const wave = makeWave({
+      state: "flipped",
+      repos: [
+        {
+          repo: "ippoan/a",
+          target_tag: "v1",
+          head_sha: "x",
+          stage_status: "done",
+          preview_url: "https://preview-a.ippoan.org",
+          stage_error: null,
+          flip_status: "done",
+          flip_error: null,
+          flip_from_revision: "a-old-rev",
+          rolled_back_to_revision: null,
+        },
+        {
+          repo: "ippoan/b",
+          target_tag: "v1",
+          head_sha: "y",
+          stage_status: "failed",
+          preview_url: null,
+          stage_error: "build broke",
+          flip_status: "pending",
+          flip_error: null,
+          flip_from_revision: null,
+          rolled_back_to_revision: null,
+        },
+      ],
+    });
+    const env = fakeEnv({ getReturn: { ok: true, data: wave } });
+    const resp = await handleReleaseWaveDetailPage(env, "w1");
+    const html = await resp.text();
+    expect(html).toContain("preview-a.ippoan.org");
+    expect(html).toContain("a-old-rev");
+    expect(html).toContain("build broke");
+    expect(html).toContain("ippoan/a");
+    expect(html).toContain("ippoan/b");
+  });
+
+  it("events timeline lists newest first", async () => {
+    const wave = makeWave({
+      events: [
+        { at: "2026-01-01T00:00:00Z", kind: "start", summary: "first" },
+        { at: "2026-01-02T00:00:00Z", kind: "stage_report", summary: "second" },
+        { at: "2026-01-03T00:00:00Z", kind: "approve", summary: "third" },
+      ],
+    });
+    const env = fakeEnv({ getReturn: { ok: true, data: wave } });
+    const resp = await handleReleaseWaveDetailPage(env, "w1");
+    const html = await resp.text();
+    // third (newest) は first より前にあるべき
+    expect(html.indexOf("third")).toBeLessThan(html.indexOf("first"));
+  });
+
+  it("escapes HTML in repo names / wave_id / event summaries", async () => {
+    const wave = makeWave({
+      wave_id: "evil<wave>",
+      repos: [
+        {
+          repo: "ippoan/<script>alert(1)</script>",
+          target_tag: "v1",
+          head_sha: "x",
+          stage_status: "done",
+          preview_url: null,
+          stage_error: null,
+          flip_status: "done",
+          flip_error: null,
+          flip_from_revision: null,
+          rolled_back_to_revision: null,
+        },
+      ],
+      events: [
+        { at: "2026-01-01T00:00:00Z", kind: "start", summary: "<bad>" },
+      ],
+    });
+    const env = fakeEnv({ getReturn: { ok: true, data: wave } });
+    const resp = await handleReleaseWaveDetailPage(env, "evil<wave>");
+    const html = await resp.text();
+    expect(html).not.toContain("<script>alert");
+    expect(html).toContain("&lt;script&gt;");
+  });
+});


### PR DESCRIPTION
## 概要

Phase 3e — Release Wave 機構の最終 piece: **operator 向け admin UI + Cloudflare Access wildcard 設定ドキュメント**を追加。issue #137 の Phase 3 全体 (3a〜3e) 完結。

## 関連 issue

Refs ippoan/ci-dashboard#137

## 追加するページ / endpoint

| path | 内容 |
|---|---|
| `GET /release-wave` | 全 wave 一覧 (state badge + 詳細リンク) |
| `GET /release-wave/<wave_id>` | 1 wave の詳細 + action buttons + events timeline + raw JSON |
| `POST /api/release-wave/<wave_id>/approve` | pending-approval → flipping |
| `POST /api/release-wave/<wave_id>/rollback` | flipped → rolled-back (form `force=true` で unsafe override) |
| `POST /api/release-wave/<wave_id>/abort` | staging/pending-approval → aborted (form `reason` で audit) |

すべて完了後 **303 redirect** で詳細ページに戻る (= 標準的な form post-redirect-get パターン)。

## 認証

ci-dashboard.ippoan.org に既に被さる **Cloudflare Access edge** (Google OAuth + email allowlist) に委譲。`/releases` `/issues` と同じトラストモデル。

actor email は `Cf-Access-Authenticated-User-Email` header から取り出して audit trail (`approved_by` / `rolled_back_by` / `aborted_by`) に記録。header 不在時は dev fallback `"operator"`。

## UI の振る舞い

- **button enable/disable** は state-aware:
  - Approve: `pending-approval` のみ
  - Rollback: `flipped` のみ
  - Abort: `staging` / `pending-approval` のみ
- **rollback.safe=false** 時の特殊表示:
  - 赤い警告 box (`contract migration applied: <id>`)
  - button ラベルが "Rollback (force)" に変わる
  - 隠し form input `force=true` を自動付与 → API がそのまま DO に渡す
- **HTML escape** で XSS 防止 (wave_id / repo 名 / event summary)。test で regression 固定
- **events timeline** は newest first
- **nav-tabs.ts** に "🌊 Release Waves" tab を追加 (`release-wave` key)

## ドキュメント (`docs/release-wave.md`)

- アーキテクチャ全体図 (Admin UI / MCP / GitHub Actions / DO / release-wave-gcp の関係)
- **Cloudflare Access wildcard setup 手順** (`preview-*.ippoan.org` の preview application)
- MCP tool 経由運用ガイド
- GitHub Actions step 経由 contract 通知運用ガイド (curl snippet 含む)
- 日常運用フロー (通常 / 失敗 / rollback)
- トラブルシューティング表

## 変更点

| ファイル | 内容 |
|---|---|
| `src/release-wave/page.ts` (新規) | SSR HTML 2 ページ |
| `src/release-wave/api.ts` (新規) | action endpoints 3 個 |
| `src/index.ts` | 5 route 追加 |
| `src/nav-tabs.ts` | `release-wave` tab key + emoji label |
| `docs/release-wave.md` (新規) | 運用ガイド |
| `test/release-wave/page.test.ts` (新規) | 11 test |
| `test/release-wave/api.test.ts` (新規) | 16 test |

## 動作確認

- [x] `tsc --noEmit` 型エラー無し
- [x] vitest 実機実行 `test/release-wave/` 全 5 file **98/98 pass** (state 33 + do 18 + webhook 11 + MCP tools 9 + page 11 + api 16)

## 後続作業 (Phase 3 完了後、Phase 4 へ)

issue #137 Phase 4 以降:
1. **Phase 4**: `ci-workflows` に `release-wave-handler.yml` reusable + `config/release-wave-targets.yaml`
2. **Phase 5**: 各 repo に薄い caller `release-wave.yml` 追加 (rust-alc-api + auth-worker から)
3. **Phase 6**: 試運転 (rust-alc-api + auth-worker で wave x3)
4. **Phase 7**: 残り frontend 展開 (nuxt-notify / alc-app / nuxt-pwa-carins / nuxt-egov)

そして本 PR merge 後、user 側で **Cloudflare Access の `preview-*.ippoan.org` wildcard application** を docs/release-wave.md の手順で 1 度だけ手動 setup する。

## メモ

- Admin UI は SSR で stateless (= 各リクエストで DO から fresh load)。WebSocket / SSE で push したい時は CIDashboardHub 同様の WS broadcast を後付け可能だが、wave の進捗 polling は数秒〜数分なので manual reload で十分
- action endpoints の CSRF 保護は CF Access の same-origin 性に依存。public 公開しないこと前提

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm4uPMVQZHWm5eFurYMJif)_