### PR TITLE
fix(release-wave): block javascript:/data: scheme in preview_url + add CSP

### DIFF
--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -30,6 +30,29 @@ function escapeHtml(s: string): string {
     .replace(/'/g, "&#039;");
 }
 
+/**
+ * URL を http(s) のみに絞って返す。`javascript:`, `data:`, `vbscript:` 等の
+ * scheme を持つ値は null を返して link 化させない (= XSS 防止)。
+ *
+ * `escapeHtml` は content escape のみで scheme injection を防げない:
+ * `javascript:alert(1)` には HTML 特殊文字が無いため escape 後も生のまま
+ * `<a href="...">` に乗り、クリックすると script 実行される。
+ *
+ * preview_url は repo 側 release-wave handler が `release_wave_stage`
+ * MCP tool で報告する値 = handler が compromise されれば任意値を入れられる
+ * = trust boundary を越える input なので必ず scheme check を入れる。
+ */
+function safeHttpUrl(u: string | null | undefined): string | null {
+  if (!u) return null;
+  try {
+    const parsed = new URL(u);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
 /** state name → 表示色 (CSS hex)。 */
 function stateColor(state: WaveStateName): string {
   switch (state) {
@@ -53,7 +76,21 @@ function stateColor(state: WaveStateName): string {
 function htmlResponse(body: string, status = 200): Response {
   return new Response(body, {
     status,
-    headers: { "Content-Type": "text/html; charset=utf-8" },
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      // Defense in depth against XSS:
+      // - `script-src 'none'` で <script> / event handler 経由の実行をブロック
+      // - `style-src 'self' 'unsafe-inline'` は本ページが inline <style> を
+      //   使うため許可 (= injected style での data exfil は別軸の懸念だが、
+      //   本ページの content は admin trusted DO state なのでバランス内)
+      // - `default-src 'none'` で他リソース読み込みを全 deny
+      // - `connect-src 'none'` で fetch / XHR 全 deny (本ページに JS 無し)
+      // - preview link は target=_blank で別タブに飛ばすため frame-src 不要
+      "Content-Security-Policy":
+        "default-src 'none'; style-src 'self' 'unsafe-inline'; connect-src 'none'; img-src 'self'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'",
+      "X-Content-Type-Options": "nosniff",
+      "Referrer-Policy": "no-referrer",
+    },
   });
 }
 
@@ -228,8 +265,13 @@ export async function handleReleaseWaveDetailPage(
         : r.flip_status === "failed"
         ? `<span class="err">failed</span>`
         : `<span class="pending">pending</span>`;
-      const previewCell = r.preview_url
-        ? `<a href="${escapeHtml(r.preview_url)}" target="_blank" rel="noopener">${escapeHtml(r.preview_url)}</a>`
+      // preview_url は scheme を http/https に絞ってから link 化する。
+      // javascript: / data: 等の dangerous scheme は null 化して text-only 表示。
+      const safePreview = safeHttpUrl(r.preview_url);
+      const previewCell = safePreview
+        ? `<a href="${escapeHtml(safePreview)}" target="_blank" rel="noopener noreferrer">${escapeHtml(safePreview)}</a>`
+        : r.preview_url
+        ? `<span class="meta" title="non-http(s) scheme rejected">${escapeHtml(r.preview_url)}</span>`
         : `<span class="meta">—</span>`;
       const rollbackTargetCell = r.flip_from_revision
         ? escapeHtml(r.flip_from_revision)

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -351,6 +351,100 @@ describe("handleReleaseWaveDetailPage", () => {
     expect(html.indexOf("third")).toBeLessThan(html.indexOf("first"));
   });
 
+  it("rejects javascript: scheme in preview_url (XSS regression)", async () => {
+    const wave = makeWave({
+      state: "flipped",
+      repos: [
+        {
+          repo: "ippoan/evil",
+          target_tag: "v1",
+          head_sha: "x",
+          stage_status: "done",
+          // attacker-controlled preview_url (= release_wave_stage MCP callback
+          // from a compromised handler). safeHttpUrl で reject 必須。
+          preview_url: "javascript:alert(1)",
+          stage_error: null,
+          flip_status: "done",
+          flip_error: null,
+          flip_from_revision: null,
+          rolled_back_to_revision: null,
+        },
+      ],
+    });
+    const env = fakeEnv({ getReturn: { ok: true, data: wave } });
+    const resp = await handleReleaseWaveDetailPage(env, "w1");
+    const html = await resp.text();
+    // クリック可能な <a href="javascript:..."> が生えないこと
+    expect(html).not.toMatch(/href="javascript:/i);
+    // 値自体は (escape された text として) 残って operator が気づける
+    expect(html).toContain("javascript:alert(1)");
+    // non-http(s) scheme は span (=non-link) 化されていること
+    expect(html).toMatch(/<span[^>]*title="non-http\(s\) scheme rejected"/);
+  });
+
+  it("rejects data: scheme in preview_url", async () => {
+    const wave = makeWave({
+      state: "flipped",
+      repos: [
+        {
+          repo: "ippoan/a",
+          target_tag: "v1",
+          head_sha: "x",
+          stage_status: "done",
+          preview_url: "data:text/html,<script>alert(1)</script>",
+          stage_error: null,
+          flip_status: "done",
+          flip_error: null,
+          flip_from_revision: null,
+          rolled_back_to_revision: null,
+        },
+      ],
+    });
+    const env = fakeEnv({ getReturn: { ok: true, data: wave } });
+    const resp = await handleReleaseWaveDetailPage(env, "w1");
+    const html = await resp.text();
+    expect(html).not.toMatch(/href="data:/i);
+    expect(html).not.toContain("<script>alert");
+  });
+
+  it("accepts https: preview_url and renders as link with noreferrer", async () => {
+    const wave = makeWave({
+      state: "flipped",
+      repos: [
+        {
+          repo: "ippoan/a",
+          target_tag: "v1",
+          head_sha: "x",
+          stage_status: "done",
+          preview_url: "https://preview-rust-alc-api.ippoan.org/",
+          stage_error: null,
+          flip_status: "done",
+          flip_error: null,
+          flip_from_revision: null,
+          rolled_back_to_revision: null,
+        },
+      ],
+    });
+    const env = fakeEnv({ getReturn: { ok: true, data: wave } });
+    const resp = await handleReleaseWaveDetailPage(env, "w1");
+    const html = await resp.text();
+    expect(html).toMatch(
+      /<a href="https:\/\/preview-rust-alc-api\.ippoan\.org[^"]*"[^>]*rel="noopener noreferrer"/,
+    );
+  });
+
+  it("sets Content-Security-Policy + nosniff + no-referrer headers", async () => {
+    const env = fakeEnv({ listReturn: [] });
+    const resp = await handleReleaseWaveListPage(env);
+    const csp = resp.headers.get("Content-Security-Policy") ?? "";
+    // default-src 'none' で script を含む全 unspecified resource を deny
+    expect(csp).toContain("default-src 'none'");
+    expect(csp).toContain("form-action 'self'");
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(resp.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(resp.headers.get("Referrer-Policy")).toBe("no-referrer");
+  });
+
   it("escapes HTML in repo names / wave_id / event summaries", async () => {
     const wave = makeWave({
       wave_id: "evil<wave>",


### PR DESCRIPTION
## 概要

Phase 3e merge 後の automated security review が指摘した XSS 経路を closing。

### 問題

`src/release-wave/page.ts` の repos table で `preview_url` を `escapeHtml` してから `<a href="...">` に乗せていた。`escapeHtml` は content escape のみで scheme injection を防げない: `javascript:alert(1)` には HTML 特殊文字が無いため escape 後も生のまま href に乗り、クリックで script 実行。

**Trust boundary**: `preview_url` は repo 側 release-wave handler が `release_wave_stage` MCP tool で報告する値 → handler が compromise されれば任意値を入れられる。

## 関連 issue

Refs ippoan/ci-dashboard#137

## 修正

### 1. URL scheme validation

`safeHttpUrl(u)` ヘルパで `new URL(u).protocol` を `http:` / `https:` に限定。それ以外 (`javascript:`, `data:`, `vbscript:` 等) は null を返し link 化させない。link 化されなかった値も operator が気付けるよう span (text-only) で表示し `title="non-http(s) scheme rejected"` を付与。

`<a>` の `rel` に `noreferrer` を追加 (preview URL は社内専用だが defense in depth)。

### 2. Defense in depth — HTTP response headers

| header | 値 |
|---|---|
| `Content-Security-Policy` | `default-src 'none'; style-src 'self' 'unsafe-inline'; form-action 'self'; frame-ancestors 'none'; ...` |
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `no-referrer` |

`default-src 'none'` で script を含む全 unspecified resource を deny。`style-src 'self' 'unsafe-inline'` は本ページが inline `<style>` を使うため必要。

## Test (regression として固定)

`test/release-wave/page.test.ts` に 4 ケース追加:

- `javascript:` scheme → `href` に乗らないこと、span 化、value 自体は表示
- `data:text/html,<script>...` → 同上、script tag 除去
- `https:` scheme → 正しく link 化 + `rel="noopener noreferrer"` 付与
- CSP / nosniff / no-referrer header 存在

合計 **31 tests pass** (既存 27 + XSS regression / CSP 4)。

## メモ

- 既に merged されている Phase 3e (PR #142) には残らない (= main に脆弱コードが入った状態)。本 PR を merge すれば修正される
- attacker model: 同 GitHub org に commit 権限を持ち、release-wave handler workflow を書き換えられる立場の attacker。実際の deploy 経路 (Cloud Run Cf-Access edge) は別 layer の auth gate があるが、defense in depth で個別 sink も塞ぐ
- 他の admin page (`/issues`, `/releases` 等) でも同種の URL rendering があれば同じ pattern を展開する余地あり (本 PR は scope を release-wave に絞る)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm4uPMVQZHWm5eFurYMJif)_