### PR TITLE
fix: extract cross-repo style `Refs <owner>/<name>#N` for /releases tracking

### DIFF
--- a/src/release-alert.ts
+++ b/src/release-alert.ts
@@ -71,9 +71,10 @@ export async function collectIssueNumbersForRange(
 
   const issueNumbers = new Set<number>();
   const prNumbers = new Set<number>();
+  const repoCtx = { owner, name };
   for (const c of commits) {
     const msg = c.commit.message;
-    for (const n of extractRefIssues(msg)) issueNumbers.add(n);
+    for (const n of extractRefIssues(msg, repoCtx)) issueNumbers.add(n);
     const pr = extractPrNumber(msg);
     if (pr !== null) prNumbers.add(pr);
   }
@@ -86,7 +87,7 @@ export async function collectIssueNumbersForRange(
       const fromBranch = extractBranchIssue(pr.head.ref);
       if (fromBranch !== null) issueNumbers.add(fromBranch);
       if (pr.body) {
-        for (const ref of extractRefIssues(pr.body)) issueNumbers.add(ref);
+        for (const ref of extractRefIssues(pr.body, repoCtx)) issueNumbers.add(ref);
       }
     } catch { /* ignore per-PR failure */ }
   }));
@@ -198,6 +199,7 @@ export async function computeReleaseAlertForPr(
   const token = await tokenForOrg(env, owner);
 
   const issueNumbers = new Set<number>();
+  const repoCtx = { owner, name };
 
   // PR metadata: body has `Refs #N`, branch name has the issue prefix
   // (CLAUDE.md convention <issue>-<type>-<desc>).
@@ -206,7 +208,7 @@ export async function computeReleaseAlertForPr(
     const fromBranch = extractBranchIssue(pr.head.ref);
     if (fromBranch !== null) issueNumbers.add(fromBranch);
     if (pr.body) {
-      for (const ref of extractRefIssues(pr.body)) issueNumbers.add(ref);
+      for (const ref of extractRefIssues(pr.body, repoCtx)) issueNumbers.add(ref);
     }
   } catch { /* PR fetch failure — still try commit walk */ }
 
@@ -216,7 +218,7 @@ export async function computeReleaseAlertForPr(
   try {
     const commits = await cachedPullRequestCommits(token, kv, owner, name, prNumber);
     for (const c of commits) {
-      for (const n of extractRefIssues(c.commit.message)) issueNumbers.add(n);
+      for (const n of extractRefIssues(c.commit.message, repoCtx)) issueNumbers.add(n);
     }
   } catch { /* commits API failure — proceed with what we have */ }
 

--- a/src/release-helpers.ts
+++ b/src/release-helpers.ts
@@ -5,12 +5,37 @@
 // `Refs #N` / `Related to #N` / `Part of #N` (case-insensitive). The Refs-style
 // convention is documented in CLAUDE.md as the auto-close-safe replacement for
 // `Closes #N` / `Fixes #N`.
-const REF_PATTERN = /(?:Refs|Related to|Part of)\s+#(\d+)/gi;
+//
+// Cross-repo style `Refs <owner>/<name>#N` も許容する。Claude (LLM agent) が
+// PR を生成する際、同 repo の issue でも cross-repo style で書く場合があり
+// (Refs ippoan/secrets-inventory#57, ippoan/HealthConnectReaderWorker#60 等)、
+// これを capture するため owner/name 部分を optional として match する。
+// caller が `currentRepo` を渡すと、その repo に属する ref のみ返す
+// (= 真の cross-repo ref を誤って同 repo issue として混入させない)。
+const REF_PATTERN = /(?:Refs|Related to|Part of)\s+([\w.-]+\/[\w.-]+)?#(\d+)/gi;
 
-export function extractRefIssues(text: string): number[] {
+export function extractRefIssues(
+  text: string,
+  currentRepo?: { owner: string; name: string },
+): number[] {
   if (!text) return [];
   const out = new Set<number>();
-  for (const m of text.matchAll(REF_PATTERN)) out.add(Number(m[1]));
+  const wantOwner = currentRepo?.owner.toLowerCase();
+  const wantName = currentRepo?.name.toLowerCase();
+  for (const m of text.matchAll(REF_PATTERN)) {
+    const crossRepo = m[1]; // optional `<owner>/<name>`
+    const num = Number(m[2]);
+    if (crossRepo) {
+      // currentRepo 未指定なら cross-repo ref は除外 (= 別 repo の issue
+      // 番号を本 repo のものと誤って混ぜないよう conservative に skip)。
+      if (!wantOwner || !wantName) continue;
+      const slash = crossRepo.indexOf("/");
+      const o = crossRepo.slice(0, slash).toLowerCase();
+      const n = crossRepo.slice(slash + 1).toLowerCase();
+      if (o !== wantOwner || n !== wantName) continue;
+    }
+    out.add(num);
+  }
   return [...out];
 }
 

--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -237,7 +237,7 @@ async function loadRepoView(
       const cmp = await cachedCompare(token, kv, owner, name, prevTag, tag);
       const refs = new Set<number>();
       for (const c of cmp.commits) {
-        for (const n of extractRefIssues(c.commit.message)) refs.add(n);
+        for (const n of extractRefIssues(c.commit.message, { owner, name })) refs.add(n);
       }
       return { tag, prevTag, refs: [...refs] };
     } catch {
@@ -328,7 +328,7 @@ async function loadSyntheticBlock(
 
   const refs = new Set<number>();
   for (const c of commits) {
-    for (const n of extractRefIssues(c.commit.message)) refs.add(n);
+    for (const n of extractRefIssues(c.commit.message, { owner, name })) refs.add(n);
   }
   if (refs.size === 0) {
     // No referenced issues in the recent window — nothing to confirm. Skipping

--- a/test/release-helpers.test.ts
+++ b/test/release-helpers.test.ts
@@ -28,6 +28,41 @@ describe("extractRefIssues", () => {
     expect(extractRefIssues("")).toEqual([]);
     expect(extractRefIssues("no references here")).toEqual([]);
   });
+
+  // Cross-repo style `Refs <owner>/<name>#N` のサポート。Claude (LLM agent) が
+  // PR を生成する際、同 repo の issue でも cross-repo style で書くことがあり
+  // (例: 本 commit 内で見られる `Refs ippoan/HealthConnectReaderWorker#60`)、
+  // currentRepo を渡せばその repo の ref として正しく拾えるようにする。
+  describe("cross-repo style (Refs <owner>/<name>#N)", () => {
+    const repo = { owner: "ippoan", name: "HealthConnectReaderWorker" };
+
+    it("picks cross-repo refs that match currentRepo", () => {
+      const msg = "Refs ippoan/HealthConnectReaderWorker#60\nRefs #61";
+      expect(extractRefIssues(msg, repo).sort()).toEqual([60, 61]);
+    });
+
+    it("filters out cross-repo refs to other repos", () => {
+      const msg =
+        "Refs ippoan/HealthConnectReaderWorker#60\n" +
+        "Refs ippoan/other-repo#99";
+      expect(extractRefIssues(msg, repo)).toEqual([60]);
+    });
+
+    it("is case-insensitive on owner/name", () => {
+      const msg = "Refs IPPOAN/healthconnectreaderworker#60";
+      expect(extractRefIssues(msg, repo)).toEqual([60]);
+    });
+
+    it("without currentRepo skips cross-repo refs (conservative)", () => {
+      // currentRepo 未指定なら cross-repo style は全部 skip。bare `Refs #N`
+      // のみ拾う。これは別 repo の issue 番号を本 repo の番号と取り違える
+      // 事故を防ぐため。
+      const msg =
+        "Refs ippoan/HealthConnectReaderWorker#60\n" +
+        "Refs #42";
+      expect(extractRefIssues(msg)).toEqual([42]);
+    });
+  });
 });
 
 describe("extractPrNumber", () => {


### PR DESCRIPTION
## 概要

`/releases` ページに HealthConnectReaderWorker や secrets-inventory の synthetic block が出てこない原因の fix。

## 根本原因

PR #146 で HCRW を `TAGLESS_REPOS` に追加したが、`loadSyntheticBlock` が PR #61 commit から `Refs` を抽出できず空配列を返すため、synthetic block 自体が `null` 扱いで表示されない。

regex:

```ts
const REF_PATTERN = /(?:Refs|Related to|Part of)\s+#(\d+)/gi;
```

これは bare `Refs #N` 形式のみを match する。一方、PR #61 commit message は:

```
Refs ippoan/HealthConnectReaderWorker#60
```

という **cross-repo style** で書かれている。Claude (LLM agent) が PR を生成する際にこの style を使う癖があり、同じ問題は secrets-inventory#58 にも存在 (`Refs ippoan/secrets-inventory#57`)。

## 修正

`extractRefIssues` を拡張:

1. **regex に optional `<owner>/<name>` prefix を追加**:
   ```ts
   /(?:Refs|Related to|Part of)\s+([\w.-]+\/[\w.-]+)?#(\d+)/gi
   ```
2. **第 2 引数 `currentRepo?: { owner, name }` を受ける**
3. cross-repo style ref は `currentRepo` と一致した時のみ採用 (case-insensitive)
4. `currentRepo` 未指定なら cross-repo style は **skip** (bare `Refs #N` のみ拾う)
   - = 別 repo の issue 番号を本 repo の番号と取り違える事故を防ぐ conservative 動作

呼び出し側 (`releases-page.ts` × 2、`release-alert.ts` × 4) を全て更新し、scope 内の `owner` / `name` を渡すよう変更。

## テスト

`test/release-helpers.test.ts` に 4 ケース追加 (合計 9 ケース):

- cross-repo style + currentRepo match → 拾う
- cross-repo style + 別 repo → 拾わない
- case-insensitive (`IPPOAN/healthconnectreaderworker` でも match)
- currentRepo 未指定 → cross-repo style は skip

既存の bare `Refs #N` テスト 5 ケースは互換性確認のため変更なし。

## Test plan

- [ ] CI green
- [ ] deploy 後、`/releases` で HealthConnectReaderWorker と secrets-inventory が synthetic block で出ること
- [ ] `Refs #60` `Refs #61` (HCRW)、`Refs #57` `Refs #58` (secrets-inventory) が close 候補として表示されること

Refs #147

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb2hASFhbDtbdd83fNtFEB)_