### PR TITLE
fix: prepend Unreleased synthetic block for TAGLESS_REPOS repos that have tags

### DIFF
--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -280,6 +280,18 @@ async function loadRepoView(
       .sort((a, c) => a.number - c.number),
   }));
 
+  // TAGLESS_REPOS に居る repo が tag を持つ場合、latest tag → HEAD で merge
+  // されたが未 release な PR 由来の open issue を「Unreleased」block として
+  // tag blocks の先頭に追加する。ci-dashboard / secrets-inventory のような
+  // 「PR merge = staging deploy だが release tag も cut する」混合運用の repo
+  // で、merge 済み未 release の issue を見落とさないようにするのが目的。
+  // Refs ippoan/ci-dashboard#147 (cross-repo Refs 修正) + #145 (TAGLESS 追加)。
+  if (useSynthetic) {
+    const latestTag = sorted[0]!;
+    const unreleased = await loadSyntheticBlock(token, owner, name, kv, latestTag);
+    if (unreleased) tagBlocks.unshift(unreleased);
+  }
+
   return {
     repo: `${owner}/${name}`,
     tagBlocks,
@@ -308,6 +320,13 @@ async function loadSyntheticBlock(
   owner: string,
   name: string,
   kv?: KVNamespace,
+  // `sinceTag` 指定時は latestTag..defaultBranch の compare で commits を取り、
+  // `<branch>@<sha7> (since <sinceTag>)` という "Unreleased" 風の block にする。
+  // 指定無しなら従来通り default branch の最近 SYNTHETIC_COMMIT_WINDOW commits。
+  // Refs ippoan/ci-dashboard#147 (cross-repo Refs 修正) と #145 の延長:
+  // TAGLESS_REPOS 指定の repo が tag を持つ場合に「latest tag → HEAD で merge
+  // されたが未 release な PR」を表示するための「unreleased zone」用途。
+  sinceTag?: string,
 ): Promise<TagBlock | null> {
   let defaultBranch: string;
   try {
@@ -320,7 +339,12 @@ async function loadSyntheticBlock(
 
   let commits: RawCommit[] = [];
   try {
-    commits = await cachedCommits(token, kv, owner, name, defaultBranch, SYNTHETIC_COMMIT_WINDOW);
+    if (sinceTag) {
+      const cmp = await cachedCompare(token, kv, owner, name, sinceTag, defaultBranch);
+      commits = cmp.commits;
+    } else {
+      commits = await cachedCommits(token, kv, owner, name, defaultBranch, SYNTHETIC_COMMIT_WINDOW);
+    }
   } catch {
     return null;
   }
@@ -357,10 +381,18 @@ async function loadSyntheticBlock(
 
   if (openRows.length === 0) return null;
 
-  const headSha7 = commits[0]!.sha.slice(0, 7);
+  // commits の並び順:
+  //   - 通常 (sinceTag 無し): cachedCommits は最新 first (GitHub /commits API 既定)
+  //   - sinceTag 有り:        cachedCompare は古い first (GitHub /compare API)
+  // どちらでも HEAD (= 最も新しい) sha を tag 名に含めたいので分岐させる。
+  const headCommit = sinceTag ? commits[commits.length - 1]! : commits[0]!;
+  const headSha7 = headCommit.sha.slice(0, 7);
+  const tagLabel = sinceTag
+    ? `Unreleased (${defaultBranch}@${headSha7})`
+    : `${defaultBranch}@${headSha7}`;
   return {
-    tag: `${defaultBranch}@${headSha7}`,
-    prevTag: null,
+    tag: tagLabel,
+    prevTag: sinceTag ?? null,
     issues: openRows,
     synthetic: true,
   };

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -7,8 +7,9 @@ import { clearReleaseCache } from "../src/release-cache";
 // `watched` populates the Hub `/statuses` response so the no-params index
 // page can enumerate repos. Defaults to empty so existing tests keep their
 // pre-#41 behavior (form-only).
-function testEnv(opts: { watched?: string[] } = {}): Env {
+function testEnv(opts: { watched?: string[]; tagless?: string[] } = {}): Env {
   const watched = opts.watched ?? [];
+  const tagless = opts.tagless;
   return {
     CI_STATUS: env.CI_STATUS,
     WEBHOOK_SECRET: { get: async () => "test-secret" } as unknown as SecretsStoreSecret,
@@ -26,6 +27,7 @@ function testEnv(opts: { watched?: string[] } = {}): Env {
     } as unknown as DurableObjectNamespace,
     RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
     RELEASE_WAVE_WEBHOOK_SECRET: { get: async () => "test-webhook-secret" } as unknown as SecretsStoreSecret,
+    ...(tagless ? { TAGLESS_REPOS: tagless.join(",") } : {}),
   };
 }
 
@@ -716,6 +718,88 @@ describe("GET /releases", () => {
     // Second load should be served entirely from KV — no new GitHub calls.
     expect(fetchCount).toBe(firstLoadCalls);
     expect(res2.status).toBe(200);
+  });
+
+  // TAGLESS_REPOS にいる repo が tag を持つ場合、latest tag → HEAD の Unreleased
+  // 区間に対する synthetic block を tag blocks の先頭に追加する。
+  // ci-dashboard / secrets-inventory のように「PR merge = staging deploy だが
+  // release tag も cut する」混合運用の repo で、merge 済み未 release な PR
+  // の issue を `/releases` で目視できるようにするのが目的。
+  // Refs ippoan/ci-dashboard#147 (cross-repo Refs 修正) + #145 (TAGLESS 追加)。
+  it("prepends an Unreleased synthetic block for a TAGLESS_REPOS repo that has tags", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
+      const url = typeof req === "string" ? req : (req as Request).url;
+
+      // direct-push allowlist は空 (= TAGLESS_REPOS だけで repo を拾う)
+      if (url.includes("/contents/wt-direct-push/config/direct-push-ok.txt")) {
+        return Response.json({ content: btoa(""), encoding: "base64" });
+      }
+
+      // 通常通り tag がある repo
+      if (url.includes("/repos/ippoan/mixed-repo/tags")) {
+        return Response.json([
+          { name: "v1.0.0", commit: { sha: "tag1aaaa" } },
+        ]);
+      }
+
+      // default_branch lookup (loadSyntheticBlock で必要)
+      if (url.match(/\/repos\/ippoan\/mixed-repo(\?|$)/)) {
+        return Response.json({ default_branch: "main" });
+      }
+
+      // latest_tag..HEAD の compare (Unreleased zone)
+      if (url.includes("/repos/ippoan/mixed-repo/compare/v1.0.0...main")) {
+        return Response.json({
+          commits: [
+            // 1 つ目: bare Refs (古い)
+            { sha: "abc1111111111111", commit: { message: "feat: foo\n\nRefs #200" } },
+            // 2 つ目: cross-repo style Refs (新しい = HEAD、PR #149 の修正で拾える形)
+            { sha: "def2222222222222", commit: { message: "fix: bar\n\nRefs ippoan/mixed-repo#201" } },
+          ],
+        });
+      }
+
+      // tag 内部の compare は空でも問題ない (loadRepoView が prevTag=null なら refs 空)
+      // ここでは TOP_TAGS_INLINE=5 中 1 tag のみ提供しているので呼ばれない。
+
+      // 上記 Unreleased zone で抽出される issue
+      if (url.endsWith("/repos/ippoan/mixed-repo/issues/200")) {
+        return Response.json({
+          number: 200, title: "merged-but-unreleased issue", state: "open",
+          labels: [], assignees: [],
+          html_url: "https://github.com/ippoan/mixed-repo/issues/200",
+          updated_at: "2026-05-27T00:00:00Z",
+        });
+      }
+      if (url.endsWith("/repos/ippoan/mixed-repo/issues/201")) {
+        return Response.json({
+          number: 201, title: "cross-repo-style ref", state: "open",
+          labels: [], assignees: [],
+          html_url: "https://github.com/ippoan/mixed-repo/issues/201",
+          updated_at: "2026-05-27T01:00:00Z",
+        });
+      }
+
+      return new Response(`not stubbed: ${url}`, { status: 500 });
+    });
+
+    const e = testEnv({ tagless: ["ippoan/mixed-repo"] });
+    const req = new Request("http://localhost/releases");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, e, ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    // Unreleased synthetic block が出ている (label に "Unreleased" + HEAD sha7)
+    expect(html).toContain("Unreleased (main@def2222)");
+    // 両方の issue (bare + cross-repo style) が候補として表示される
+    expect(html).toContain("merged-but-unreleased issue");
+    expect(html).toContain("cross-repo-style ref");
+    // 既存 tag block (v1.0.0 / prev 無し) はそのまま — refs が無いので tag 自体は
+    // 表示されるが issue は付かない。HTML に tag 名は出てよい。
+    expect(html).toContain("ippoan/mixed-repo");
   });
 
   it("does not turn an unallowlisted tag-less repo into a synthetic block", async () => {


### PR DESCRIPTION
## 概要

ci-dashboard 自身を含め、`TAGLESS_REPOS` に登録されているが **release tag も cut している repo** で、latest tag 以降に merge された PR の Refs が `/releases` に表示されない問題を修正。

## 動機

ci-dashboard は `TAGLESS_REPOS` に登録済 (synthetic block を希望) だが、release tag (v0.0.72 まで) も cut しているため、現状の `loadRepoView` は tag path のみを返す:

```ts
if (topTags.length === 0) {
  if (useSynthetic) { return loadSyntheticBlock(...); }
  return empty;
}
// tag path: tag blocks のみ — synthetic は出ない
```

結果として PR #146 / #149 (= 本 PR が修正対象とする issue #145, #147 を Refs) は `/releases` に出てこなかった。secrets-inventory 同様。

## 修正

`TAGLESS_REPOS` semantic を **「synthetic block も追加で出す」** に再定義 (既存「tag 無し時 fallback」から拡張):

1. **`loadSyntheticBlock` に `sinceTag?: string` パラメタ追加**
   - 指定時: `/compare/<sinceTag>...<defaultBranch>` で commits 取得 (古い→新しい順)
   - 指定無し: 従来通り `cachedCommits` 経由 100 commits (= tag-less repo fallback、behavior 変更無し)
2. **戻り値 label を分岐**
   - 通常: `<branch>@<sha7>` (既存)
   - Unreleased zone: `Unreleased (<branch>@<sha7>)`
3. **`loadRepoView` の tag path 末尾**で `useSynthetic` ガード付きで `loadSyntheticBlock(..., latestTag)` を呼び、tagBlocks の先頭に `unshift`

## 動作マトリクス

| Repo | TAGLESS_REPOS | tags | 動作 |
|---|---|---|---|
| HCRW | ✓ | 無し | `cachedCommits` 経由 synthetic block (既存) |
| secrets-inventory | ✓ | 無し | 同上 (既存) |
| ci-dashboard | ✓ | 有り (v0.0.72) | **Unreleased block (v0.0.72→HEAD) + tag blocks** (新規) |
| 他 (alc-app 等) | — | 有り | tag blocks のみ (既存) |

## テスト

新規ケース: TAGLESS で tags 持ち + Unreleased zone に bare Refs と cross-repo style Refs 混合 commits → Unreleased block が `tagBlocks[0]` として表示され、両方の issue が候補に出現。

`testEnv` の opts に `tagless?: string[]` を追加 (既存 test は invariance)。

## Test plan

- [ ] CI green (typecheck + vitest)
- [ ] deploy 後、`/releases` で:
  - ci-dashboard カードに `Unreleased (main@<sha>)` block が tag 群の前に表示
  - その block に issue #145、#147 (場合により他の release-wave 関連 issue) が close 候補として並ぶ
- [ ] secrets-inventory も同様 (こちらは現状 tag 無しなので既存 synthetic path、変化なし)
- [ ] HCRW も従来通り synthetic block で表示

Refs #150

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb2hASFhbDtbdd83fNtFEB)_