### PR TITLE
feat(release-wave): add stage-report + flip-report HTTP webhooks (Phase 4a)

### DIFF
--- a/docs/release-wave.md
+++ b/docs/release-wave.md
@@ -133,7 +133,46 @@ action)、MCP tool は自動化 / IDE 統合用。
 
 ---
 
-## GitHub Actions step 経由の運用 (contract migration 通知)
+## GitHub Actions step 経由の運用 (release-wave-handler reusable + 3 webhook)
+
+GitHub Actions が release-wave 機構と連携する経路は以下 3 endpoint の shared
+secret 認証 HTTP webhook で統一されている (= MCP OAuth を Actions で動かさ
+ない設計)。すべて `X-Release-Wave-Webhook-Secret` header + JSON body。
+
+| endpoint | 用途 | DO method |
+|---|---|---|
+| `POST /webhooks/release-wave/stage-report` | release-wave-handler の stage 完了 callback | `stageReport` |
+| `POST /webhooks/release-wave/flip-report`  | flip 完了 callback                          | `flipReport` |
+| `POST /webhooks/release-wave/contract-applied` | contract migration deploy 後の通知       | `contractApplied` |
+
+### stage-report body
+
+```json
+{
+  "wave_id": "wave_2026_05_27_01",
+  "repo": "ippoan/rust-alc-api",
+  "ok": true,
+  "preview_url": "https://preview-rust-alc-api.ippoan.org",
+  "flip_from_revision": "rust-alc-api-00041-zzz"
+}
+```
+
+`ok=false` 時は `error` フィールドで失敗詳細を渡し、`preview_url` /
+`flip_from_revision` は省略可。
+
+### flip-report body
+
+```json
+{
+  "wave_id": "wave_2026_05_27_01",
+  "repo": "ippoan/rust-alc-api",
+  "ok": true
+}
+```
+
+`ok=false` 時は `error` 必要。
+
+### contract-applied 通知 step (caller repo 側)
 
 caller repo (e.g. `rust-alc-api`) の migration deploy workflow に以下 step を
 追加:

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,11 @@ import { handleRecheck } from "./recheck";
 import { handleSecretGenPage } from "./secret-gen-page";
 import { handleTagRelease } from "./tag-release";
 import { handleMcpRequest } from "./mcp/server";
-import { handleContractAppliedWebhook } from "./release-wave/webhook";
+import {
+  handleContractAppliedWebhook,
+  handleStageReportWebhook,
+  handleFlipReportWebhook,
+} from "./release-wave/webhook";
 import {
   handleReleaseWaveListPage,
   handleReleaseWaveDetailPage,
@@ -181,11 +185,18 @@ app.get("/oauth/callback", (c) => handleOAuthCallback(c.req.raw, c.env, OAUTH_OP
 // MCP endpoint (Streamable HTTP)
 app.all("/mcp", (c) => handleMcpRequest(c.req.raw, c.env));
 
-// Release Wave: contract migration 適用通知 webhook (Refs #137 Phase 3d)。
-// GitHub Actions step が curl で叩く。MCP 経路と機能等価だが、OAuth 不要の
-// shared secret (`RELEASE_WAVE_WEBHOOK_SECRET`) で済む。
+// Release Wave: GitHub Actions step が叩く HTTP webhook 3 本 (Refs #137
+// Phase 3d + Phase 4)。MCP 経路と機能等価だが OAuth 不要の shared secret
+// (`RELEASE_WAVE_WEBHOOK_SECRET`) で済むため、release-wave-handler reusable
+// から curl 1 行で呼べる。
 app.post("/webhooks/release-wave/contract-applied", (c) =>
   handleContractAppliedWebhook(c.req.raw, c.env),
+);
+app.post("/webhooks/release-wave/stage-report", (c) =>
+  handleStageReportWebhook(c.req.raw, c.env),
+);
+app.post("/webhooks/release-wave/flip-report", (c) =>
+  handleFlipReportWebhook(c.req.raw, c.env),
 );
 
 // Release Wave admin UI (Refs #137 Phase 3e)。

--- a/src/release-wave/webhook.ts
+++ b/src/release-wave/webhook.ts
@@ -1,24 +1,21 @@
 /**
- * GitHub Actions step からの contract migration 適用通知を受ける webhook。
+ * GitHub Actions step が叩く HTTP webhook 群。MCP 経路と機能等価だが、
+ * OAuth 不要の shared secret 認証で Actions 側を curl 1 行で済むようにする。
  *
- * MCP 経路 (`release_wave_contract_applied` tool) は OAuth (auth-worker
- * 経由) を必要とし、Actions 側で実装が重い。本 webhook は shared secret
- * 認証のシンプルな HTTP endpoint で、Actions step が curl で叩く想定。
+ * 全 endpoint 共通:
+ *   POST 必須、`X-Release-Wave-Webhook-Secret` header の constant-time 比較、
+ *   Secrets Store binding `RELEASE_WAVE_WEBHOOK_SECRET` から expected 値取得、
+ *   body は JSON、エラーは JSON `{ code, error }` で返す。
  *
- * 認証:
- *   X-Release-Wave-Webhook-Secret header の constant-time 比較。
- *   Secrets Store binding `RELEASE_WAVE_WEBHOOK_SECRET` から値取得。
+ * 提供する 3 endpoint:
+ *   POST /webhooks/release-wave/stage-report       — release-wave-handler が
+ *      stage deploy 完了後に呼ぶ (= release_wave_stage MCP tool 等価)
+ *   POST /webhooks/release-wave/flip-report        — flip 完了後に呼ぶ
+ *      (= release_wave_flip MCP tool 等価)
+ *   POST /webhooks/release-wave/contract-applied   — migration deploy 後に呼ぶ
+ *      (= release_wave_contract_applied MCP tool 等価)
  *
- * Body:
- *   {
- *     "wave_id": "wave_2026_05_27_01",
- *     "repo": "ippoan/rust-alc-api",
- *     "migration_id": "20260601_001_drop_legacy_token"
- *   }
- *
- * 成功時 200 + wave 現状 JSON、失敗時 4xx + { code, error }。
- *
- * 設計の親 issue: ippoan/ci-dashboard#137 "release_wave_contract_applied MCP tool 仕様"
+ * 設計の親 issue: ippoan/ci-dashboard#137 Phase 3d + Phase 4
  */
 
 import { z } from "zod";
@@ -26,17 +23,13 @@ import type { Env } from "../index";
 import type { ReleaseWaveHub, RpcResult } from "./do";
 import type { WaveState } from "./types";
 
-const requestSchema = z.object({
-  wave_id: z.string().min(1),
-  repo: z.string().min(1),
-  migration_id: z.string().min(1),
-});
+// ----------------------------------------------------------------------------
+// Common helpers
+// ----------------------------------------------------------------------------
 
 /** constant-time string compare (= timing attack 防止)。 */
 function constantTimeEqual(a: string, b: string): boolean {
   if (a.length !== b.length) return false;
-  // Web Crypto に直接 ConstantTimeCompare は無いので XOR sum で代替。
-  // 長さ check を分けたうえで 1 文字ずつ XOR 累算するので timing は均一。
   let diff = 0;
   for (let i = 0; i < a.length; i++) {
     diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
@@ -51,73 +44,191 @@ function jsonResponse(status: number, body: unknown): Response {
   });
 }
 
+/** RpcError code → HTTP status の共通 map。 */
+function rpcErrorToHttpStatus(code: string): number {
+  if (code === "NOT_FOUND" || code === "REPO_NOT_IN_WAVE") return 404;
+  return 409;
+}
+
+/** ReleaseWaveHub stub 取得。 */
+function hubStub(env: Env): DurableObjectStub<ReleaseWaveHub> {
+  const id = env.RELEASE_WAVE_HUB.idFromName("singleton");
+  return env.RELEASE_WAVE_HUB.get(id) as DurableObjectStub<ReleaseWaveHub>;
+}
+
 /**
- * POST /webhooks/release-wave/contract-applied を処理する。
- * 全エラーは JSON body で返す (Actions step が parse できるよう)。
+ * 共通 prologue: method check + secret check + body parse + zod validate。
+ * 成功時に validated body を返し、失敗時に Response を返す (caller は早期 return)。
  */
-export async function handleContractAppliedWebhook(
+async function validateAndAuth<S extends z.ZodTypeAny>(
   request: Request,
   env: Env,
-): Promise<Response> {
+  schema: S,
+): Promise<{ ok: true; data: z.infer<S> } | { ok: false; response: Response }> {
   if (request.method !== "POST") {
-    return jsonResponse(405, { code: "METHOD_NOT_ALLOWED", error: "use POST" });
+    return {
+      ok: false,
+      response: jsonResponse(405, { code: "METHOD_NOT_ALLOWED", error: "use POST" }),
+    };
   }
 
-  // 1) Secret check
   const provided = request.headers.get("X-Release-Wave-Webhook-Secret") ?? "";
   const expected = await env.RELEASE_WAVE_WEBHOOK_SECRET.get();
   if (!expected) {
-    return jsonResponse(500, {
-      code: "SECRET_NOT_CONFIGURED",
-      error: "RELEASE_WAVE_WEBHOOK_SECRET is not bound",
-    });
+    return {
+      ok: false,
+      response: jsonResponse(500, {
+        code: "SECRET_NOT_CONFIGURED",
+        error: "RELEASE_WAVE_WEBHOOK_SECRET is not bound",
+      }),
+    };
   }
   if (!constantTimeEqual(provided, expected)) {
-    return jsonResponse(401, { code: "UNAUTHORIZED", error: "invalid webhook secret" });
+    return {
+      ok: false,
+      response: jsonResponse(401, {
+        code: "UNAUTHORIZED",
+        error: "invalid webhook secret",
+      }),
+    };
   }
 
-  // 2) Body parse + validate
   let rawBody: unknown;
   try {
     rawBody = await request.json();
   } catch {
-    return jsonResponse(400, { code: "BAD_JSON", error: "request body is not valid JSON" });
+    return {
+      ok: false,
+      response: jsonResponse(400, {
+        code: "BAD_JSON",
+        error: "request body is not valid JSON",
+      }),
+    };
   }
-  const parsed = requestSchema.safeParse(rawBody);
+  const parsed = schema.safeParse(rawBody);
   if (!parsed.success) {
-    // zod 4 の `error.issues` を読みつつ、フォーマット差異で fail しないよう
-    // `error.message` も含めて返す (= テスト assertion でも path 名でも文言
-    // でも match できる)。
     const issuesText = parsed.error.issues
       .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
       .join("; ");
-    return jsonResponse(400, {
-      code: "BAD_REQUEST",
-      error: issuesText || parsed.error.message || "validation failed",
-    });
+    return {
+      ok: false,
+      response: jsonResponse(400, {
+        code: "BAD_REQUEST",
+        error: issuesText || parsed.error.message || "validation failed",
+      }),
+    };
   }
+  return { ok: true, data: parsed.data };
+}
 
-  // 3) Call DO。Workers RPC は戻り値を Disposable で intersect するため、
-  //    TS の discriminated-union narrowing が崩れる。as cast で復元する。
-  const id = env.RELEASE_WAVE_HUB.idFromName("singleton");
-  const stub = env.RELEASE_WAVE_HUB.get(id) as DurableObjectStub<ReleaseWaveHub>;
-  const result = (await stub.contractApplied({
-    wave_id: parsed.data.wave_id,
-    repo: parsed.data.repo,
-    migration_id: parsed.data.migration_id,
-  })) as RpcResult<WaveState>;
-
+/** DO RpcResult → HTTP Response の共通 map。 */
+function rpcResultToResponse(result: RpcResult<WaveState>): Response {
   if (result.ok) {
     return jsonResponse(200, { ok: true, state: result.data });
   }
-  // DO の RpcError code を HTTP status に map
-  const httpStatus =
-    result.code === "NOT_FOUND" ? 404
-      : result.code === "REPO_NOT_IN_WAVE" ? 404
-      : 409; // INVALID_TRANSITION / TERMINAL_STATE / etc.
-  return jsonResponse(httpStatus, {
+  return jsonResponse(rpcErrorToHttpStatus(result.code), {
     ok: false,
     code: result.code,
     error: result.error,
   });
+}
+
+// ----------------------------------------------------------------------------
+// /webhooks/release-wave/contract-applied  (Phase 3d, 既存)
+// ----------------------------------------------------------------------------
+
+const contractAppliedSchema = z.object({
+  wave_id: z.string().min(1),
+  repo: z.string().min(1),
+  migration_id: z.string().min(1),
+});
+
+export async function handleContractAppliedWebhook(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  const v = await validateAndAuth(request, env, contractAppliedSchema);
+  if (!v.ok) return v.response;
+  const result = (await hubStub(env).contractApplied({
+    wave_id: v.data.wave_id,
+    repo: v.data.repo,
+    migration_id: v.data.migration_id,
+  })) as RpcResult<WaveState>;
+  return rpcResultToResponse(result);
+}
+
+// ----------------------------------------------------------------------------
+// /webhooks/release-wave/stage-report  (Phase 4 NEW)
+// ----------------------------------------------------------------------------
+
+/**
+ * stage-report body:
+ *   {
+ *     "wave_id": "wave_...",
+ *     "repo": "ippoan/rust-alc-api",
+ *     "ok": true,
+ *     "preview_url": "https://preview-rust-alc-api.ippoan.org",      // ok=true 時のみ意味あり
+ *     "flip_from_revision": "rust-alc-api-00041-zzz",                // ok=true 時のみ
+ *     "error": "build failed"                                        // ok=false 時のみ
+ *   }
+ */
+const stageReportSchema = z.object({
+  wave_id: z.string().min(1),
+  repo: z.string().min(1),
+  ok: z.boolean(),
+  preview_url: z.string().url().optional(),
+  flip_from_revision: z.string().optional(),
+  error: z.string().optional(),
+});
+
+export async function handleStageReportWebhook(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  const v = await validateAndAuth(request, env, stageReportSchema);
+  if (!v.ok) return v.response;
+  const result = (await hubStub(env).stageReport({
+    wave_id: v.data.wave_id,
+    repo: v.data.repo,
+    ok: v.data.ok,
+    preview_url: v.data.preview_url ?? null,
+    flip_from_revision: v.data.flip_from_revision ?? null,
+    error: v.data.error ?? null,
+  })) as RpcResult<WaveState>;
+  return rpcResultToResponse(result);
+}
+
+// ----------------------------------------------------------------------------
+// /webhooks/release-wave/flip-report  (Phase 4 NEW)
+// ----------------------------------------------------------------------------
+
+/**
+ * flip-report body:
+ *   {
+ *     "wave_id": "wave_...",
+ *     "repo": "ippoan/rust-alc-api",
+ *     "ok": true,
+ *     "error": "patch denied"   // ok=false 時のみ
+ *   }
+ */
+const flipReportSchema = z.object({
+  wave_id: z.string().min(1),
+  repo: z.string().min(1),
+  ok: z.boolean(),
+  error: z.string().optional(),
+});
+
+export async function handleFlipReportWebhook(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  const v = await validateAndAuth(request, env, flipReportSchema);
+  if (!v.ok) return v.response;
+  const result = (await hubStub(env).flipReport({
+    wave_id: v.data.wave_id,
+    repo: v.data.repo,
+    ok: v.data.ok,
+    error: v.data.error ?? null,
+  })) as RpcResult<WaveState>;
+  return rpcResultToResponse(result);
 }

--- a/test/release-wave/webhook.test.ts
+++ b/test/release-wave/webhook.test.ts
@@ -1,25 +1,47 @@
 import { describe, it, expect, vi } from "vitest";
-import { handleContractAppliedWebhook } from "../../src/release-wave/webhook";
+import {
+  handleContractAppliedWebhook,
+  handleStageReportWebhook,
+  handleFlipReportWebhook,
+} from "../../src/release-wave/webhook";
 import type { Env } from "../../src/index";
 import type { ReleaseWaveHub } from "../../src/release-wave/do";
 
-// 各 test で hub method の呼び出しと secret 値を切替えられる fake env を作る。
+// ----------------------------------------------------------------------------
+// Fake env / request builder (3 endpoint 共通)
+// ----------------------------------------------------------------------------
+
+type FakeSpies = {
+  contractApplied: ReturnType<typeof vi.fn>;
+  stageReport: ReturnType<typeof vi.fn>;
+  flipReport: ReturnType<typeof vi.fn>;
+};
+
 function fakeEnv(opts: {
   secret?: string | null;
   contractAppliedReturn?:
     | { ok: true; data: unknown }
     | { ok: false; code: string; error: string };
-}): {
-  env: Env;
-  spy: ReturnType<typeof vi.fn>;
-} {
-  const spy = vi.fn().mockResolvedValue(
-    opts.contractAppliedReturn ?? {
-      ok: true,
-      data: { wave_id: "w1", state: "flipped" },
-    },
-  );
-  const hub = { contractApplied: spy } as unknown as ReleaseWaveHub;
+  stageReportReturn?:
+    | { ok: true; data: unknown }
+    | { ok: false; code: string; error: string };
+  flipReportReturn?:
+    | { ok: true; data: unknown }
+    | { ok: false; code: string; error: string };
+} = {}): { env: Env; spies: FakeSpies } {
+  const okState = { wave_id: "w1", state: "staging" };
+  const spies: FakeSpies = {
+    contractApplied: vi
+      .fn()
+      .mockResolvedValue(opts.contractAppliedReturn ?? { ok: true, data: okState }),
+    stageReport: vi
+      .fn()
+      .mockResolvedValue(opts.stageReportReturn ?? { ok: true, data: okState }),
+    flipReport: vi
+      .fn()
+      .mockResolvedValue(opts.flipReportReturn ?? { ok: true, data: okState }),
+  };
+  const hub = spies as unknown as ReleaseWaveHub;
   const env = {
     RELEASE_WAVE_HUB: {
       idFromName: () => ({}),
@@ -30,10 +52,11 @@ function fakeEnv(opts: {
         opts.secret === undefined ? "expected-secret" : opts.secret,
     },
   } as unknown as Env;
-  return { env, spy };
+  return { env, spies };
 }
 
 function jsonRequest(opts: {
+  url?: string;
   method?: string;
   body?: unknown;
   secret?: string | null;
@@ -45,24 +68,26 @@ function jsonRequest(opts: {
     headers["X-Release-Wave-Webhook-Secret"] = opts.secret;
   }
   const method = opts.method ?? "POST";
-  // GET/HEAD with body は Request constructor が TypeError を投げるので、
-  // body は POST のみで attach する (= method check の test では body 不要)。
   const init: RequestInit = { method, headers };
   if (method !== "GET" && method !== "HEAD" && opts.body !== undefined) {
     init.body =
       typeof opts.body === "string" ? opts.body : JSON.stringify(opts.body);
   }
   return new Request(
-    "https://ci-dashboard.ippoan.org/webhooks/release-wave/contract-applied",
+    opts.url ?? "https://ci-dashboard.ippoan.org/webhooks/release-wave/contract-applied",
     init,
   );
 }
 
+// ============================================================================
+// /webhooks/release-wave/contract-applied
+// ============================================================================
+
 describe("handleContractAppliedWebhook", () => {
   it("rejects non-POST with 405", async () => {
-    const { env } = fakeEnv({});
+    const { env } = fakeEnv();
     const resp = await handleContractAppliedWebhook(
-      jsonRequest({ method: "GET", secret: "expected-secret", body: {} }),
+      jsonRequest({ method: "GET", secret: "expected-secret" }),
       env,
     );
     expect(resp.status).toBe(405);
@@ -75,35 +100,28 @@ describe("handleContractAppliedWebhook", () => {
     const resp = await handleContractAppliedWebhook(
       jsonRequest({
         secret: "anything",
-        body: {
-          wave_id: "w1",
-          repo: "ippoan/a",
-          migration_id: "m",
-        },
+        body: { wave_id: "w1", repo: "ippoan/a", migration_id: "m" },
       }),
       env,
     );
     expect(resp.status).toBe(500);
-    const body = (await resp.json()) as { code: string };
-    expect(body.code).toBe("SECRET_NOT_CONFIGURED");
+    expect(((await resp.json()) as { code: string }).code).toBe("SECRET_NOT_CONFIGURED");
   });
 
   it("rejects with 401 on missing header", async () => {
-    const { env } = fakeEnv({});
+    const { env } = fakeEnv();
     const resp = await handleContractAppliedWebhook(
       jsonRequest({
-        secret: null, // do not set header
+        secret: null,
         body: { wave_id: "w1", repo: "ippoan/a", migration_id: "m" },
       }),
       env,
     );
     expect(resp.status).toBe(401);
-    const body = (await resp.json()) as { code: string };
-    expect(body.code).toBe("UNAUTHORIZED");
   });
 
   it("rejects with 401 on wrong header value", async () => {
-    const { env } = fakeEnv({});
+    const { env } = fakeEnv();
     const resp = await handleContractAppliedWebhook(
       jsonRequest({
         secret: "wrong-secret",
@@ -115,7 +133,7 @@ describe("handleContractAppliedWebhook", () => {
   });
 
   it("rejects with 401 on different-length header (constant-time path)", async () => {
-    const { env } = fakeEnv({});
+    const { env } = fakeEnv();
     const resp = await handleContractAppliedWebhook(
       jsonRequest({
         secret: "short",
@@ -127,18 +145,17 @@ describe("handleContractAppliedWebhook", () => {
   });
 
   it("rejects with 400 on non-JSON body", async () => {
-    const { env } = fakeEnv({});
+    const { env } = fakeEnv();
     const resp = await handleContractAppliedWebhook(
       jsonRequest({ secret: "expected-secret", body: "not json {" }),
       env,
     );
     expect(resp.status).toBe(400);
-    const body = (await resp.json()) as { code: string };
-    expect(body.code).toBe("BAD_JSON");
+    expect(((await resp.json()) as { code: string }).code).toBe("BAD_JSON");
   });
 
   it("rejects with 400 on missing fields", async () => {
-    const { env } = fakeEnv({});
+    const { env } = fakeEnv();
     const resp = await handleContractAppliedWebhook(
       jsonRequest({ secret: "expected-secret", body: { wave_id: "w1" } }),
       env,
@@ -151,7 +168,7 @@ describe("handleContractAppliedWebhook", () => {
   });
 
   it("succeeds (200) when secret OK and DO returns ok", async () => {
-    const { env, spy } = fakeEnv({});
+    const { env, spies } = fakeEnv();
     const resp = await handleContractAppliedWebhook(
       jsonRequest({
         secret: "expected-secret",
@@ -164,9 +181,7 @@ describe("handleContractAppliedWebhook", () => {
       env,
     );
     expect(resp.status).toBe(200);
-    const body = (await resp.json()) as { ok: boolean; state: unknown };
-    expect(body.ok).toBe(true);
-    expect(spy).toHaveBeenCalledWith({
+    expect(spies.contractApplied).toHaveBeenCalledWith({
       wave_id: "wave_2026_05_27_01",
       repo: "ippoan/rust-alc-api",
       migration_id: "20260601_001_drop",
@@ -184,26 +199,16 @@ describe("handleContractAppliedWebhook", () => {
     const resp = await handleContractAppliedWebhook(
       jsonRequest({
         secret: "expected-secret",
-        body: {
-          wave_id: "w1",
-          repo: "ippoan/a",
-          migration_id: "m",
-        },
+        body: { wave_id: "w1", repo: "ippoan/a", migration_id: "m" },
       }),
       env,
     );
     expect(resp.status).toBe(409);
-    const body = (await resp.json()) as { code: string };
-    expect(body.code).toBe("INVALID_TRANSITION");
   });
 
   it("maps NOT_FOUND to 404", async () => {
     const { env } = fakeEnv({
-      contractAppliedReturn: {
-        ok: false,
-        code: "NOT_FOUND",
-        error: "no such wave",
-      },
+      contractAppliedReturn: { ok: false, code: "NOT_FOUND", error: "no wave" },
     });
     const resp = await handleContractAppliedWebhook(
       jsonRequest({
@@ -231,5 +236,294 @@ describe("handleContractAppliedWebhook", () => {
       env,
     );
     expect(resp.status).toBe(404);
+  });
+});
+
+// ============================================================================
+// /webhooks/release-wave/stage-report
+// ============================================================================
+
+const STAGE_URL =
+  "https://ci-dashboard.ippoan.org/webhooks/release-wave/stage-report";
+
+describe("handleStageReportWebhook", () => {
+  it("returns 405 on GET", async () => {
+    const { env } = fakeEnv();
+    const resp = await handleStageReportWebhook(
+      jsonRequest({ url: STAGE_URL, method: "GET", secret: "expected-secret" }),
+      env,
+    );
+    expect(resp.status).toBe(405);
+  });
+
+  it("returns 401 on wrong secret", async () => {
+    const { env } = fakeEnv();
+    const resp = await handleStageReportWebhook(
+      jsonRequest({
+        url: STAGE_URL,
+        secret: "wrong",
+        body: { wave_id: "w1", repo: "ippoan/a", ok: true },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(401);
+  });
+
+  it("returns 400 on missing fields", async () => {
+    const { env } = fakeEnv();
+    const resp = await handleStageReportWebhook(
+      jsonRequest({
+        url: STAGE_URL,
+        secret: "expected-secret",
+        body: { wave_id: "w1" },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(400);
+    const body = (await resp.json()) as { error: string };
+    expect(body.error).toContain("repo");
+    expect(body.error).toContain("ok");
+  });
+
+  it("returns 400 on invalid preview_url (non-URL)", async () => {
+    const { env } = fakeEnv();
+    const resp = await handleStageReportWebhook(
+      jsonRequest({
+        url: STAGE_URL,
+        secret: "expected-secret",
+        body: {
+          wave_id: "w1",
+          repo: "ippoan/a",
+          ok: true,
+          preview_url: "not a url",
+        },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(400);
+  });
+
+  it("succeeds with full payload (ok=true)", async () => {
+    const { env, spies } = fakeEnv();
+    const resp = await handleStageReportWebhook(
+      jsonRequest({
+        url: STAGE_URL,
+        secret: "expected-secret",
+        body: {
+          wave_id: "w1",
+          repo: "ippoan/a",
+          ok: true,
+          preview_url: "https://preview-a.ippoan.org/",
+          flip_from_revision: "a-old-rev",
+        },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(200);
+    expect(spies.stageReport).toHaveBeenCalledWith({
+      wave_id: "w1",
+      repo: "ippoan/a",
+      ok: true,
+      preview_url: "https://preview-a.ippoan.org/",
+      flip_from_revision: "a-old-rev",
+      error: null,
+    });
+  });
+
+  it("succeeds with failure payload (ok=false, error)", async () => {
+    const { env, spies } = fakeEnv();
+    const resp = await handleStageReportWebhook(
+      jsonRequest({
+        url: STAGE_URL,
+        secret: "expected-secret",
+        body: {
+          wave_id: "w1",
+          repo: "ippoan/a",
+          ok: false,
+          error: "build broke",
+        },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(200);
+    expect(spies.stageReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ok: false,
+        error: "build broke",
+        preview_url: null,
+        flip_from_revision: null,
+      }),
+    );
+  });
+
+  it("nullifies omitted optional fields", async () => {
+    const { env, spies } = fakeEnv();
+    await handleStageReportWebhook(
+      jsonRequest({
+        url: STAGE_URL,
+        secret: "expected-secret",
+        body: { wave_id: "w1", repo: "ippoan/a", ok: true },
+      }),
+      env,
+    );
+    expect(spies.stageReport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preview_url: null,
+        flip_from_revision: null,
+        error: null,
+      }),
+    );
+  });
+
+  it("maps NOT_FOUND to 404", async () => {
+    const { env } = fakeEnv({
+      stageReportReturn: { ok: false, code: "NOT_FOUND", error: "no wave" },
+    });
+    const resp = await handleStageReportWebhook(
+      jsonRequest({
+        url: STAGE_URL,
+        secret: "expected-secret",
+        body: { wave_id: "ghost", repo: "ippoan/a", ok: true },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(404);
+  });
+
+  it("maps INVALID_TRANSITION to 409", async () => {
+    const { env } = fakeEnv({
+      stageReportReturn: {
+        ok: false,
+        code: "INVALID_TRANSITION",
+        error: "wave is flipping",
+      },
+    });
+    const resp = await handleStageReportWebhook(
+      jsonRequest({
+        url: STAGE_URL,
+        secret: "expected-secret",
+        body: { wave_id: "w1", repo: "ippoan/a", ok: true },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(409);
+  });
+});
+
+// ============================================================================
+// /webhooks/release-wave/flip-report
+// ============================================================================
+
+const FLIP_URL =
+  "https://ci-dashboard.ippoan.org/webhooks/release-wave/flip-report";
+
+describe("handleFlipReportWebhook", () => {
+  it("returns 405 on GET", async () => {
+    const { env } = fakeEnv();
+    const resp = await handleFlipReportWebhook(
+      jsonRequest({ url: FLIP_URL, method: "GET", secret: "expected-secret" }),
+      env,
+    );
+    expect(resp.status).toBe(405);
+  });
+
+  it("returns 401 on wrong secret", async () => {
+    const { env } = fakeEnv();
+    const resp = await handleFlipReportWebhook(
+      jsonRequest({
+        url: FLIP_URL,
+        secret: "wrong",
+        body: { wave_id: "w1", repo: "ippoan/a", ok: true },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(401);
+  });
+
+  it("returns 400 on missing fields", async () => {
+    const { env } = fakeEnv();
+    const resp = await handleFlipReportWebhook(
+      jsonRequest({
+        url: FLIP_URL,
+        secret: "expected-secret",
+        body: { wave_id: "w1" },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(400);
+  });
+
+  it("succeeds with ok=true", async () => {
+    const { env, spies } = fakeEnv();
+    const resp = await handleFlipReportWebhook(
+      jsonRequest({
+        url: FLIP_URL,
+        secret: "expected-secret",
+        body: { wave_id: "w1", repo: "ippoan/a", ok: true },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(200);
+    expect(spies.flipReport).toHaveBeenCalledWith({
+      wave_id: "w1",
+      repo: "ippoan/a",
+      ok: true,
+      error: null,
+    });
+  });
+
+  it("succeeds with ok=false + error", async () => {
+    const { env, spies } = fakeEnv();
+    const resp = await handleFlipReportWebhook(
+      jsonRequest({
+        url: FLIP_URL,
+        secret: "expected-secret",
+        body: {
+          wave_id: "w1",
+          repo: "ippoan/a",
+          ok: false,
+          error: "traffic update denied",
+        },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(200);
+    expect(spies.flipReport).toHaveBeenCalledWith(
+      expect.objectContaining({ ok: false, error: "traffic update denied" }),
+    );
+  });
+
+  it("maps NOT_FOUND to 404", async () => {
+    const { env } = fakeEnv({
+      flipReportReturn: { ok: false, code: "NOT_FOUND", error: "no wave" },
+    });
+    const resp = await handleFlipReportWebhook(
+      jsonRequest({
+        url: FLIP_URL,
+        secret: "expected-secret",
+        body: { wave_id: "ghost", repo: "ippoan/a", ok: true },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(404);
+  });
+
+  it("maps INVALID_TRANSITION to 409", async () => {
+    const { env } = fakeEnv({
+      flipReportReturn: {
+        ok: false,
+        code: "INVALID_TRANSITION",
+        error: "wave not in flipping",
+      },
+    });
+    const resp = await handleFlipReportWebhook(
+      jsonRequest({
+        url: FLIP_URL,
+        secret: "expected-secret",
+        body: { wave_id: "w1", repo: "ippoan/a", ok: true },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(409);
   });
 });


### PR DESCRIPTION
## 概要

Phase 4a (Phase 4 の前段): release-wave-handler reusable (Phase 4b で ci-workflows 側に追加予定) が叩く 2 つの新 HTTP webhook を ci-dashboard に追加。これで MCP OAuth を GitHub Actions で動かす必要が無くなる。

## 関連 issue

Refs ippoan/ci-dashboard#137

## 新 endpoint

| endpoint | DO method | 用途 |
|---|---|---|
| `POST /webhooks/release-wave/stage-report` | `stageReport` | stage deploy 完了後の callback |
| `POST /webhooks/release-wave/flip-report` | `flipReport` | flip 完了後の callback |

既存の `/webhooks/release-wave/contract-applied` (Phase 3d) と同じ `RELEASE_WAVE_WEBHOOK_SECRET` で認証。3 endpoint 共通の auth / parse / map ロジックを `validateAndAuth()` + `rpcResultToResponse()` に抽出して DRY 化。

## Body 仕様

### stage-report

```json
{
  "wave_id": "wave_2026_05_27_01",
  "repo": "ippoan/rust-alc-api",
  "ok": true,
  "preview_url": "https://preview-rust-alc-api.ippoan.org",
  "flip_from_revision": "rust-alc-api-00041-zzz"
}
```

`ok=false` 時は `error` 詳細、`preview_url` / `flip_from_revision` 省略可。

### flip-report

```json
{
  "wave_id": "wave_2026_05_27_01",
  "repo": "ippoan/rust-alc-api",
  "ok": true
}
```

`ok=false` 時は `error` 詳細。

## Response

3 endpoint 共通:

| status | 内容 |
|---|---|
| 200 | `{ ok: true, state: <WaveState> }` |
| 400 | `BAD_JSON` / `BAD_REQUEST` |
| 401 | `UNAUTHORIZED` |
| 404 | `NOT_FOUND` / `REPO_NOT_IN_WAVE` |
| 409 | `INVALID_TRANSITION` / `TERMINAL_STATE` / etc. |
| 500 | `SECRET_NOT_CONFIGURED` |

## 動作確認

- [x] `tsc --noEmit` 型エラー無し
- [x] vitest 実機 `test/release-wave/webhook.test.ts` **27/27 pass** (contract-applied 11 + stage-report 10 + flip-report 6)

## 変更点

| ファイル | 内容 |
|---|---|
| `src/release-wave/webhook.ts` | 既存 + 2 endpoint、共通ヘルパ抽出 |
| `src/index.ts` | 2 route 追加 |
| `test/release-wave/webhook.test.ts` | テスト拡張 (16 new) |
| `docs/release-wave.md` | "GitHub Actions step 経由の運用" を 3 endpoint 表に拡張 |

## 後続 (Phase 4b)

本 PR merge 後、ci-workflows side で:
- `.github/workflows/release-wave-handler.yml` (reusable workflow)
- `config/release-wave-targets.yaml` (repo metadata)

を別 PR で追加し、各 repo が薄い caller (`release-wave.yml` 10 行) で使う形にする。

## メモ

- 全 endpoint 同一 secret (`RELEASE_WAVE_WEBHOOK_SECRET`) を使い回すので caller 側の GitHub org secret も 1 つ (`RELEASE_WAVE_WEBHOOK_SECRET`) で済む
- 既存 contract-applied のリファクタは behavior preserving — レスポンス shape も 変えていない

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm4uPMVQZHWm5eFurYMJif)_