### PR TITLE
feat(release-wave): compatibility KV data plane (Phase A)

### DIFF
--- a/docs/release-wave.md
+++ b/docs/release-wave.md
@@ -147,6 +147,14 @@ secret 認証 HTTP webhook で統一されている (= MCP OAuth を Actions で
 | `POST /webhooks/release-wave/stage-report` | release-wave-handler の stage 完了 callback | `stageReport` |
 | `POST /webhooks/release-wave/flip-report`  | flip 完了 callback                          | `flipReport` |
 | `POST /webhooks/release-wave/contract-applied` | contract migration deploy 後の通知       | `contractApplied` |
+| `POST /webhooks/release-wave/frontend-test-report` | frontend CI green 時の compatibility 記録 (KV write) | — (COMPAT_KV) |
+| `POST /webhooks/release-wave/backend-deploy-report` | backend deploy 成功時の compatibility 記録 (KV write) | — (COMPAT_KV) |
+
+compatibility 系 2 endpoint の body / KV shape は
+[`docs/release-wave-compatibility-kv.md`](release-wave-compatibility-kv.md) を参照。
+突合結果の read は CF Access edge gate 配下の read-only endpoint
+`GET /compatibility?backend_repo=&backend_target_image=` /
+`GET /backend-current-image?repo=` で取得する。
 
 ### stage-report body
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,13 @@ import {
   handleContractAppliedWebhook,
   handleStageReportWebhook,
   handleFlipReportWebhook,
+  handleFrontendTestReportWebhook,
+  handleBackendDeployReportWebhook,
 } from "./release-wave/webhook";
+import {
+  handleCompatibility,
+  handleBackendCurrentImage,
+} from "./release-wave/compat-api";
 import {
   handleReleaseWaveListPage,
   handleReleaseWaveDetailPage,
@@ -59,6 +65,12 @@ export interface Env extends AuthClientWorkerEnv {
   // into the default branch are treated as releases for these. See
   // wrangler.jsonc and src/tagless-repos.ts.
   TAGLESS_REPOS?: string;
+  /**
+   * Release Wave compatibility 突合用 KV (`frontend::*` / `backend::*` records)。
+   * 既存 CI_STATUS namespace を別 binding で流用する (key prefix で衝突回避)。
+   * Refs #157 / #158、shape は docs/release-wave-compatibility-kv.md。
+   */
+  COMPAT_KV: KVNamespace;
 }
 
 // OAuth flow config — shared between /oauth/login, /oauth/callback, and the
@@ -197,6 +209,20 @@ app.post("/webhooks/release-wave/stage-report", (c) =>
 );
 app.post("/webhooks/release-wave/flip-report", (c) =>
   handleFlipReportWebhook(c.req.raw, c.env),
+);
+// Compatibility 突合 (frontend ↔ backend image)。frontend CI / backend deploy が
+// shared secret 付きで write する 2 endpoint。Refs #157 (Phase A) / #158。
+app.post("/webhooks/release-wave/frontend-test-report", (c) =>
+  handleFrontendTestReportWebhook(c.req.raw, c.env),
+);
+app.post("/webhooks/release-wave/backend-deploy-report", (c) =>
+  handleBackendDeployReportWebhook(c.req.raw, c.env),
+);
+
+// Compatibility read endpoints (CF Access edge gate に認証を委譲、read-only)。
+app.get("/compatibility", (c) => handleCompatibility(c.req.raw, c.env));
+app.get("/backend-current-image", (c) =>
+  handleBackendCurrentImage(c.req.raw, c.env),
 );
 
 // Release Wave admin UI (Refs #137 Phase 3e)。

--- a/src/release-wave/compat-api.ts
+++ b/src/release-wave/compat-api.ts
@@ -1,0 +1,89 @@
+/**
+ * Release Wave compatibility の read-only HTTP endpoint 2 本。
+ *
+ *   GET /compatibility?backend_repo=...&backend_target_image=...
+ *     → 指定 backend を target image に flip する際の frontend 互換性 matrix
+ *
+ *   GET /backend-current-image?repo=...
+ *     → 指定 backend の現 production image (frontend CI が test 対象を知る用)
+ *
+ * 認証は ci-dashboard 全体に被さる Cloudflare Access edge gate に委譲
+ * (= /releases, /status と同じトラストモデル)。write は webhook.ts の
+ * shared-secret endpoint 側にあり、こちらは read 専用。
+ *
+ * 設計の親 issue: ippoan/ci-dashboard#157 (Phase A)
+ */
+
+import type { Env } from "../index";
+import { computeCompatibility, getBackendCurrent } from "./compat";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body, null, 2), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}
+
+// ----------------------------------------------------------------------------
+// GET /compatibility
+// ----------------------------------------------------------------------------
+
+export async function handleCompatibility(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const backend_repo = url.searchParams.get("backend_repo")?.trim();
+  const backend_target_image = url.searchParams
+    .get("backend_target_image")
+    ?.trim();
+
+  if (!backend_repo || !backend_target_image) {
+    return jsonResponse(400, {
+      code: "BAD_REQUEST",
+      error: "backend_repo and backend_target_image query params are required",
+    });
+  }
+
+  const result = await computeCompatibility(
+    env.COMPAT_KV,
+    backend_repo,
+    backend_target_image,
+  );
+  return jsonResponse(200, result);
+}
+
+// ----------------------------------------------------------------------------
+// GET /backend-current-image
+// ----------------------------------------------------------------------------
+
+export async function handleBackendCurrentImage(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const repo = url.searchParams.get("repo")?.trim();
+
+  if (!repo) {
+    return jsonResponse(400, {
+      code: "BAD_REQUEST",
+      error: "repo query param is required",
+    });
+  }
+
+  const record = await getBackendCurrent(env.COMPAT_KV, repo);
+  if (!record) {
+    return jsonResponse(404, {
+      code: "NOT_FOUND",
+      error: `no backend deploy record for ${repo}`,
+    });
+  }
+  return jsonResponse(200, {
+    repo: record.repo,
+    current_image: record.current_image,
+    deployed_at: record.deployed_at,
+  });
+}

--- a/src/release-wave/compat.ts
+++ b/src/release-wave/compat.ts
@@ -1,0 +1,286 @@
+/**
+ * Release Wave compatibility — frontend ↔ backend image 突合の KV データ層。
+ *
+ * frontend CI (integration test green) と backend deploy (成功時) が ci-dashboard
+ * の webhook 経由で書く KV record の read / write / 突合ロジック。shape の仕様は
+ * docs/release-wave-compatibility-kv.md を SoT とする。
+ *
+ * 設計の親 issue: ippoan/ci-dashboard#157 (Phase A)
+ * shape 確定 issue: ippoan/ci-dashboard#158
+ */
+
+// ----------------------------------------------------------------------------
+// 定数
+// ----------------------------------------------------------------------------
+
+/** 現行 schema version。破壊的変更時に bump。 */
+export const SCHEMA_VERSION = 1;
+
+/** `tested_against` の最大保持件数 (sliding window の件数上限)。 */
+export const TESTED_AGAINST_MAX = 50;
+
+/** `tested_against` の保持日数 (sliding window の時間上限)。 */
+export const WINDOW_DAYS = 90;
+
+/** `frontend::*` entry の KV TTL (秒)。write 毎に renew される。 */
+export const FRONTEND_TTL_SECONDS = WINDOW_DAYS * 24 * 60 * 60;
+
+const FRONTEND_PREFIX = "frontend::";
+const BACKEND_PREFIX = "backend::";
+
+function frontendKey(repo: string): string {
+  return `${FRONTEND_PREFIX}${repo}`;
+}
+
+function backendKey(repo: string): string {
+  return `${BACKEND_PREFIX}${repo}`;
+}
+
+// ----------------------------------------------------------------------------
+// Record 型 (docs/release-wave-compatibility-kv.md と一致)
+// ----------------------------------------------------------------------------
+
+/** `frontend::<repo>` の `tested_against` 1 entry。 */
+export interface TestedAgainstEntry {
+  backend_repo: string;
+  /** backend image identifier (platform 別、不透明文字列として完全一致比較)。 */
+  backend_image: string;
+  tested_at: string;
+  ci_run_url?: string;
+}
+
+/** `frontend::<repo>` value。 */
+export interface FrontendCompatRecord {
+  schema_version: number;
+  repo: string;
+  prod_version: string;
+  prod_deployed_at: string;
+  /** 新しい順 (= index 0 が直近)。window trim 済み。 */
+  tested_against: TestedAgainstEntry[];
+}
+
+/** `backend::<repo>` value。最新 deploy のみ保持 (upsert)。 */
+export interface BackendCompatRecord {
+  schema_version: number;
+  repo: string;
+  current_image: string;
+  deployed_at: string;
+  deployed_by: string;
+  /** wave 経由 deploy なら wave_id、単独 deploy なら null。 */
+  wave_id: string | null;
+}
+
+// ----------------------------------------------------------------------------
+// Write: frontend test report
+// ----------------------------------------------------------------------------
+
+export interface RecordFrontendTestInput {
+  repo: string;
+  prod_version: string;
+  tested: {
+    backend_repo: string;
+    backend_image: string;
+    ci_run_url?: string;
+  };
+  /** caller が渡す UTC ISO timestamp (テスト容易性のため内部で Date を呼ばない)。 */
+  now: string;
+}
+
+/**
+ * frontend CI green path の report を KV に反映する。
+ *
+ * read-modify-write:
+ *  1. 既存 record を load (schema 不一致 / 無ければ新規)
+ *  2. 同 (backend_repo, backend_image) の旧 entry を除去
+ *  3. 新 entry を先頭に追加
+ *  4. window (90日) で古い entry を落とし、最大 50 件に trim
+ *  5. prod_version / prod_deployed_at を更新して put (TTL renew)
+ */
+export async function recordFrontendTest(
+  kv: KVNamespace,
+  input: RecordFrontendTestInput,
+): Promise<FrontendCompatRecord> {
+  const existing = await kv.get<FrontendCompatRecord>(frontendKey(input.repo), "json");
+
+  const prior: TestedAgainstEntry[] =
+    existing && existing.schema_version === SCHEMA_VERSION && Array.isArray(existing.tested_against)
+      ? existing.tested_against
+      : [];
+
+  const newEntry: TestedAgainstEntry = {
+    backend_repo: input.tested.backend_repo,
+    backend_image: input.tested.backend_image,
+    tested_at: input.now,
+    ...(input.tested.ci_run_url ? { ci_run_url: input.tested.ci_run_url } : {}),
+  };
+
+  const deduped = prior.filter(
+    (e) =>
+      !(
+        e.backend_repo === newEntry.backend_repo &&
+        e.backend_image === newEntry.backend_image
+      ),
+  );
+
+  const merged = [newEntry, ...deduped];
+  const trimmed = trimTestedAgainst(merged, input.now);
+
+  const record: FrontendCompatRecord = {
+    schema_version: SCHEMA_VERSION,
+    repo: input.repo,
+    prod_version: input.prod_version,
+    prod_deployed_at: input.now,
+    tested_against: trimmed,
+  };
+
+  await kv.put(frontendKey(input.repo), JSON.stringify(record), {
+    expirationTtl: FRONTEND_TTL_SECONDS,
+  });
+  return record;
+}
+
+/** window (件数 + 日数) で `tested_against` を trim。新しい順を維持。 */
+function trimTestedAgainst(
+  entries: TestedAgainstEntry[],
+  now: string,
+): TestedAgainstEntry[] {
+  const cutoffMs = Date.parse(now) - WINDOW_DAYS * 24 * 60 * 60 * 1000;
+  const withinWindow = entries.filter((e) => {
+    const t = Date.parse(e.tested_at);
+    // 不正な tested_at は安全側 (= 残す) に倒す。
+    return Number.isNaN(t) || t >= cutoffMs;
+  });
+  return withinWindow.slice(0, TESTED_AGAINST_MAX);
+}
+
+// ----------------------------------------------------------------------------
+// Write: backend deploy report
+// ----------------------------------------------------------------------------
+
+export interface RecordBackendDeployInput {
+  repo: string;
+  current_image: string;
+  deployed_by: string;
+  wave_id?: string | null;
+  now: string;
+}
+
+/** backend deploy 成功時の upsert (最新のみ、TTL なし)。 */
+export async function recordBackendDeploy(
+  kv: KVNamespace,
+  input: RecordBackendDeployInput,
+): Promise<BackendCompatRecord> {
+  const record: BackendCompatRecord = {
+    schema_version: SCHEMA_VERSION,
+    repo: input.repo,
+    current_image: input.current_image,
+    deployed_at: input.now,
+    deployed_by: input.deployed_by,
+    wave_id: input.wave_id ?? null,
+  };
+  await kv.put(backendKey(input.repo), JSON.stringify(record));
+  return record;
+}
+
+// ----------------------------------------------------------------------------
+// Read: backend current image
+// ----------------------------------------------------------------------------
+
+/** `backend::<repo>` を読む。無ければ null。 */
+export async function getBackendCurrent(
+  kv: KVNamespace,
+  repo: string,
+): Promise<BackendCompatRecord | null> {
+  const v = await kv.get<BackendCompatRecord>(backendKey(repo), "json");
+  if (!v || v.schema_version !== SCHEMA_VERSION) return null;
+  return v;
+}
+
+// ----------------------------------------------------------------------------
+// Read: compatibility matrix
+// ----------------------------------------------------------------------------
+
+/** 1 frontend について「対象 backend image を test 済みか」の判定結果。 */
+export interface CompatMatrixEntry {
+  frontend: string;
+  prod_version: string | null;
+  /** target image を test 済みなら true (= 緑)。 */
+  tested_against_target: boolean;
+  /** 緑のとき、その test の tested_at。 */
+  tested_against_at: string | null;
+  /** 赤のとき、同 backend_repo について直近に test した image (参考)。 */
+  last_tested_image: string | null;
+}
+
+export interface CompatibilityResult {
+  backend_repo: string;
+  backend_target_image: string;
+  /**
+   * matrix が空でなく、かつ全 frontend が緑なら true。
+   * 空 (= この backend を test した frontend が 1 つも無い) の場合は
+   * 「検証できない」として false。
+   */
+  verified: boolean;
+  matrix: CompatMatrixEntry[];
+}
+
+/**
+ * 全 `frontend::*` record を走査し、指定 backend を `backend_target_image` に
+ * flip する際の互換性 matrix を構築する。
+ *
+ * matrix に載るのは「`tested_against` に当該 backend_repo の entry を 1 つ以上
+ * 持つ frontend」のみ (= その backend の consumer とみなせる frontend)。
+ * Phase A では `consumed_by` 設定を持たないため、test 履歴を consumer の
+ * 近似として使う。
+ */
+export async function computeCompatibility(
+  kv: KVNamespace,
+  backend_repo: string,
+  backend_target_image: string,
+): Promise<CompatibilityResult> {
+  const records = await listFrontendRecords(kv);
+  const matrix: CompatMatrixEntry[] = [];
+
+  for (const rec of records) {
+    const relevant = rec.tested_against.filter(
+      (e) => e.backend_repo === backend_repo,
+    );
+    if (relevant.length === 0) continue; // この backend の consumer ではない
+
+    const match = relevant.find((e) => e.backend_image === backend_target_image);
+    matrix.push({
+      frontend: rec.repo,
+      prod_version: rec.prod_version || null,
+      tested_against_target: match !== undefined,
+      tested_against_at: match ? match.tested_at : null,
+      // relevant は元 record の新しい順を維持しているので [0] が直近。
+      last_tested_image: match ? null : (relevant[0]?.backend_image ?? null),
+    });
+  }
+
+  matrix.sort((a, b) => (a.frontend < b.frontend ? -1 : 1));
+
+  const verified =
+    matrix.length > 0 && matrix.every((m) => m.tested_against_target);
+
+  return { backend_repo, backend_target_image, verified, matrix };
+}
+
+/** `frontend::*` を全件 list して parse する。schema 不一致は除外。 */
+async function listFrontendRecords(
+  kv: KVNamespace,
+): Promise<FrontendCompatRecord[]> {
+  const out: FrontendCompatRecord[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await kv.list({ prefix: FRONTEND_PREFIX, cursor });
+    for (const key of page.keys) {
+      const rec = await kv.get<FrontendCompatRecord>(key.name, "json");
+      if (rec && rec.schema_version === SCHEMA_VERSION && Array.isArray(rec.tested_against)) {
+        out.push(rec);
+      }
+    }
+    cursor = page.list_complete ? undefined : page.cursor;
+  } while (cursor);
+  return out;
+}

--- a/src/release-wave/webhook.ts
+++ b/src/release-wave/webhook.ts
@@ -22,6 +22,7 @@ import { z } from "zod";
 import type { Env } from "../index";
 import type { ReleaseWaveHub, RpcResult } from "./do";
 import type { WaveState } from "./types";
+import { recordFrontendTest, recordBackendDeploy } from "./compat";
 
 // ----------------------------------------------------------------------------
 // Common helpers
@@ -231,4 +232,91 @@ export async function handleFlipReportWebhook(
     error: v.data.error ?? null,
   })) as RpcResult<WaveState>;
   return rpcResultToResponse(result);
+}
+
+// ----------------------------------------------------------------------------
+// /webhooks/release-wave/frontend-test-report  (compatibility, Refs #157/#158)
+// ----------------------------------------------------------------------------
+
+/**
+ * frontend CI が integration test green 時に打つ。ci-dashboard 側で
+ * `frontend::<repo>` を read-modify-write し `tested_against` に append する。
+ *
+ * body:
+ *   {
+ *     "repo": "ippoan/auth-worker",
+ *     "prod_version": "v0.5.32",
+ *     "tested": {
+ *       "backend_repo": "ippoan/rust-alc-api",
+ *       "backend_image": "rust-alc-api-00042-abc",
+ *       "ci_run_url": "https://github.com/.../runs/123"   // optional
+ *     }
+ *   }
+ */
+const frontendTestReportSchema = z.object({
+  repo: z.string().min(1),
+  prod_version: z.string().min(1),
+  tested: z.object({
+    backend_repo: z.string().min(1),
+    backend_image: z.string().min(1),
+    ci_run_url: z.string().url().optional(),
+  }),
+});
+
+export async function handleFrontendTestReportWebhook(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  const v = await validateAndAuth(request, env, frontendTestReportSchema);
+  if (!v.ok) return v.response;
+  const record = await recordFrontendTest(env.COMPAT_KV, {
+    repo: v.data.repo,
+    prod_version: v.data.prod_version,
+    tested: {
+      backend_repo: v.data.tested.backend_repo,
+      backend_image: v.data.tested.backend_image,
+      ci_run_url: v.data.tested.ci_run_url,
+    },
+    now: new Date().toISOString(),
+  });
+  return jsonResponse(200, { ok: true, record });
+}
+
+// ----------------------------------------------------------------------------
+// /webhooks/release-wave/backend-deploy-report  (compatibility, Refs #157/#158)
+// ----------------------------------------------------------------------------
+
+/**
+ * backend deploy 成功時に release-wave-gcp / 各 backend deploy workflow が打つ。
+ * ci-dashboard 側で `backend::<repo>` を upsert する。
+ *
+ * body:
+ *   {
+ *     "repo": "ippoan/rust-alc-api",
+ *     "current_image": "rust-alc-api-00042-abc",
+ *     "deployed_by": "release-wave-gcp",
+ *     "wave_id": "wave_2026_05_27_01"   // optional (単独 deploy 時は省略)
+ *   }
+ */
+const backendDeployReportSchema = z.object({
+  repo: z.string().min(1),
+  current_image: z.string().min(1),
+  deployed_by: z.string().min(1),
+  wave_id: z.string().min(1).nullable().optional(),
+});
+
+export async function handleBackendDeployReportWebhook(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  const v = await validateAndAuth(request, env, backendDeployReportSchema);
+  if (!v.ok) return v.response;
+  const record = await recordBackendDeploy(env.COMPAT_KV, {
+    repo: v.data.repo,
+    current_image: v.data.current_image,
+    deployed_by: v.data.deployed_by,
+    wave_id: v.data.wave_id ?? null,
+    now: new Date().toISOString(),
+  });
+  return jsonResponse(200, { ok: true, record });
 }

--- a/test/release-wave/compat-http.test.ts
+++ b/test/release-wave/compat-http.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { env as testEnv } from "cloudflare:test";
+import {
+  handleFrontendTestReportWebhook,
+  handleBackendDeployReportWebhook,
+} from "../../src/release-wave/webhook";
+import {
+  handleCompatibility,
+  handleBackendCurrentImage,
+} from "../../src/release-wave/compat-api";
+import { getBackendCurrent } from "../../src/release-wave/compat";
+import type { Env } from "../../src/index";
+
+const SECRET = "expected-secret";
+
+function compatEnv(secret: string | null = SECRET): Env {
+  return {
+    COMPAT_KV: testEnv.COMPAT_KV,
+    RELEASE_WAVE_WEBHOOK_SECRET: { get: async () => secret },
+  } as unknown as Env;
+}
+
+function postReq(url: string, body: unknown, secret: string | null = SECRET): Request {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (secret !== null) headers["X-Release-Wave-Webhook-Secret"] = secret;
+  return new Request(url, {
+    method: "POST",
+    headers,
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+async function clearCompatKeys(): Promise<void> {
+  for (const prefix of ["frontend::", "backend::"]) {
+    const { keys } = await testEnv.COMPAT_KV.list({ prefix });
+    await Promise.all(keys.map((k) => testEnv.COMPAT_KV.delete(k.name)));
+  }
+}
+beforeEach(clearCompatKeys);
+
+const FT_URL =
+  "https://ci-dashboard.ippoan.org/webhooks/release-wave/frontend-test-report";
+const BD_URL =
+  "https://ci-dashboard.ippoan.org/webhooks/release-wave/backend-deploy-report";
+
+describe("handleFrontendTestReportWebhook", () => {
+  it("rejects non-POST with 405", async () => {
+    const req = new Request(FT_URL, {
+      method: "GET",
+      headers: { "X-Release-Wave-Webhook-Secret": SECRET },
+    });
+    const resp = await handleFrontendTestReportWebhook(req, compatEnv());
+    expect(resp.status).toBe(405);
+  });
+
+  it("rejects wrong secret with 401", async () => {
+    const resp = await handleFrontendTestReportWebhook(
+      postReq(FT_URL, { repo: "x", prod_version: "v1", tested: { backend_repo: "b", backend_image: "i" } }, "wrong"),
+      compatEnv(),
+    );
+    expect(resp.status).toBe(401);
+  });
+
+  it("rejects missing fields with 400", async () => {
+    const resp = await handleFrontendTestReportWebhook(
+      postReq(FT_URL, { repo: "x" }),
+      compatEnv(),
+    );
+    expect(resp.status).toBe(400);
+    const body = (await resp.json()) as { error: string };
+    expect(body.error).toContain("prod_version");
+  });
+
+  it("rejects non-URL ci_run_url with 400", async () => {
+    const resp = await handleFrontendTestReportWebhook(
+      postReq(FT_URL, {
+        repo: "ippoan/auth-worker",
+        prod_version: "v1",
+        tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "i", ci_run_url: "not-a-url" },
+      }),
+      compatEnv(),
+    );
+    expect(resp.status).toBe(400);
+  });
+
+  it("writes the frontend record and returns it (200)", async () => {
+    const resp = await handleFrontendTestReportWebhook(
+      postReq(FT_URL, {
+        repo: "ippoan/auth-worker",
+        prod_version: "v0.5.32",
+        tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "img-a" },
+      }),
+      compatEnv(),
+    );
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { ok: boolean; record: { tested_against: unknown[] } };
+    expect(body.ok).toBe(true);
+    expect(body.record.tested_against).toHaveLength(1);
+  });
+});
+
+describe("handleBackendDeployReportWebhook", () => {
+  it("rejects wrong secret with 401", async () => {
+    const resp = await handleBackendDeployReportWebhook(
+      postReq(BD_URL, { repo: "b", current_image: "i", deployed_by: "x" }, "wrong"),
+      compatEnv(),
+    );
+    expect(resp.status).toBe(401);
+  });
+
+  it("rejects missing fields with 400", async () => {
+    const resp = await handleBackendDeployReportWebhook(
+      postReq(BD_URL, { repo: "b" }),
+      compatEnv(),
+    );
+    expect(resp.status).toBe(400);
+  });
+
+  it("accepts null wave_id", async () => {
+    const resp = await handleBackendDeployReportWebhook(
+      postReq(BD_URL, {
+        repo: "ippoan/rust-alc-api",
+        current_image: "img-1",
+        deployed_by: "hotfix",
+        wave_id: null,
+      }),
+      compatEnv(),
+    );
+    expect(resp.status).toBe(200);
+    const got = await getBackendCurrent(testEnv.COMPAT_KV, "ippoan/rust-alc-api");
+    expect(got!.wave_id).toBeNull();
+  });
+
+  it("writes the backend record (200)", async () => {
+    const resp = await handleBackendDeployReportWebhook(
+      postReq(BD_URL, {
+        repo: "ippoan/rust-alc-api",
+        current_image: "img-1",
+        deployed_by: "release-wave-gcp",
+        wave_id: "wave_1",
+      }),
+      compatEnv(),
+    );
+    expect(resp.status).toBe(200);
+    const got = await getBackendCurrent(testEnv.COMPAT_KV, "ippoan/rust-alc-api");
+    expect(got!.current_image).toBe("img-1");
+  });
+});
+
+describe("handleCompatibility (GET /compatibility)", () => {
+  it("400 when query params missing", async () => {
+    const resp = await handleCompatibility(
+      new Request("https://ci-dashboard.ippoan.org/compatibility"),
+      compatEnv(),
+    );
+    expect(resp.status).toBe(400);
+  });
+
+  it("returns matrix for a tested backend image", async () => {
+    await handleFrontendTestReportWebhook(
+      postReq(FT_URL, {
+        repo: "ippoan/auth-worker",
+        prod_version: "v0.5.32",
+        tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "target" },
+      }),
+      compatEnv(),
+    );
+    const resp = await handleCompatibility(
+      new Request(
+        "https://ci-dashboard.ippoan.org/compatibility?backend_repo=ippoan/rust-alc-api&backend_target_image=target",
+      ),
+      compatEnv(),
+    );
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { verified: boolean; matrix: unknown[] };
+    expect(body.verified).toBe(true);
+    expect(body.matrix).toHaveLength(1);
+  });
+});
+
+describe("handleBackendCurrentImage (GET /backend-current-image)", () => {
+  it("400 when repo missing", async () => {
+    const resp = await handleBackendCurrentImage(
+      new Request("https://ci-dashboard.ippoan.org/backend-current-image"),
+      compatEnv(),
+    );
+    expect(resp.status).toBe(400);
+  });
+
+  it("404 when no record", async () => {
+    const resp = await handleBackendCurrentImage(
+      new Request(
+        "https://ci-dashboard.ippoan.org/backend-current-image?repo=ippoan/nope",
+      ),
+      compatEnv(),
+    );
+    expect(resp.status).toBe(404);
+  });
+
+  it("returns current image when present", async () => {
+    await handleBackendDeployReportWebhook(
+      postReq(BD_URL, {
+        repo: "ippoan/rust-alc-api",
+        current_image: "img-9",
+        deployed_by: "x",
+      }),
+      compatEnv(),
+    );
+    const resp = await handleBackendCurrentImage(
+      new Request(
+        "https://ci-dashboard.ippoan.org/backend-current-image?repo=ippoan/rust-alc-api",
+      ),
+      compatEnv(),
+    );
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { current_image: string };
+    expect(body.current_image).toBe("img-9");
+  });
+});

--- a/test/release-wave/compat.test.ts
+++ b/test/release-wave/compat.test.ts
@@ -1,0 +1,343 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:test";
+import {
+  recordFrontendTest,
+  recordBackendDeploy,
+  getBackendCurrent,
+  computeCompatibility,
+  TESTED_AGAINST_MAX,
+  WINDOW_DAYS,
+  SCHEMA_VERSION,
+  type FrontendCompatRecord,
+} from "../../src/release-wave/compat";
+
+const kv = () => env.COMPAT_KV;
+
+/** 各テスト前に compat key (frontend:: / backend::) を一掃する。 */
+async function clearCompatKeys(): Promise<void> {
+  for (const prefix of ["frontend::", "backend::"]) {
+    const { keys } = await kv().list({ prefix });
+    await Promise.all(keys.map((k) => kv().delete(k.name)));
+  }
+}
+
+beforeEach(clearCompatKeys);
+
+const daysAgo = (n: number): string =>
+  new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString();
+
+describe("recordFrontendTest", () => {
+  it("creates a new record with one tested_against entry", async () => {
+    const rec = await recordFrontendTest(kv(), {
+      repo: "ippoan/auth-worker",
+      prod_version: "v0.5.32",
+      tested: {
+        backend_repo: "ippoan/rust-alc-api",
+        backend_image: "img-a",
+        ci_run_url: "https://github.com/ippoan/auth-worker/actions/runs/1",
+      },
+      now: "2026-05-27T00:00:00.000Z",
+    });
+    expect(rec.schema_version).toBe(SCHEMA_VERSION);
+    expect(rec.repo).toBe("ippoan/auth-worker");
+    expect(rec.prod_version).toBe("v0.5.32");
+    expect(rec.tested_against).toHaveLength(1);
+    expect(rec.tested_against[0]).toMatchObject({
+      backend_repo: "ippoan/rust-alc-api",
+      backend_image: "img-a",
+      ci_run_url: "https://github.com/ippoan/auth-worker/actions/runs/1",
+    });
+
+    const stored = await kv().get<FrontendCompatRecord>(
+      "frontend::ippoan/auth-worker",
+      "json",
+    );
+    expect(stored?.tested_against).toHaveLength(1);
+  });
+
+  it("omits ci_run_url when not provided", async () => {
+    const rec = await recordFrontendTest(kv(), {
+      repo: "ippoan/alc-app",
+      prod_version: "v1",
+      tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "img-a" },
+      now: daysAgo(0),
+    });
+    expect(rec.tested_against[0]!.ci_run_url).toBeUndefined();
+  });
+
+  it("prepends new entries (most-recent first)", async () => {
+    await recordFrontendTest(kv(), {
+      repo: "ippoan/auth-worker",
+      prod_version: "v1",
+      tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "old" },
+      now: daysAgo(2),
+    });
+    const rec = await recordFrontendTest(kv(), {
+      repo: "ippoan/auth-worker",
+      prod_version: "v2",
+      tested: { backend_repo: "ippoan/cc-relay", backend_image: "new" },
+      now: daysAgo(1),
+    });
+    expect(rec.tested_against.map((e) => e.backend_image)).toEqual([
+      "new",
+      "old",
+    ]);
+    expect(rec.prod_version).toBe("v2");
+  });
+
+  it("dedupes same (backend_repo, backend_image), keeping the latest", async () => {
+    const latest = daysAgo(1);
+    await recordFrontendTest(kv(), {
+      repo: "ippoan/auth-worker",
+      prod_version: "v1",
+      tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "img-a" },
+      now: daysAgo(3),
+    });
+    const rec = await recordFrontendTest(kv(), {
+      repo: "ippoan/auth-worker",
+      prod_version: "v1",
+      tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "img-a" },
+      now: latest,
+    });
+    expect(rec.tested_against).toHaveLength(1);
+    expect(rec.tested_against[0]!.tested_at).toBe(latest);
+  });
+
+  it("keeps distinct backend_repo entries side by side", async () => {
+    await recordFrontendTest(kv(), {
+      repo: "ippoan/auth-worker",
+      prod_version: "v1",
+      tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "a" },
+      now: daysAgo(2),
+    });
+    const rec = await recordFrontendTest(kv(), {
+      repo: "ippoan/auth-worker",
+      prod_version: "v1",
+      tested: { backend_repo: "ippoan/cc-relay", backend_image: "b" },
+      now: daysAgo(1),
+    });
+    expect(rec.tested_against).toHaveLength(2);
+  });
+
+  it("drops entries older than the window", async () => {
+    // 既存 record に古い entry を仕込む
+    await kv().put(
+      "frontend::ippoan/auth-worker",
+      JSON.stringify({
+        schema_version: SCHEMA_VERSION,
+        repo: "ippoan/auth-worker",
+        prod_version: "v0",
+        prod_deployed_at: daysAgo(WINDOW_DAYS + 10),
+        tested_against: [
+          {
+            backend_repo: "ippoan/rust-alc-api",
+            backend_image: "ancient",
+            tested_at: daysAgo(WINDOW_DAYS + 10),
+          },
+        ],
+      } satisfies FrontendCompatRecord),
+    );
+    const rec = await recordFrontendTest(kv(), {
+      repo: "ippoan/auth-worker",
+      prod_version: "v1",
+      tested: { backend_repo: "ippoan/cc-relay", backend_image: "fresh" },
+      now: daysAgo(0),
+    });
+    expect(rec.tested_against.map((e) => e.backend_image)).toEqual(["fresh"]);
+  });
+
+  it("caps entries to TESTED_AGAINST_MAX", async () => {
+    for (let i = 0; i < TESTED_AGAINST_MAX + 5; i++) {
+      await recordFrontendTest(kv(), {
+        repo: "ippoan/auth-worker",
+        prod_version: "v1",
+        tested: { backend_repo: "ippoan/rust-alc-api", backend_image: `img-${i}` },
+        now: new Date(Date.parse("2026-05-27T00:00:00.000Z") + i * 1000).toISOString(),
+      });
+    }
+    const stored = await kv().get<FrontendCompatRecord>(
+      "frontend::ippoan/auth-worker",
+      "json",
+    );
+    expect(stored!.tested_against).toHaveLength(TESTED_AGAINST_MAX);
+    // 直近 (最大 index) が先頭
+    expect(stored!.tested_against[0]!.backend_image).toBe(
+      `img-${TESTED_AGAINST_MAX + 4}`,
+    );
+  });
+
+  it("resets tested_against when stored schema_version mismatches", async () => {
+    await kv().put(
+      "frontend::ippoan/auth-worker",
+      JSON.stringify({
+        schema_version: 99,
+        repo: "ippoan/auth-worker",
+        prod_version: "old",
+        prod_deployed_at: daysAgo(1),
+        tested_against: [
+          { backend_repo: "x", backend_image: "stale", tested_at: daysAgo(1) },
+        ],
+      }),
+    );
+    const rec = await recordFrontendTest(kv(), {
+      repo: "ippoan/auth-worker",
+      prod_version: "v1",
+      tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "new" },
+      now: daysAgo(0),
+    });
+    expect(rec.tested_against.map((e) => e.backend_image)).toEqual(["new"]);
+  });
+});
+
+describe("recordBackendDeploy / getBackendCurrent", () => {
+  it("upserts and reads back", async () => {
+    await recordBackendDeploy(kv(), {
+      repo: "ippoan/rust-alc-api",
+      current_image: "img-1",
+      deployed_by: "release-wave-gcp",
+      wave_id: "wave_1",
+      now: "2026-05-27T01:00:00.000Z",
+    });
+    const got = await getBackendCurrent(kv(), "ippoan/rust-alc-api");
+    expect(got).toMatchObject({
+      repo: "ippoan/rust-alc-api",
+      current_image: "img-1",
+      deployed_by: "release-wave-gcp",
+      wave_id: "wave_1",
+    });
+  });
+
+  it("defaults wave_id to null when omitted", async () => {
+    const rec = await recordBackendDeploy(kv(), {
+      repo: "ippoan/rust-alc-api",
+      current_image: "img-1",
+      deployed_by: "hotfix-deploy",
+      now: daysAgo(0),
+    });
+    expect(rec.wave_id).toBeNull();
+  });
+
+  it("overwrites on subsequent deploy (latest only)", async () => {
+    await recordBackendDeploy(kv(), {
+      repo: "ippoan/rust-alc-api",
+      current_image: "old",
+      deployed_by: "x",
+      now: daysAgo(1),
+    });
+    await recordBackendDeploy(kv(), {
+      repo: "ippoan/rust-alc-api",
+      current_image: "new",
+      deployed_by: "y",
+      now: daysAgo(0),
+    });
+    const got = await getBackendCurrent(kv(), "ippoan/rust-alc-api");
+    expect(got!.current_image).toBe("new");
+  });
+
+  it("returns null when missing", async () => {
+    expect(await getBackendCurrent(kv(), "ippoan/nope")).toBeNull();
+  });
+
+  it("returns null on schema mismatch", async () => {
+    await kv().put(
+      "backend::ippoan/rust-alc-api",
+      JSON.stringify({ schema_version: 99, repo: "ippoan/rust-alc-api" }),
+    );
+    expect(await getBackendCurrent(kv(), "ippoan/rust-alc-api")).toBeNull();
+  });
+});
+
+describe("computeCompatibility", () => {
+  it("returns empty matrix and verified=false when no frontend tested the backend", async () => {
+    const res = await computeCompatibility(kv(), "ippoan/rust-alc-api", "target");
+    expect(res.matrix).toHaveLength(0);
+    expect(res.verified).toBe(false);
+  });
+
+  it("marks a frontend green when it tested the exact target image", async () => {
+    const at = daysAgo(1);
+    await recordFrontendTest(kv(), {
+      repo: "ippoan/auth-worker",
+      prod_version: "v0.5.32",
+      tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "target" },
+      now: at,
+    });
+    const res = await computeCompatibility(kv(), "ippoan/rust-alc-api", "target");
+    expect(res.verified).toBe(true);
+    expect(res.matrix).toHaveLength(1);
+    expect(res.matrix[0]).toMatchObject({
+      frontend: "ippoan/auth-worker",
+      prod_version: "v0.5.32",
+      tested_against_target: true,
+      tested_against_at: at,
+      last_tested_image: null,
+    });
+  });
+
+  it("marks a frontend red when it only tested a different image", async () => {
+    await recordFrontendTest(kv(), {
+      repo: "ippoan/alc-app",
+      prod_version: "v1.2.10",
+      tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "old-sha" },
+      now: daysAgo(2),
+    });
+    const res = await computeCompatibility(kv(), "ippoan/rust-alc-api", "target");
+    expect(res.verified).toBe(false);
+    expect(res.matrix[0]).toMatchObject({
+      frontend: "ippoan/alc-app",
+      tested_against_target: false,
+      tested_against_at: null,
+      last_tested_image: "old-sha",
+    });
+  });
+
+  it("excludes frontends that never tested this backend_repo", async () => {
+    await recordFrontendTest(kv(), {
+      repo: "ippoan/auth-worker",
+      prod_version: "v1",
+      tested: { backend_repo: "ippoan/cc-relay", backend_image: "x" },
+      now: daysAgo(1),
+    });
+    const res = await computeCompatibility(kv(), "ippoan/rust-alc-api", "target");
+    expect(res.matrix).toHaveLength(0);
+  });
+
+  it("combines green + red and sorts by frontend name; verified=false if any red", async () => {
+    await recordFrontendTest(kv(), {
+      repo: "ippoan/auth-worker",
+      prod_version: "v1",
+      tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "target" },
+      now: daysAgo(1),
+    });
+    await recordFrontendTest(kv(), {
+      repo: "ippoan/alc-app",
+      prod_version: "v2",
+      tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "stale" },
+      now: daysAgo(1),
+    });
+    const res = await computeCompatibility(kv(), "ippoan/rust-alc-api", "target");
+    expect(res.matrix.map((m) => m.frontend)).toEqual([
+      "ippoan/alc-app",
+      "ippoan/auth-worker",
+    ]);
+    expect(res.verified).toBe(false);
+  });
+
+  it("verified=true when every consuming frontend is green", async () => {
+    await recordFrontendTest(kv(), {
+      repo: "ippoan/auth-worker",
+      prod_version: "v1",
+      tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "target" },
+      now: daysAgo(1),
+    });
+    await recordFrontendTest(kv(), {
+      repo: "ippoan/alc-app",
+      prod_version: "v2",
+      tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "target" },
+      now: daysAgo(1),
+    });
+    const res = await computeCompatibility(kv(), "ippoan/rust-alc-api", "target");
+    expect(res.verified).toBe(true);
+    expect(res.matrix).toHaveLength(2);
+  });
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -19,6 +19,13 @@
     {
       "binding": "CI_STATUS",
       "id": "ffb983ee8324499f915b11a0b8cf787b"
+    },
+    {
+      // Release Wave compatibility 突合用 (`frontend::*` / `backend::*` records)。
+      // 新規 namespace を切らず CI_STATUS と同じ namespace を別 binding で流用する
+      // (key prefix で衝突回避、frontend:: は 90d TTL)。Refs #157 / #158。
+      "binding": "COMPAT_KV",
+      "id": "ffb983ee8324499f915b11a0b8cf787b"
     }
   ],
   "durable_objects": {
@@ -120,6 +127,10 @@
       "kv_namespaces": [
         {
           "binding": "CI_STATUS",
+          "id": "ffb983ee8324499f915b11a0b8cf787b"
+        },
+        {
+          "binding": "COMPAT_KV",
           "id": "ffb983ee8324499f915b11a0b8cf787b"
         }
       ],


### PR DESCRIPTION
## 概要

#157 Phase A の **compatibility データプレーン**を実装する。#158 で確定した KV write shape
(docs/release-wave-compatibility-kv.md) に準拠した read/write 経路を ci-dashboard worker に追加する。
既存の wave state machine / admin UI は一切変更しない、純粋に additive。

## 変更点

- **`COMPAT_KV` binding 追加** (wrangler.jsonc, top-level + staging)
  - 新規 namespace は切らず、既存 `CI_STATUS` namespace を別 binding として流用。
    `frontend::` / `backend::` の key prefix で衝突回避。インフラ変更ゼロ・可逆。
- **`src/release-wave/compat.ts`** — KV データ層
  - `frontend::<repo>` (`tested_against` sliding window 50件/90日, TTL 90日) と
    `backend::<repo>` (current_image upsert) の read/write
  - `computeCompatibility()`: 全 frontend を走査し緑/赤 matrix を構築。緑判定は
    「`(backend_repo, backend_image)` の entry が 1 つ以上」、matrix に載るのは当該
    backend を test 済みの frontend のみ (Phase A は test 履歴を consumer の近似に使う)
- **write webhook 2本** (`src/release-wave/webhook.ts`, 既存 shared-secret 認証を再利用)
  - `POST /webhooks/release-wave/frontend-test-report`
  - `POST /webhooks/release-wave/backend-deploy-report`
- **read endpoint 2本** (`src/release-wave/compat-api.ts`, CF Access edge gate に認証委譲)
  - `GET /compatibility?backend_repo=&backend_target_image=`
  - `GET /backend-current-image?repo=`
- docs/release-wave.md の webhook 表に 2 endpoint 追記

## Phase A 残り (後続 PR)

- `release_wave_status` 返り値に `compatibility` field
- `release_wave_start` dispatcher に compatibility precheck (warning event only)
- admin UI の compatibility matrix 表示

## テスト

- `test/release-wave/compat.test.ts` (KV ロジック) + `compat-http.test.ts` (webhook/endpoint) を追加
- ローカルで全 486 件 + 新規 33 件パス、`tsc --noEmit` 通過
  (private dep は file: 参照で一時 install して検証、package.json は元に戻し済み)

## レビュー観点

- COMPAT_KV を CI_STATUS と同 namespace 流用にした判断 (vs 専用 namespace)
- 緑/赤判定ルールと「consumer = test 履歴あり」の近似が Phase A として妥当か
- sliding window trim (件数 + 日数) のロジック

Refs #157
Refs #158
Refs #137


---
_Generated by [Claude Code](https://claude.ai/code/session_01RaEpH3beN6Zed6PqNEieuH)_