### PR TITLE
feat(release-wave): add repository_dispatch fan-out from DO state transitions

### DIFF
--- a/src/release-wave/dispatch.ts
+++ b/src/release-wave/dispatch.ts
@@ -1,0 +1,172 @@
+/**
+ * Release Wave dispatcher: DO state 遷移 → 各 caller repo への
+ * `repository_dispatch` 発火を担当する。
+ *
+ * 設計の親 issue: ippoan/ci-dashboard#137 Phase 5 pre-req
+ *
+ * 構造:
+ *   `decideDispatches(prev, next)` — 純粋関数。prev_state と next_state から
+ *      どの repo にどの event_type で何の client_payload を投げるかを決める。
+ *      DO / HTTP に依存しないため state.test.ts と同様に unit test できる。
+ *
+ *   `dispatchAll(env, dispatches)` — IO。各 Dispatch を GitHub API
+ *      `POST /repos/:owner/:repo/dispatches` に並列で送る。失敗は per-repo
+ *      ログに留め、wave 全体は止めない (= 1 repo の dispatch fail で他 repo の
+ *      着火を阻害しないため)。
+ */
+
+import type { Env } from "../index";
+import { githubApi, parseRepo, tokenForOrg } from "../github-api";
+import type { WaveState } from "./types";
+
+// ----------------------------------------------------------------------------
+// Types
+// ----------------------------------------------------------------------------
+
+export type DispatchEventType =
+  | "release-wave-stage"
+  | "release-wave-flip"
+  | "release-wave-rollback";
+
+export interface Dispatch {
+  /** "owner/name" 形式 */
+  readonly repo: string;
+  readonly event_type: DispatchEventType;
+  readonly client_payload: Record<string, unknown>;
+}
+
+// ----------------------------------------------------------------------------
+// Pure: decideDispatches
+// ----------------------------------------------------------------------------
+
+/**
+ * prev/next state を比べて発火すべき dispatch を返す。
+ *
+ * 発火条件:
+ *   prev=null            && next.state="staging"   → 全 repo に stage
+ *   prev.state="pending-approval" && next.state="flipping" → 全 repo に flip
+ *   prev.state="staging" && next.state="flipping"  → 全 repo に flip (auto policy)
+ *   prev.state="flipped" && next.state="rolled-back" → 全 repo に rollback
+ *
+ * それ以外 (failed / aborted / stage_report 完了 / contract_applied 等) は
+ * 発火しない。空配列を返す。
+ *
+ * @param prev 直前の state。`createWave` 直後は null。
+ * @param next 遷移後の state。
+ */
+export function decideDispatches(
+  prev: WaveState | null,
+  next: WaveState,
+): Dispatch[] {
+  // start: null → staging
+  if (prev === null && next.state === "staging") {
+    return next.repos.map((r) => ({
+      repo: r.repo,
+      event_type: "release-wave-stage" as const,
+      client_payload: {
+        wave_id: next.wave_id,
+        target_tag: r.target_tag,
+        head_sha: r.head_sha,
+      },
+    }));
+  }
+
+  // flip: pending-approval → flipping (manual approve)
+  //       staging          → flipping (auto policy)
+  if (
+    prev !== null &&
+    next.state === "flipping" &&
+    prev.state !== "flipping"
+  ) {
+    return next.repos.map((r) => ({
+      repo: r.repo,
+      event_type: "release-wave-flip" as const,
+      client_payload: {
+        wave_id: next.wave_id,
+        target_tag: r.target_tag,
+        head_sha: r.head_sha,
+      },
+    }));
+  }
+
+  // rollback: flipped → rolled-back
+  if (
+    prev !== null &&
+    prev.state === "flipped" &&
+    next.state === "rolled-back"
+  ) {
+    return next.repos.map((r) => ({
+      repo: r.repo,
+      event_type: "release-wave-rollback" as const,
+      client_payload: {
+        wave_id: next.wave_id,
+        target_tag: r.target_tag,
+        head_sha: r.head_sha,
+        // rollback 戻し先 revision。cloudrun matrix は services 単位、cf-workers
+        // は repo 単位なので両者を載せる (handler が選ぶ)。
+        flip_from_revision: r.flip_from_revision,
+        // cloudrun rollback handler が service ごとに引く想定の map。
+        // 現在 schema 上 per-service 表現が無いため、handler 側は空の
+        // map で fallback (= TODO Phase 5+ で per-service rollback target を
+        // RepoState に持たせる)。
+        rollback_target: {},
+      },
+    }));
+  }
+
+  return [];
+}
+
+// ----------------------------------------------------------------------------
+// IO: dispatchAll
+// ----------------------------------------------------------------------------
+
+/**
+ * Dispatch[] を GitHub `POST /repos/:owner/:repo/dispatches` に並列送信。
+ *
+ * 失敗 (= GitHub API non-2xx / token 取得失敗) はログのみ残し、Promise は
+ * 個別 settle で集約する。1 件失敗で他の dispatch を止めると wave が部分
+ * 着火状態で hang するため、最大 best-effort。
+ *
+ * @returns 全 dispatch の結果配列 (caller 側で metric / log に使う)。
+ */
+export async function dispatchAll(
+  env: Env,
+  dispatches: ReadonlyArray<Dispatch>,
+): Promise<
+  Array<
+    | { ok: true; repo: string; event_type: string }
+    | { ok: false; repo: string; event_type: string; error: string }
+  >
+> {
+  if (dispatches.length === 0) return [];
+  const settled = await Promise.allSettled(
+    dispatches.map((d) => dispatchOne(env, d)),
+  );
+  return settled.map((s, i) => {
+    const d = dispatches[i]!;
+    if (s.status === "fulfilled") {
+      return { ok: true, repo: d.repo, event_type: d.event_type };
+    }
+    return {
+      ok: false,
+      repo: d.repo,
+      event_type: d.event_type,
+      error: s.reason instanceof Error ? s.reason.message : String(s.reason),
+    };
+  });
+}
+
+async function dispatchOne(env: Env, d: Dispatch): Promise<void> {
+  const { owner, repo } = parseRepo(d.repo);
+  const token = await tokenForOrg(env, owner);
+  await githubApi(
+    token,
+    "POST",
+    `/repos/${owner}/${repo}/dispatches`,
+    {
+      event_type: d.event_type,
+      client_payload: d.client_payload,
+    },
+  );
+}

--- a/src/release-wave/do.ts
+++ b/src/release-wave/do.ts
@@ -27,6 +27,7 @@ import type {
   WaveEvent,
   WaveState,
 } from "./types";
+import { decideDispatches, dispatchAll } from "./dispatch";
 
 // ----------------------------------------------------------------------------
 // Storage keys
@@ -165,6 +166,9 @@ export class ReleaseWaveHub extends DurableObject<Env> {
       now,
     });
     await this.saveWave(state);
+    // 各 caller repo に release-wave-stage dispatch を fan-out。
+    // 失敗は best-effort で log/result に残す (dispatchAll は throw しない)。
+    await this.maybeDispatch(null, state);
     return { ok: true, data: state };
   }
 
@@ -271,7 +275,37 @@ export class ReleaseWaveHub extends DurableObject<Env> {
       return { ok: false, code: result.code, error: result.error };
     }
     await this.saveWave(result.state);
+    // 副作用: state 遷移に応じて caller repo へ repository_dispatch を発火。
+    // approve → flipping, stage_report → flipping (auto), rollback → rolled-back
+    // のいずれかで dispatchAll が走る。stage_report の途中遷移 (= staging のまま)
+    // / contract_applied / fail 等は decideDispatches が空配列を返すので no-op。
+    await this.maybeDispatch(state, result.state);
     return { ok: true, data: result.state };
+  }
+
+  /**
+   * state 遷移 (prev → next) を受けて発火すべき dispatch を計算し、GitHub
+   * `POST /repos/:owner/:repo/dispatches` で fan-out する。失敗は best-effort。
+   *
+   * 本来は ctx.waitUntil() で非同期に投げて DO method を即時 return したい
+   * ところだが、テスト容易性 + state machine と dispatch の対応関係の透明性
+   * を優先して同期的に await する。release wave の N=10 程度の参加 repo に
+   * 並列 POST する HTTP 程度なら数秒で済むので許容範囲。
+   */
+  private async maybeDispatch(
+    prev: WaveState | null,
+    next: WaveState,
+  ): Promise<void> {
+    const dispatches = decideDispatches(prev, next);
+    if (dispatches.length === 0) return;
+    const results = await dispatchAll(this.env, dispatches);
+    for (const r of results) {
+      if (!r.ok) {
+        console.warn(
+          `[release-wave] dispatch failed: repo=${r.repo} event=${r.event_type}: ${r.error}`,
+        );
+      }
+    }
   }
 
   private async loadWave(wave_id: string): Promise<WaveState | null> {

--- a/test/release-wave/dispatch.test.ts
+++ b/test/release-wave/dispatch.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect } from "vitest";
+import { decideDispatches } from "../../src/release-wave/dispatch";
+import { createWave, transition } from "../../src/release-wave/state";
+import type { WaveState } from "../../src/release-wave/types";
+
+const T0 = "2026-05-28T00:00:00Z";
+const T1 = "2026-05-28T00:05:00Z";
+const T2 = "2026-05-28T00:10:00Z";
+
+function makeWave(opts: { flip_policy?: "manual-approval" | "auto" } = {}): WaveState {
+  return createWave({
+    wave_id: "w1",
+    flip_policy: opts.flip_policy ?? "manual-approval",
+    note: "test",
+    repos: [
+      { repo: "ippoan/rust-alc-api", target_tag: "v1.1.0", head_sha: "sha-a" },
+      { repo: "ippoan/auth-worker", target_tag: "v0.5.0", head_sha: "sha-b" },
+    ],
+    now: T0,
+  });
+}
+
+function ok<T extends { ok: boolean }>(r: T): Extract<T, { ok: true }> {
+  if (!r.ok) throw new Error("expected ok: " + JSON.stringify(r));
+  return r as Extract<T, { ok: true }>;
+}
+
+// ============================================================================
+// start (null → staging) → release-wave-stage to all repos
+// ============================================================================
+
+describe("decideDispatches: start", () => {
+  it("emits release-wave-stage to all repos when wave starts", () => {
+    const next = makeWave();
+    const ds = decideDispatches(null, next);
+    expect(ds).toHaveLength(2);
+    expect(ds[0]).toMatchObject({
+      repo: "ippoan/rust-alc-api",
+      event_type: "release-wave-stage",
+      client_payload: {
+        wave_id: "w1",
+        target_tag: "v1.1.0",
+        head_sha: "sha-a",
+      },
+    });
+    expect(ds[1]).toMatchObject({
+      repo: "ippoan/auth-worker",
+      event_type: "release-wave-stage",
+      client_payload: {
+        wave_id: "w1",
+        target_tag: "v0.5.0",
+        head_sha: "sha-b",
+      },
+    });
+  });
+});
+
+// ============================================================================
+// stage_report → no dispatch unless state moved to flipping
+// ============================================================================
+
+describe("decideDispatches: stage_report (mid-staging)", () => {
+  it("does not dispatch when state stays staging (partial stage)", () => {
+    const prev = makeWave();
+    const next = ok(
+      transition(prev, {
+        kind: "stage_report",
+        now: T1,
+        repo: "ippoan/rust-alc-api",
+        ok: true,
+      }),
+    ).state;
+    expect(decideDispatches(prev, next)).toEqual([]);
+  });
+
+  it("does not dispatch when state moves to pending-approval (manual policy)", () => {
+    let s = makeWave({ flip_policy: "manual-approval" });
+    s = ok(transition(s, { kind: "stage_report", now: T1, repo: "ippoan/rust-alc-api", ok: true })).state;
+    const prev = s;
+    const next = ok(
+      transition(prev, {
+        kind: "stage_report",
+        now: T2,
+        repo: "ippoan/auth-worker",
+        ok: true,
+      }),
+    ).state;
+    expect(next.state).toBe("pending-approval");
+    expect(decideDispatches(prev, next)).toEqual([]);
+  });
+
+  it("emits release-wave-flip to all repos when auto policy stage completes", () => {
+    let s = makeWave({ flip_policy: "auto" });
+    s = ok(transition(s, { kind: "stage_report", now: T1, repo: "ippoan/rust-alc-api", ok: true })).state;
+    const prev = s;
+    const next = ok(
+      transition(prev, {
+        kind: "stage_report",
+        now: T2,
+        repo: "ippoan/auth-worker",
+        ok: true,
+      }),
+    ).state;
+    expect(next.state).toBe("flipping");
+    const ds = decideDispatches(prev, next);
+    expect(ds).toHaveLength(2);
+    expect(ds.every((d) => d.event_type === "release-wave-flip")).toBe(true);
+  });
+
+  it("does not dispatch when state moves to failed", () => {
+    const prev = makeWave();
+    const next = ok(
+      transition(prev, {
+        kind: "stage_report",
+        now: T1,
+        repo: "ippoan/rust-alc-api",
+        ok: false,
+        error: "build broke",
+      }),
+    ).state;
+    expect(next.state).toBe("failed");
+    expect(decideDispatches(prev, next)).toEqual([]);
+  });
+});
+
+// ============================================================================
+// approve → release-wave-flip
+// ============================================================================
+
+describe("decideDispatches: approve", () => {
+  function pendingApprovalWave(): WaveState {
+    let s = makeWave({ flip_policy: "manual-approval" });
+    s = ok(transition(s, { kind: "stage_report", now: T1, repo: "ippoan/rust-alc-api", ok: true })).state;
+    s = ok(transition(s, { kind: "stage_report", now: T1, repo: "ippoan/auth-worker", ok: true })).state;
+    return s;
+  }
+
+  it("emits release-wave-flip to all repos when approved", () => {
+    const prev = pendingApprovalWave();
+    const next = ok(
+      transition(prev, { kind: "approve", now: T2, approved_by: "ops@example.com" }),
+    ).state;
+    expect(next.state).toBe("flipping");
+    const ds = decideDispatches(prev, next);
+    expect(ds).toHaveLength(2);
+    expect(ds[0]!.event_type).toBe("release-wave-flip");
+    expect(ds[0]!.client_payload.wave_id).toBe("w1");
+  });
+});
+
+// ============================================================================
+// flip_report → no dispatch
+// ============================================================================
+
+describe("decideDispatches: flip_report", () => {
+  function flippingWave(): WaveState {
+    let s = makeWave({ flip_policy: "auto" });
+    s = ok(transition(s, { kind: "stage_report", now: T1, repo: "ippoan/rust-alc-api", ok: true })).state;
+    s = ok(transition(s, { kind: "stage_report", now: T1, repo: "ippoan/auth-worker", ok: true })).state;
+    return s;
+  }
+
+  it("does not dispatch on partial flip", () => {
+    const prev = flippingWave();
+    const next = ok(
+      transition(prev, { kind: "flip_report", now: T2, repo: "ippoan/rust-alc-api", ok: true }),
+    ).state;
+    expect(decideDispatches(prev, next)).toEqual([]);
+  });
+
+  it("does not dispatch when flipped completes", () => {
+    let s = flippingWave();
+    s = ok(transition(s, { kind: "flip_report", now: T2, repo: "ippoan/rust-alc-api", ok: true })).state;
+    const prev = s;
+    const next = ok(
+      transition(prev, { kind: "flip_report", now: T2, repo: "ippoan/auth-worker", ok: true }),
+    ).state;
+    expect(next.state).toBe("flipped");
+    expect(decideDispatches(prev, next)).toEqual([]);
+  });
+});
+
+// ============================================================================
+// rollback → release-wave-rollback
+// ============================================================================
+
+describe("decideDispatches: rollback", () => {
+  function flippedWave(): WaveState {
+    let s = makeWave({ flip_policy: "auto" });
+    s = ok(transition(s, { kind: "stage_report", now: T1, repo: "ippoan/rust-alc-api", ok: true })).state;
+    s = ok(transition(s, { kind: "stage_report", now: T1, repo: "ippoan/auth-worker", ok: true })).state;
+    s = ok(transition(s, { kind: "flip_report", now: T2, repo: "ippoan/rust-alc-api", ok: true })).state;
+    s = ok(transition(s, { kind: "flip_report", now: T2, repo: "ippoan/auth-worker", ok: true })).state;
+    return s;
+  }
+
+  it("emits release-wave-rollback to all repos", () => {
+    const prev = flippedWave();
+    const next = ok(
+      transition(prev, { kind: "rollback", now: T2, rolled_back_by: "ops" }),
+    ).state;
+    expect(next.state).toBe("rolled-back");
+    const ds = decideDispatches(prev, next);
+    expect(ds).toHaveLength(2);
+    expect(ds[0]!.event_type).toBe("release-wave-rollback");
+    expect(ds[0]!.client_payload).toHaveProperty("flip_from_revision");
+    expect(ds[0]!.client_payload).toHaveProperty("rollback_target");
+  });
+
+  it("includes flip_from_revision per repo when available", () => {
+    let s = makeWave({ flip_policy: "auto" });
+    s = ok(
+      transition(s, {
+        kind: "stage_report",
+        now: T1,
+        repo: "ippoan/rust-alc-api",
+        ok: true,
+        flip_from_revision: "rust-alc-api-old-rev",
+      }),
+    ).state;
+    s = ok(
+      transition(s, {
+        kind: "stage_report",
+        now: T1,
+        repo: "ippoan/auth-worker",
+        ok: true,
+        flip_from_revision: "auth-worker-old-rev",
+      }),
+    ).state;
+    s = ok(transition(s, { kind: "flip_report", now: T2, repo: "ippoan/rust-alc-api", ok: true })).state;
+    s = ok(transition(s, { kind: "flip_report", now: T2, repo: "ippoan/auth-worker", ok: true })).state;
+    const prev = s;
+    const next = ok(
+      transition(prev, { kind: "rollback", now: T2, rolled_back_by: "ops" }),
+    ).state;
+    const ds = decideDispatches(prev, next);
+    expect(ds[0]!.client_payload.flip_from_revision).toBe("rust-alc-api-old-rev");
+    expect(ds[1]!.client_payload.flip_from_revision).toBe("auth-worker-old-rev");
+  });
+});
+
+// ============================================================================
+// abort / fail / contract_applied → no dispatch
+// ============================================================================
+
+describe("decideDispatches: silent transitions", () => {
+  it("does not dispatch on abort", () => {
+    const prev = makeWave();
+    const next = ok(
+      transition(prev, {
+        kind: "abort",
+        now: T1,
+        aborted_by: "ops",
+        reason: "test",
+      }),
+    ).state;
+    expect(decideDispatches(prev, next)).toEqual([]);
+  });
+
+  it("does not dispatch on fail", () => {
+    const prev = makeWave();
+    const next = ok(
+      transition(prev, { kind: "fail", now: T1, reason: "boom" }),
+    ).state;
+    expect(decideDispatches(prev, next)).toEqual([]);
+  });
+
+  it("does not dispatch on contract_applied", () => {
+    let s = makeWave({ flip_policy: "auto" });
+    s = ok(transition(s, { kind: "stage_report", now: T1, repo: "ippoan/rust-alc-api", ok: true })).state;
+    s = ok(transition(s, { kind: "stage_report", now: T1, repo: "ippoan/auth-worker", ok: true })).state;
+    s = ok(transition(s, { kind: "flip_report", now: T2, repo: "ippoan/rust-alc-api", ok: true })).state;
+    s = ok(transition(s, { kind: "flip_report", now: T2, repo: "ippoan/auth-worker", ok: true })).state;
+    const prev = s;
+    const next = ok(
+      transition(prev, {
+        kind: "contract_applied",
+        now: T2,
+        repo: "ippoan/rust-alc-api",
+        migration_id: "20260601_001_drop",
+      }),
+    ).state;
+    expect(decideDispatches(prev, next)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 概要

Phase 5 の前提: ci-dashboard 内で DO state 遷移を契機に各 caller repo へ `repository_dispatch` を fan-out する **dispatcher** を追加。これで `release_wave_start` MCP tool / Admin UI ボタンが実際に repo の `release-wave.yml` workflow を起動できるようになる。

## 関連 issue

Refs ippoan/ci-dashboard#137

## 変更点

### `src/release-wave/dispatch.ts` (新規)

| function | 役割 |
|---|---|
| `decideDispatches(prev, next)` | **pure**。state 遷移から発火すべき `Dispatch[]` を計算 |
| `dispatchAll(env, dispatches)` | IO。GitHub API へ並列送信 (best-effort) |

発火条件:

| 遷移 | event_type | 対象 |
|---|---|---|
| `null → staging` | `release-wave-stage` | 全 repo |
| `* → flipping` | `release-wave-flip` | 全 repo |
| `flipped → rolled-back` | `release-wave-rollback` | 全 repo |
| その他 (stage 中継 / contract / abort / fail) | — | 空配列 |

### `src/release-wave/do.ts`

- `start()` / `applyEvent()` の末尾で `maybeDispatch(prev, next)` を呼ぶ
- `maybeDispatch` は decideDispatches → dispatchAll → 失敗 console.warn
- 失敗時も DO method 自体は ok を返す → caller への state 提供は維持、実 dispatch fail は operator が log で気付く設計

### Tests (`test/release-wave/dispatch.test.ts`)

13 cases — 全遷移パスを exercise、空配列 case も網羅。
既存 DO test 19/19 pass 維持 (dispatchAll best-effort 設計のおかげで GitHub token 不在環境でも DO method 自体は成功)。

## client_payload に載せる field

```json
{
  "wave_id":           "wave_2026_05_28_01",
  "target_tag":        "v1.42.0",
  "head_sha":          "abc123...",

  // rollback event 時のみ追加
  "flip_from_revision": "rust-alc-api-old-rev",
  "rollback_target":    {}   // per-service map (Phase 5+ で活用予定)
}
```

これは Phase 4b/4c で実装した release-wave-handler.yml が受ける形式と一致。

## 動作確認

- [x] `tsc --noEmit` 型エラー無し
- [x] vitest `test/release-wave/dispatch.test.ts` **13/13 pass**
- [x] vitest `test/release-wave/do.test.ts` **19/19 pass** (regression なし)
- [ ] 実 dispatch は staging に deploy 後、release_wave_start MCP 試運転で確認

## 後続 (Phase 5 へ進むのに必要な残り)

| 項目 | 状態 |
|---|---|
| **release-wave-gcp の実 deploy** (GCP setup + repo CI deploy-staging job) | 未 |
| **`RELEASE_WAVE_GCP_API_KEY` 投入** (secret-rotate-pipe 経由) | 未 |
| **rust-alc-api `deploy.yml` に `--no-traffic --tag` モード追加** | 未 |
| **各 repo に `release-wave.yml` caller 追加 (rust-alc-api / auth-worker)** | 未 (Phase 5 本体) |

本 PR merge 後、これらを順次 PR で着手。

## メモ

- dispatcher は同期 `await` で待つ (`ctx.waitUntil` 非採用)。理由: state 遷移と dispatch の対応関係を透明にし、テスト容易性を保つため。N=10 程度の並列 POST なら数秒で済むので許容範囲
- 各 dispatch は per-repo の `tokenForOrg(env, owner)` で GitHub App token を取得 (既存 `src/github-api.ts` の経路を流用)。caller repo 側に追加の installation 設定は不要 (ci-dashboard が ippoan org に App として install 済の前提)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm4uPMVQZHWm5eFurYMJif)_