### PR TITLE
feat: add HealthConnectReaderWorker to TAGLESS_REPOS for /releases tracking

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,7 +13,7 @@
     // mini-release: it scans the merged PR for `Refs #N` and surfaces any still-
     // open issues on the dashboard banner + /releases synthetic blocks. Repos
     // not listed here keep the original tag-driven flow.
-    "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard"
+    "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker"
   },
   "kv_namespaces": [
     {
@@ -115,7 +115,7 @@
         }
       ],
       "vars": {
-        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard"
+        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker"
       },
       "kv_namespaces": [
         {


### PR DESCRIPTION
## 概要

`ippoan/HealthConnectReaderWorker` (HCRW) を `TAGLESS_REPOS` env var に追加し、`/releases` で synthetic block として表示されるようにする。

## 動機

HCRW は release tag を cut しない運用 (PR merge = staging/prod deploy が自動で走る、wrangler.jsonc に `deploy_release_script` 設定あり、tag 一覧も空)。現状 `/releases` には**何も出ない**ため、merge 済 PR の `Refs #N` issue を目視 close する operator UX が無い。

実害: `ippoan/HealthConnectReaderWorker#60` / `#61` を merge した後、close 確認すべき issue が dashboard に出ないため track できなかった。

## 変更

`wrangler.jsonc` の `TAGLESS_REPOS` (`vars` + `env.staging.vars`) に `ippoan/HealthConnectReaderWorker` を追加するだけ。

```diff
- "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard"
+ "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker"
```

追加後の挙動 (既存 `secrets-inventory` と同じ):

1. `loadSyntheticBlock` が default branch (`main`) の最近の commits から `Refs #N` を抽出
2. 該当 open issue を `/releases` ページに表示
3. operator が UI 上で close 操作 → `close_issue` MCP tool 経由で github 側 close

## Test plan

- [ ] CI green
- [ ] deploy 後、`https://ci-dashboard.ippoan.org/releases` で HealthConnectReaderWorker が synthetic block で出ること
- [ ] `Refs #60` `Refs #61` (HCRW) と `Refs #57` `Refs #58` (secrets-inventory) が close 候補として表示されること

Refs #145

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb2hASFhbDtbdd83fNtFEB)_