### PR TITLE
fix: exclude archived repos from /releases

### DIFF
--- a/src/release-cache.ts
+++ b/src/release-cache.ts
@@ -40,7 +40,13 @@ interface TagListItem { name: string; commit: { sha: string } }
 interface RawCommit { sha: string; commit: { message: string } }
 interface CompareResponse { commits: RawCommit[] }
 interface PrResponse { head: { ref: string }; body: string | null }
-interface RepoMeta { default_branch: string }
+interface RepoMeta {
+  default_branch: string;
+  // GitHub /repos endpoint returns `archived: true` for archived repos.
+  // archived repo は issues も read-only になり close できないため、
+  // /releases ページから除外するのに使う (Refs ippoan/ci-dashboard#155)。
+  archived?: boolean;
+}
 export interface RawIssue {
   number: number;
   title: string;

--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -206,6 +206,23 @@ async function loadRepoView(
   const { owner, repo: name } = parseRepo(repo);
   const token = await tokenForOrg(env, owner);
 
+  // 0. Drop archived repos early. GitHub API は archived repo の issue PATCH
+  //    で 403 "Repository was archived so is read-only." を返すため、
+  //    operator が release UI から close しようとして必ず失敗する。
+  //    そもそも archived repo は将来の release tag も cut されない前提なので
+  //    一覧から外す。Refs ippoan/ci-dashboard#155 (ippoan/github-mcp-server-rs
+  //    が monorepo 化で archive されたが /releases に残っていた問題)。
+  //
+  //    meta fetch 自体が失敗 (private / 削除 / token 権限喪失 / network) した
+  //    場合は best-effort で握り潰し、既存の tag fetch 失敗 → null 経路に
+  //    判断を委ねる (= 「archived と確認できた時だけ」drop)。
+  try {
+    const meta = await cachedRepoMeta(token, kv, owner, name);
+    if (meta.archived === true) return null;
+  } catch {
+    /* archived 判定不能 — 続行 */
+  }
+
   // 1. Recent semver tags. 10 gives us 5 inline + room for the predecessor
   //    pairing on the oldest of those 5 + a small "older" strip.
   const allTags = await cachedTags(token, kv, owner, name, 10);
@@ -318,7 +335,10 @@ async function loadRepoView(
 // supported for these tags — `renderTagBlock` skips the link.
 const SYNTHETIC_COMMIT_WINDOW = 100;
 
-interface RepoMeta { default_branch: string }
+interface RepoMeta {
+  default_branch: string;
+  archived?: boolean;
+}
 
 async function loadSyntheticBlock(
   token: string,

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -802,6 +802,45 @@ describe("GET /releases", () => {
     expect(html).toContain("ippoan/mixed-repo");
   });
 
+  // archived repo は GitHub API で issue close ができない (403 read-only) ため、
+  // /releases から一切除外する。Refs ippoan/ci-dashboard#155
+  // (ippoan/github-mcp-server-rs が monorepo 化で archive されたが Refs を
+  // 含む過去 commit のせいで /releases に残り、close を試みて failed
+  // していた問題)。
+  it("excludes archived repos from /releases entirely", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
+      const url = typeof req === "string" ? req : (req as Request).url;
+
+      if (url.includes("/contents/wt-direct-push/config/direct-push-ok.txt")) {
+        return Response.json({ content: btoa(""), encoding: "base64" });
+      }
+
+      // /repos/{o}/{n} で archived: true を返す
+      if (url.match(/\/repos\/ippoan\/zombie-repo(\?|$)/)) {
+        return Response.json({ default_branch: "main", archived: true });
+      }
+
+      // archived 判定が効いていれば tag fetch には到達しない。到達したら test fail。
+      if (url.includes("/repos/ippoan/zombie-repo/tags")) {
+        throw new Error("unexpected fetch: archived filter leaked, tag path reached");
+      }
+
+      return new Response(`not stubbed: ${url}`, { status: 500 });
+    });
+
+    const e = testEnv({ watched: ["ippoan/zombie-repo"] });
+    const req = new Request("http://localhost/releases");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, e, ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).not.toContain("zombie-repo");
+    // 何も watched に残らない empty-state に倒れる
+    expect(html).toContain("No releases with referenced issues");
+  });
+
   it("does not turn an unallowlisted tag-less repo into a synthetic block", async () => {
     // Guard against the auto-merge regression the user called out: a PR repo
     // briefly without tags must NOT show its main-branch commits here.

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -851,12 +851,17 @@ describe("GET /releases", () => {
       if (url.includes("/contents/wt-direct-push/config/direct-push-ok.txt")) {
         return Response.json({ content: btoa(""), encoding: "base64" });
       }
+      // archived filter (#155) で meta fetch が走るようになったので、
+      // 通常 repo として返す (archived: false 相当 = 未指定)。
+      if (url.match(/\/repos\/ippoan\/some-pr-repo(\?|$)/)) {
+        return Response.json({ default_branch: "main" });
+      }
       if (url.includes("/repos/ippoan/some-pr-repo/tags")) {
         return Response.json([]);
       }
-      // /repos/{o}/{n} should NOT be hit for the non-allowlisted path; fail
-      // loudly if it is so we notice the regression in CI.
-      if (url.match(/\/repos\/ippoan\/some-pr-repo(\?|$)/)) {
+      // synthetic path 本体の indicator: /commits は loadSyntheticBlock 経由
+      // のみで叩かれる。ここに到達したら synthetic path 漏れ。
+      if (url.includes("/repos/ippoan/some-pr-repo/commits")) {
         throw new Error("unexpected fetch: synthetic path leaked");
       }
       return new Response(`not stubbed: ${url}`, { status: 500 });

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -681,6 +681,12 @@ describe("GET /releases", () => {
       if (url.includes("/repos/ippoan/placeholder/commits")) {
         return Response.json([]);
       }
+      // archived filter (#155) で meta fetch が走るため、ここも stub して
+      // 2 度目の load で KV hit するようにする (= fetch 数が増えない invariant
+      // を維持)。stub しないと 500 → throw → 未キャッシュで毎回 fetch する。
+      if (url.match(/\/repos\/ippoan\/ci-dashboard(\?|$)/)) {
+        return Response.json({ default_branch: "main" });
+      }
       if (url.includes("/repos/ippoan/ci-dashboard/tags")) {
         return Response.json([
           { name: "v1.2.0", commit: { sha: "a" } },


### PR DESCRIPTION
## 概要

archived な repo を `/releases` から完全に除外する。

## 動機

archived repo は GitHub API で issue close ができない (`403 Repository was archived so is read-only.`) ため、operator が `/releases` UI から close を試みて必ず失敗する。

実害: `ippoan/github-mcp-server-rs` は monorepo 化 (ippoan/mcp-relay-rs へ統合) で archive されたが、過去 commit に `Refs #N` があるため `/releases` に残り続けていた。`#59` の close で failed (#154 で reason 表示は改善したが、そもそも一覧に出すべきでない)。

## 修正

`loadRepoView` の冒頭 (cachedTags 前) で `cachedRepoMeta` を fetch し、`archived === true` なら早期 `null` で repo を一覧から落とす:

```ts
try {
  const meta = await cachedRepoMeta(token, kv, owner, name);
  if (meta.archived === true) return null;
} catch {
  /* archived 判定不能 — 続行 (tag fetch 失敗 → null は既存経路) */
}
```

**best-effort 設計**:
- `archived: true` と確認できた時のみ drop
- meta fetch 失敗 (private 化 / 削除 / network) は握り潰し、既存の tag fetch 失敗 → null 経路に委ねる
- `cachedRepoMeta` は TTL 3600s で KV cache 済 → 既存 synthetic block path と fetch を共有するため、tagged-only repo の cold-start でも 1 extra fetch のみ

`RepoMeta` interface に `archived?: boolean` を追加 (`src/release-cache.ts` + `src/releases-page.ts`)。

## 既存挙動への影響

- 通常 repo: `archived` 未指定 → drop されず既存挙動
- archived repo: drop されて消える
- meta fetch 失敗 repo: 既存挙動 (tag fetch 失敗時に null 返却) と同じ

既存 test の `/repos/{o}/{n}` 未 stub case は catch で握り潰されるため tag path に到達して既存挙動を継続。

## テスト

新規ケース 1 件: `archived: true` を返す stub で repo card が一切出ない (empty-state まで倒れる) ことを assert。tag fetch に到達したら明示的に test fail で leak 検出。

## Test plan

- [ ] CI green
- [ ] deploy 後、`/releases` で `ippoan/github-mcp-server-rs` が消えていることを確認
- [ ] 通常 repo (alc-app / ci-dashboard 等) は変わらず表示されること

Refs #155

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb2hASFhbDtbdd83fNtFEB)_