### PR TITLE
fix: surface close-failure reason on /releases (e.g. archived repo 403)

### DIFF
--- a/src/release-close-batch.ts
+++ b/src/release-close-batch.ts
@@ -1,4 +1,5 @@
 import { githubApi, parseRepo, tokenForOrg } from "./github-api";
+import { formatCloseFailureReason } from "./release-close";
 import type { AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
 import { invalidateIssue } from "./release-cache";
 
@@ -88,9 +89,14 @@ export async function handleReleaseCloseBatch(
 
   const closed: number[] = [];
   const failed: number[] = [];
+  const failedReasons: Array<{ n: number; reason: string }> = [];
   settled.forEach((r, i) => {
     if (r.status === "fulfilled") closed.push(r.value);
-    else failed.push(ops[i]!.issue);
+    else {
+      const n = ops[i]!.issue;
+      failed.push(n);
+      failedReasons.push({ n, reason: formatCloseFailureReason(r.reason) });
+    }
   });
 
   // Invalidate cached issue snapshots so the next /releases load reflects the
@@ -116,6 +122,12 @@ export async function handleReleaseCloseBatch(
   const params = new URLSearchParams({ repo: repoParam });
   if (closed.length > 0) params.set("closed", closed.join(","));
   if (failed.length > 0) params.set("failed", failed.join(","));
+  if (failedReasons.length > 0) {
+    params.set(
+      "failed_reasons",
+      failedReasons.map((f) => `${f.n}:${encodeURIComponent(f.reason)}`).join(","),
+    );
+  }
   return redirect(`/releases?${params.toString()}`);
 }
 

--- a/src/release-close.ts
+++ b/src/release-close.ts
@@ -1,6 +1,32 @@
-import { githubApi, parseRepo, tokenForOrg } from "./github-api";
+import { GitHubApiError, githubApi, parseRepo, tokenForOrg } from "./github-api";
 import type { AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
 import { invalidateIssue } from "./release-cache";
+
+// failure 理由を URL flash param に safely 載せるための整形。
+// GitHubApiError は `GitHub API 403: {"message":"Repository was archived so
+// is read-only.",...}` のような長い文字列を持つので、典型的な状況だけ短い
+// human-readable string にマッピングし、それ以外は素の message を 100 字に
+// 切る。export しているのは test から検証するため。
+// Refs ippoan/ci-dashboard#152
+export function formatCloseFailureReason(err: unknown): string {
+  if (err instanceof GitHubApiError) {
+    const msg = err.message;
+    if (/Repository was archived/i.test(msg)) return "archived (read-only)";
+    if (err.status === 403) {
+      // 残りの 403 は token 権限不足 / SSO 未承認 / rate limit などが主。
+      // message から rate limit / SAML SSO を抜き出して短文化。
+      if (/rate limit/i.test(msg)) return "rate limit";
+      if (/SAML SSO/i.test(msg)) return "SAML SSO required";
+      return "forbidden (403)";
+    }
+    if (err.status === 404) return "not found (404)";
+    if (err.status === 410) return "issues disabled (410)";
+    if (err.status === 422) return "validation failed (422)";
+    return `${err.status} ${msg.slice(0, 80)}`;
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.slice(0, 100);
+}
 
 // POST /api/release-close
 // Receives the form submitted from /releases?repo=...&tag=... and closes the
@@ -69,9 +95,14 @@ export async function handleReleaseClose(
 
   const closed: number[] = [];
   const failed: number[] = [];
+  const failedReasons: Array<{ n: number; reason: string }> = [];
   settled.forEach((r, i) => {
     if (r.status === "fulfilled") closed.push(r.value);
-    else failed.push(issueNumbers[i]!);
+    else {
+      const n = issueNumbers[i]!;
+      failed.push(n);
+      failedReasons.push({ n, reason: formatCloseFailureReason(r.reason) });
+    }
   });
 
   // Drop the just-closed issues from the release cache so the next /releases
@@ -98,6 +129,15 @@ export async function handleReleaseClose(
   const params = new URLSearchParams({ repo: repoParam, tag });
   if (closed.length > 0) params.set("closed", closed.join(","));
   if (failed.length > 0) params.set("failed", failed.join(","));
+  if (failedReasons.length > 0) {
+    // `failed_reasons=N:reason,N:reason` 形式で flash 経路に乗せる。reason 側に
+    // `,` や `:` が出る可能性は低いが、URL safety のため reason は個別に
+    // encodeURIComponent し、最外側は URLSearchParams が encode する。
+    params.set(
+      "failed_reasons",
+      failedReasons.map((f) => `${f.n}:${encodeURIComponent(f.reason)}`).join(","),
+    );
+  }
   return redirect(`/releases?${params.toString()}`);
 }
 

--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -52,6 +52,9 @@ export async function handleReleasesPage(
   // Flash params populated by POST /api/release-close{,-batch} redirects.
   const closedFlash = numericList(url.searchParams.get("closed"));
   const failedFlash = numericList(url.searchParams.get("failed"));
+  // `failed_reasons=N:reason,N:reason` 形式。reason は URL-encoded。
+  // Refs ippoan/ci-dashboard#152 (close 失敗時の原因表示)
+  const failedReasons = parseFailedReasons(url.searchParams.get("failed_reasons"));
 
   // Only the fully-specified pair opens the detail page; every other shape
   // (no params / partial / post-close redirect) falls through to the index so
@@ -73,7 +76,7 @@ export async function handleReleasesPage(
       return html(renderError(msg), 502);
     }
     return html(
-      renderHtml(result, closedFlash, failedFlash),
+      renderHtml(result, closedFlash, failedFlash, failedReasons),
       200,
       cacheControlFor(hasFlash, /* detail */ true),
     );
@@ -81,7 +84,7 @@ export async function handleReleasesPage(
 
   // Index page; `repoParam` (when set without tag, e.g. from the batch-close
   // redirect) tags along so flash links can point at the right GitHub repo.
-  return await handleIndexPage(env, closedFlash, failedFlash, repoParam, hasFlash);
+  return await handleIndexPage(env, closedFlash, failedFlash, failedReasons, repoParam, hasFlash);
 }
 
 // Cache-Control policy:
@@ -132,6 +135,7 @@ async function handleIndexPage(
   },
   closedFlash: number[],
   failedFlash: number[],
+  failedReasons: Map<number, string>,
   flashRepo: string | null,
   hasFlash: boolean,
 ): Promise<Response> {
@@ -185,6 +189,7 @@ async function handleIndexPage(
       views.filter((v): v is RepoView => v !== null),
       closedFlash,
       failedFlash,
+      failedReasons,
       flashRepo,
     ),
     200,
@@ -488,6 +493,28 @@ function numericList(s: string | null): number[] {
   return s.split(",").map((p) => Number(p.trim())).filter(Number.isInteger);
 }
 
+// `failed_reasons=N:urlencoded-reason,N:urlencoded-reason` を Map に parse する。
+// release-close{,-batch}.ts が生成する flash param 経路と対 (= 同 file の
+// `formatCloseFailureReason` でフォーマットされた 1 行短縮文字列)。
+// 不正な entry は silently drop して残りを返す (= 旧 URL や手書き URL でも
+// crash させない conservative parse)。Refs ippoan/ci-dashboard#152。
+export function parseFailedReasons(s: string | null): Map<number, string> {
+  const out = new Map<number, string>();
+  if (!s) return out;
+  for (const raw of s.split(",")) {
+    const idx = raw.indexOf(":");
+    if (idx <= 0) continue;
+    const n = Number(raw.slice(0, idx).trim());
+    if (!Number.isInteger(n) || n <= 0) continue;
+    try {
+      out.set(n, decodeURIComponent(raw.slice(idx + 1)));
+    } catch {
+      // malformed urlencoded → skip
+    }
+  }
+  return out;
+}
+
 // --------------------------------------------------------------------------
 // HTML
 // --------------------------------------------------------------------------
@@ -504,6 +531,7 @@ function renderHtml(
   data: ReleasePayload,
   closedFlash: number[],
   failedFlash: number[],
+  failedReasons: Map<number, string>,
 ): string {
   // Two filters drop rows from the form's candidate set:
   //   1. flash: just-closed rows from a close-then-redirect must not be offered
@@ -543,7 +571,7 @@ function renderHtml(
       </table>
     </details>`;
 
-  const flash = renderFlash(closedFlash, failedFlash, data.repo);
+  const flash = renderFlash(closedFlash, failedFlash, failedReasons, data.repo);
 
   const summary =
     `${escapeHtml(data.repo)} · <code>${escapeHtml(data.tag)}</code>` +
@@ -657,6 +685,7 @@ function renderRow(r: IssueRow): string {
 function renderFlash(
   closed: number[],
   failed: number[],
+  failedReasons: Map<number, string>,
   repo: string | null,
 ): string {
   if (closed.length === 0 && failed.length === 0) return "";
@@ -668,9 +697,25 @@ function renderFlash(
   const closedList = closed.length > 0
     ? `<div class="flash ok">✅ Closed: ${closed.map(issueLink).join(" ")}</div>`
     : "";
-  const failedList = failed.length > 0
-    ? `<div class="flash err">❌ Failed to close: ${failed.map(issueLink).join(" ")} (try again)</div>`
-    : "";
+  // failed_reasons が同伴している場合は per-issue で「#N: 理由」を 1 行ずつ
+  // 表示する。理由不明 (= 古い URL や旧 deploy の handler 由来) は従来通り
+  // 「try again」フォールバックを並べる。reason 文字列は formatCloseFailureReason
+  // で短縮済だが、念のため escapeHtml を通す (XSS 防御)。
+  // Refs ippoan/ci-dashboard#152。
+  let failedList = "";
+  if (failed.length > 0) {
+    if (failedReasons.size > 0) {
+      const items = failed.map((n) => {
+        const reason = failedReasons.get(n);
+        return reason
+          ? `<li>${issueLink(n)}: ${escapeHtml(reason)}</li>`
+          : `<li>${issueLink(n)}: (try again)</li>`;
+      }).join("");
+      failedList = `<div class="flash err">❌ Failed to close:<ul style="margin:0.25rem 0 0 1.25rem;padding:0">${items}</ul></div>`;
+    } else {
+      failedList = `<div class="flash err">❌ Failed to close: ${failed.map(issueLink).join(" ")} (try again)</div>`;
+    }
+  }
   return closedList + failedList;
 }
 
@@ -678,6 +723,7 @@ function renderIndex(
   views: RepoView[],
   closedFlash: number[],
   failedFlash: number[],
+  failedReasons: Map<number, string>,
   flashRepo: string | null,
 ): string {
   // Show repos with at least one referenced issue in their displayed tag
@@ -692,7 +738,7 @@ function renderIndex(
 
   // Banner sits above the cards so a successful batch close redirect always
   // lands the operator on the list with confirmation of what got closed.
-  const flash = renderFlash(closedFlash, failedFlash, flashRepo);
+  const flash = renderFlash(closedFlash, failedFlash, failedReasons, flashRepo);
 
   return `<!DOCTYPE html>
 <html lang="en"><head>

--- a/test/release-close-batch.test.ts
+++ b/test/release-close-batch.test.ts
@@ -114,6 +114,9 @@ describe("POST /api/release-close-batch", () => {
     const location = res.headers.get("Location") ?? "";
     expect(location).toContain("closed=1");
     expect(location).toContain("failed=5");
+    // batch handler も failed_reasons を flash 経路に乗せること。
+    // Refs ippoan/ci-dashboard#152
+    expect(location).toMatch(/failed_reasons=5%3A/);
     expect(calls.length).toBeGreaterThan(0);
   });
 

--- a/test/release-close-helpers.test.ts
+++ b/test/release-close-helpers.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { formatCloseFailureReason } from "../src/release-close";
+import { parseFailedReasons } from "../src/releases-page";
+import { GitHubApiError } from "../src/github-api";
+
+// Refs ippoan/ci-dashboard#152
+// close 失敗時の reason 短縮整形 + URL flash param 経路の roundtrip 検証。
+
+describe("formatCloseFailureReason", () => {
+  it("maps archived 403 to short human-readable string", () => {
+    const err = new GitHubApiError(
+      403,
+      'GitHub API 403: {"message":"Repository was archived so is read-only.","documentation_url":"..."}',
+    );
+    expect(formatCloseFailureReason(err)).toBe("archived (read-only)");
+  });
+
+  it("maps generic 403 to 'forbidden (403)'", () => {
+    const err = new GitHubApiError(403, "GitHub API 403: Resource not accessible by integration");
+    expect(formatCloseFailureReason(err)).toBe("forbidden (403)");
+  });
+
+  it("detects rate-limit 403", () => {
+    const err = new GitHubApiError(
+      403,
+      'GitHub API 403: {"message":"API rate limit exceeded for user ID 87104778"}',
+    );
+    expect(formatCloseFailureReason(err)).toBe("rate limit");
+  });
+
+  it("detects SAML SSO 403", () => {
+    const err = new GitHubApiError(
+      403,
+      'GitHub API 403: Resource protected by SAML SSO',
+    );
+    expect(formatCloseFailureReason(err)).toBe("SAML SSO required");
+  });
+
+  it("maps 404 / 410 / 422 to short labels", () => {
+    expect(formatCloseFailureReason(new GitHubApiError(404, "not found"))).toBe("not found (404)");
+    expect(formatCloseFailureReason(new GitHubApiError(410, "issues disabled"))).toBe("issues disabled (410)");
+    expect(formatCloseFailureReason(new GitHubApiError(422, "validation"))).toBe("validation failed (422)");
+  });
+
+  it("falls back to status + truncated message for other GitHubApiError", () => {
+    const err = new GitHubApiError(500, "GitHub API 500: boom");
+    const r = formatCloseFailureReason(err);
+    expect(r.startsWith("500 ")).toBe(true);
+    expect(r.length).toBeLessThanOrEqual(80 + 4);
+  });
+
+  it("handles non-Error values gracefully", () => {
+    expect(formatCloseFailureReason("network glitch")).toBe("network glitch");
+    expect(formatCloseFailureReason(new Error("offline"))).toBe("offline");
+  });
+
+  it("truncates very long fallback messages to 100 chars", () => {
+    const long = "x".repeat(500);
+    expect(formatCloseFailureReason(long).length).toBe(100);
+  });
+});
+
+describe("parseFailedReasons", () => {
+  it("parses N:urlencoded-reason,N:urlencoded-reason form", () => {
+    const m = parseFailedReasons("59:archived%20(read-only),60:rate%20limit");
+    expect(m.get(59)).toBe("archived (read-only)");
+    expect(m.get(60)).toBe("rate limit");
+  });
+
+  it("returns empty map for null / empty / malformed input", () => {
+    expect(parseFailedReasons(null).size).toBe(0);
+    expect(parseFailedReasons("").size).toBe(0);
+    expect(parseFailedReasons("garbage").size).toBe(0);
+    expect(parseFailedReasons(":no-number").size).toBe(0);
+    expect(parseFailedReasons("abc:not-a-number").size).toBe(0);
+  });
+
+  it("silently drops individual malformed entries while keeping valid ones", () => {
+    const m = parseFailedReasons("59:ok,garbage,60:also-ok");
+    expect(m.get(59)).toBe("ok");
+    expect(m.get(60)).toBe("also-ok");
+    expect(m.size).toBe(2);
+  });
+
+  it("roundtrips with the encoder used by release-close.ts", () => {
+    // release-close.ts は `${n}:${encodeURIComponent(reason)}` を join(",") で
+    // 連結する。同じ形式を assemble → parse して同値性を確認。
+    const enc = (n: number, r: string) => `${n}:${encodeURIComponent(r)}`;
+    const param = [
+      enc(1, "archived (read-only)"),
+      enc(2, "forbidden (403)"),
+      enc(3, "500 GitHub API 500: boom"),
+    ].join(",");
+    const m = parseFailedReasons(param);
+    expect(m.get(1)).toBe("archived (read-only)");
+    expect(m.get(2)).toBe("forbidden (403)");
+    expect(m.get(3)).toBe("500 GitHub API 500: boom");
+  });
+});

--- a/test/release-close.test.ts
+++ b/test/release-close.test.ts
@@ -23,7 +23,17 @@ interface RecordedCall {
   body: unknown;
 }
 
-function stubCloseFlow(opts: { failIssue?: number } = {}) {
+function stubCloseFlow(
+  opts: {
+    failIssue?: number;
+    /**
+     * 失敗時 GitHub API が返す Response。default は status 500 "boom" (= generic
+     * fallback path)。archived 403 など特定の reason を test するときに上書き。
+     * Refs ippoan/ci-dashboard#152
+     */
+    failResponse?: () => Response;
+  } = {},
+) {
   const calls: RecordedCall[] = [];
   const spy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
     const url = typeof input === "string" ? input : (input as Request).url;
@@ -37,7 +47,9 @@ function stubCloseFlow(opts: { failIssue?: number } = {}) {
     // Per-issue failure injection: any GitHub API touching the failing issue
     // returns 500 so the issue ends up in the `failed` flash list.
     if (opts.failIssue && url.includes(`/issues/${opts.failIssue}`)) {
-      return new Response("boom", { status: 500 });
+      return opts.failResponse
+        ? opts.failResponse()
+        : new Response("boom", { status: 500 });
     }
     if (url.includes("/comments")) {
       return Response.json({ id: 1 });
@@ -113,8 +125,48 @@ describe("POST /api/release-close", () => {
     const location = res.headers.get("Location") ?? "";
     expect(location).toContain("closed=12");
     expect(location).toContain("failed=34");
+    // 失敗 issue には reason が同伴している (500 fallback path)。
+    expect(location).toMatch(/failed_reasons=34%3A/);
     // Some GitHub API traffic still happened, but the failed issue short-circuits its PATCH.
     expect(calls.length).toBeGreaterThan(0);
+  });
+
+  // ippoan/github-mcp-server-rs#59 (archived 状態) で実害発生したケース。
+  // GitHub API は 403 + "Repository was archived so is read-only." を返すが、
+  // 旧 UI は "Failed to close: #N (try again)" の汎用 message しか出さず、
+  // operator が原因に気付けなかった。Refs ippoan/ci-dashboard#152。
+  it("surfaces 'archived (read-only)' as failed_reasons for an archived-repo 403", async () => {
+    stubCloseFlow({
+      failIssue: 59,
+      failResponse: () => new Response(
+        JSON.stringify({
+          message: "Repository was archived so is read-only.",
+          documentation_url: "https://docs.github.com/v3/issues",
+        }),
+        { status: 403, headers: { "Content-Type": "application/json" } },
+      ),
+    });
+    const req = new Request("http://localhost/api/release-close", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formBody([
+        ["repo", "ippoan/github-mcp-server-rs"],
+        ["tag", "v0.1.0"],
+        ["issue", "59"],
+      ]),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(303);
+    const location = res.headers.get("Location") ?? "";
+    const params = new URLSearchParams(location.split("?")[1] ?? "");
+    expect(params.get("failed")).toBe("59");
+    const reasons = params.get("failed_reasons") ?? "";
+    // 形式: `N:urlencoded-reason`。decode して reason 部分を検証。
+    expect(reasons.startsWith("59:")).toBe(true);
+    expect(decodeURIComponent(reasons.slice("59:".length))).toBe("archived (read-only)");
   });
 
   it("redirects without touching GitHub when no issues are selected", async () => {


### PR DESCRIPTION
## 概要

`/releases` の close UI が失敗時に「Failed to close: #N (try again)」しか出さず、operator が原因を判別できなかった問題を修正。`GitHubApiError` の status / message から短い理由を抽出して per-issue 表示する。

## 実害事例

`ippoan/github-mcp-server-rs#59` を close しようとして失敗。実際は repo が archived (`403 Repository was archived so is read-only.`) だったが、UI からは判別不能で operator は無限にリトライする状況に。

## 修正

### `formatCloseFailureReason(err)` (src/release-close.ts)

`GitHubApiError` を短い human-readable 文字列に整形:

| 入力 | 出力 |
|---|---|
| `403 Repository was archived...` | `archived (read-only)` |
| `403 rate limit exceeded...` | `rate limit` |
| `403 SAML SSO...` | `SAML SSO required` |
| `403` (その他) | `forbidden (403)` |
| `404` | `not found (404)` |
| `410` | `issues disabled (410)` |
| `422` | `validation failed (422)` |
| その他 status | `<status> <msg.slice(0, 80)>` |
| 非 `GitHubApiError` | `msg.slice(0, 100)` |

### Flash URL 経路

両 close handler が `Promise.allSettled` の rejection から reason を capture し、redirect URL に `failed_reasons=N:urlencoded-reason,N:...` 形式で乗せる。

### `parseFailedReasons` + `renderFlash` 更新

`releases-page.ts` に parser を追加 (export for test)。`renderFlash` を `Map<issue, reason>` 受け取りに更新:

```
❌ Failed to close:
  • #59: archived (read-only)
  • #60: rate limit
```

reason 不明 (= 旧 deploy の URL や手書き URL) は従来通り「(try again)」フォールバック。reason は `escapeHtml` を通して XSS 防御。

## ファイル変更

| ファイル | 区分 |
|---|---|
| `src/release-close.ts` | `formatCloseFailureReason` 追加、reason capture |
| `src/release-close-batch.ts` | import + reason capture |
| `src/releases-page.ts` | `parseFailedReasons` 追加、`renderFlash` / `renderIndex` / `renderHtml` / `handleIndexPage` signature 更新 |
| `test/release-close-helpers.test.ts` | 新規 (formatCloseFailureReason × 7 + parseFailedReasons × 4) |
| `test/release-close.test.ts` | archived 403 注入 case 追加、既存 partial-failure case に `failed_reasons=` assert 追加 |
| `test/release-close-batch.test.ts` | 既存 partial-failure case に `failed_reasons=` assert 追加 |

既存 UI test は failure message 文言を assert していないため renderFlash signature 変更で壊れない。

## Test plan

- [ ] CI green
- [ ] deploy 後、`ippoan/github-mcp-server-rs#59` を `/releases` から close 試行
  - 期待: `❌ Failed to close: #59: archived (read-only)` が UI に表示
- [ ] 正常 close は従来通り動く (`✅ Closed: #N`)

Refs #153

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb2hASFhbDtbdd83fNtFEB)_