### PR TITLE
feat(release-wave): compatibility status + precheck + admin matrix (Phase A)

### DIFF
--- a/src/mcp/tools/release-wave.ts
+++ b/src/mcp/tools/release-wave.ts
@@ -12,8 +12,9 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { Env } from "../../index";
-import type { ReleaseWaveHub } from "../../release-wave/do";
+import type { ReleaseWaveHub, RpcResult } from "../../release-wave/do";
 import type { WaveState } from "../../release-wave/types";
+import { computeWaveCompatibility } from "../../release-wave/compat";
 
 // ----------------------------------------------------------------------------
 // Hub helper
@@ -153,15 +154,37 @@ export function registerReleaseWaveTools(server: McpServer, env: Env): void {
     "release_wave_status",
     {
       description:
-        "Get the current state of a wave (state machine status, repo progress, rollback safety flag, audit events).",
+        "Get the current state of a wave (state machine status, repo progress, rollback safety flag, audit events) plus a compatibility matrix of already-deployed frontends vs each backend's current image. Refs ippoan/ci-dashboard#157.",
       inputSchema: {
         wave_id: z.string().min(1),
       },
       annotations: { readOnlyHint: true },
     },
     async ({ wave_id }) => {
-      const result = await hubStub(env).get(wave_id);
-      return formatRpcResult(result);
+      const result = (await hubStub(env).get(wave_id)) as RpcResult<WaveState>;
+      if (!result.ok) return formatRpcResult(result);
+
+      // compatibility field を付与 (Refs #157 Phase A)。COMPAT_KV 未 bind 時は
+      // 省略する。算出失敗時も state は返す。
+      let compatibility: unknown;
+      if (env.COMPAT_KV) {
+        try {
+          compatibility = await computeWaveCompatibility(
+            env.COMPAT_KV,
+            result.data.repos.map((r) => r.repo),
+          );
+        } catch {
+          compatibility = undefined;
+        }
+      }
+
+      const payload =
+        compatibility === undefined
+          ? result.data
+          : { ...result.data, compatibility };
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+      };
     },
   );
 

--- a/src/release-wave/compat.ts
+++ b/src/release-wave/compat.ts
@@ -266,6 +266,62 @@ export async function computeCompatibility(
   return { backend_repo, backend_target_image, verified, matrix };
 }
 
+// ----------------------------------------------------------------------------
+// Read: wave 単位の compatibility (status / precheck / admin UI 用)
+// ----------------------------------------------------------------------------
+
+/** wave 内の 1 backend repo についての突合結果。 */
+export interface WaveBackendCompat {
+  backend_repo: string;
+  /** `backend::<repo>` に記録された現 production image (record 無しなら null)。 */
+  current_image: string | null;
+  /** 当該 backend を test 済みの frontend の matrix (consumer 無しなら空)。 */
+  matrix: CompatMatrixEntry[];
+}
+
+export interface WaveCompatibility {
+  /**
+   * 認識された backend (= `backend::` record を持つ wave repo) の中に赤が
+   * 1 つも無ければ true。consumer matrix が全て空でも (= 何も検証できなくても)
+   * vacuously true になる点に注意 (`checked` で区別する)。
+   */
+  verified: boolean;
+  /** 1 つ以上の backend が非空 consumer matrix を持っていれば true。 */
+  checked: boolean;
+  backends: WaveBackendCompat[];
+}
+
+/**
+ * wave に含まれる repo 群について compatibility を構築する。
+ *
+ * Phase A では wave の flip 先 image (= 新 image) を WaveState が持たないため、
+ * 各 backend repo の **現 production image** (`backend::<repo>.current_image`)
+ * を突合対象にする。これは「wave 起動時点で既 deploy frontend が現 backend と
+ * 整合しているか」の precheck として機能する。`backend::` record を持たない
+ * repo (= frontend / 未 deploy backend) は対象外。
+ */
+export async function computeWaveCompatibility(
+  kv: KVNamespace,
+  repos: string[],
+): Promise<WaveCompatibility> {
+  const backends: WaveBackendCompat[] = [];
+  for (const repo of repos) {
+    const rec = await getBackendCurrent(kv, repo);
+    if (!rec) continue; // backend deploy record の無い repo は対象外
+    const compat = await computeCompatibility(kv, repo, rec.current_image);
+    backends.push({
+      backend_repo: repo,
+      current_image: rec.current_image,
+      matrix: compat.matrix,
+    });
+  }
+  const checked = backends.some((b) => b.matrix.length > 0);
+  const verified = backends.every((b) =>
+    b.matrix.every((m) => m.tested_against_target),
+  );
+  return { verified, checked, backends };
+}
+
 /** `frontend::*` を全件 list して parse する。schema 不一致は除外。 */
 async function listFrontendRecords(
   kv: KVNamespace,

--- a/src/release-wave/do.ts
+++ b/src/release-wave/do.ts
@@ -25,9 +25,11 @@ import type {
   FlipPolicy,
   TransitionErrorCode,
   WaveEvent,
+  WaveEventRecord,
   WaveState,
 } from "./types";
 import { decideDispatches, dispatchAll } from "./dispatch";
+import { computeWaveCompatibility } from "./compat";
 
 // ----------------------------------------------------------------------------
 // Storage keys
@@ -166,6 +168,10 @@ export class ReleaseWaveHub extends DurableObject<Env> {
       now,
     });
     await this.saveWave(state);
+    // compatibility precheck (Refs #157 Phase A): 既 deploy frontend が wave 内
+    // backend の現 image と整合しているかを突合し、赤があれば warning event を
+    // 記録する。**block はしない** (= state はそのまま staging)。
+    await this.maybeRecordCompatWarning(state);
     // 各 caller repo に release-wave-stage dispatch を fan-out。
     // 失敗は best-effort で log/result に残す (dispatchAll は throw しない)。
     await this.maybeDispatch(null, state);
@@ -306,6 +312,42 @@ export class ReleaseWaveHub extends DurableObject<Env> {
         );
       }
     }
+  }
+
+  /**
+   * wave 内 backend の現 image に対し既 deploy frontend が test 済みかを突合し、
+   * 赤があれば `compatibility_warning` event を append + save する。
+   *
+   * read-only な precheck (block しない)。COMPAT_KV 未 bind / KV エラー時は
+   * best-effort で skip する (= wave start を失敗させない)。
+   */
+  private async maybeRecordCompatWarning(state: WaveState): Promise<void> {
+    if (!this.env.COMPAT_KV) return;
+    let compat;
+    try {
+      compat = await computeWaveCompatibility(
+        this.env.COMPAT_KV,
+        state.repos.map((r) => r.repo),
+      );
+    } catch (e) {
+      console.warn(`[release-wave] compat precheck failed: ${String(e)}`);
+      return;
+    }
+    if (!compat.checked || compat.verified) return;
+
+    const reds = compat.backends.flatMap((b) =>
+      b.matrix
+        .filter((m) => !m.tested_against_target)
+        .map((m) => `${m.frontend} (vs ${b.backend_repo}@${b.current_image})`),
+    );
+    const record: WaveEventRecord = {
+      at: new Date().toISOString(),
+      kind: "compatibility_warning",
+      summary: `compatibility precheck: ${reds.length} frontend(s) not tested against current backend image`,
+      detail: { reds },
+    };
+    state.events = [...state.events, record];
+    await this.saveWave(state);
   }
 
   private async loadWave(wave_id: string): Promise<WaveState | null> {

--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -16,6 +16,7 @@ import type { Env } from "../index";
 import type { ReleaseWaveHub, RpcResult } from "./do";
 import type { WaveState, WaveStateName } from "./types";
 import { renderTabs, TAB_STYLES } from "../nav-tabs";
+import { computeWaveCompatibility, type WaveCompatibility } from "./compat";
 
 // ----------------------------------------------------------------------------
 // Small HTML helpers
@@ -301,6 +302,21 @@ export async function handleReleaseWaveDetailPage(
     })
     .join("");
 
+  // ---- Compatibility matrix (Refs #157 Phase A) ----
+  // COMPAT_KV 未 bind / 算出失敗時は section を出さない。
+  let compatHtml = "";
+  if (env.COMPAT_KV) {
+    try {
+      const compat = await computeWaveCompatibility(
+        env.COMPAT_KV,
+        w.repos.map((r) => r.repo),
+      );
+      compatHtml = renderCompatibilitySection(compat);
+    } catch {
+      compatHtml = "";
+    }
+  }
+
   const rollbackSafetyHtml = w.rollback.safe
     ? `<p class="ok">rollback.safe = <strong>true</strong> (no contract migration applied yet)</p>`
     : `<p class="err">rollback.safe = <strong>false</strong></p>
@@ -359,6 +375,8 @@ export async function handleReleaseWaveDetailPage(
       </table>
     </div>
 
+    ${compatHtml}
+
     <div class="section">
       <h2>Events</h2>
       <ul>${eventsHtml}</ul>
@@ -373,6 +391,84 @@ export async function handleReleaseWaveDetailPage(
 </html>`;
 
   return htmlResponse(html);
+}
+
+// ----------------------------------------------------------------------------
+// Compatibility matrix section (Refs #157 Phase A)
+// ----------------------------------------------------------------------------
+
+/**
+ * wave 内 backend の現 image に対する既 deploy frontend の突合 matrix を描画する。
+ * 緑 (tested) / 赤 (untested) を highlight する。read-only / 非 block。
+ */
+function renderCompatibilitySection(compat: WaveCompatibility): string {
+  if (compat.backends.length === 0) {
+    return `
+    <div class="section">
+      <h2>Compatibility (frontend ↔ backend)</h2>
+      <p class="meta">No backend deploy records for this wave's repos yet
+        (nothing to check against).</p>
+    </div>`;
+  }
+
+  const verdict = !compat.checked
+    ? `<span class="meta">no consuming frontends recorded</span>`
+    : compat.verified
+    ? `<span class="ok"><strong>verified</strong></span>`
+    : `<span class="err"><strong>not verified</strong> — some frontends untested</span>`;
+
+  const blocks = compat.backends
+    .map((b) => {
+      const rows =
+        b.matrix.length === 0
+          ? `<tr><td colspan="4" class="empty">No frontend has tested against this backend.</td></tr>`
+          : b.matrix
+              .map((m) => {
+                const statusCell = m.tested_against_target
+                  ? `<span class="ok">tested</span>`
+                  : `<span class="err">untested</span>`;
+                const at = m.tested_against_at
+                  ? `<span class="meta">${escapeHtml(m.tested_against_at)}</span>`
+                  : `<span class="meta">—</span>`;
+                const last = m.tested_against_target
+                  ? `<span class="meta">—</span>`
+                  : `<span class="meta">${escapeHtml(m.last_tested_image ?? "—")}</span>`;
+                return `
+                <tr>
+                  <td>${escapeHtml(m.frontend)}</td>
+                  <td class="meta">${escapeHtml(m.prod_version ?? "—")}</td>
+                  <td>${statusCell} ${at}</td>
+                  <td>${last}</td>
+                </tr>`;
+              })
+              .join("");
+      return `
+      <h3>${escapeHtml(b.backend_repo)}
+        <span class="meta">@ ${escapeHtml(b.current_image ?? "—")}</span>
+      </h3>
+      <table>
+        <thead>
+          <tr>
+            <th>Frontend</th>
+            <th>Prod Version</th>
+            <th>Tested vs current image</th>
+            <th>Last tested image</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>`;
+    })
+    .join("");
+
+  return `
+    <div class="section">
+      <h2>Compatibility (frontend ↔ backend) — ${verdict}</h2>
+      <p class="meta">既 deploy frontend が wave 内 backend の<strong>現 production
+        image</strong>を integration test 済みか。赤は未検証 (Phase B の re-test で
+        緑化予定)。Refs
+        <a href="https://github.com/ippoan/ci-dashboard/issues/157">#157</a>.</p>
+      ${blocks}
+    </div>`;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/release-wave/types.ts
+++ b/src/release-wave/types.ts
@@ -172,8 +172,11 @@ export type WaveEvent =
 export interface WaveEventRecord {
   /** UTC ISO。 */
   readonly at: string;
-  /** kind は WaveEvent の kind を踏襲。 */
-  readonly kind: WaveEvent["kind"];
+  /**
+   * kind は WaveEvent の kind を踏襲。加えて、状態遷移を伴わない監査専用の
+   * `compatibility_warning` (Refs #157 Phase A) を許容する。
+   */
+  readonly kind: WaveEvent["kind"] | "compatibility_warning";
   /** transition で変わった結果の 1 行 summary。 */
   readonly summary: string;
   /** 自由 detail (e.g. repo 名 / actor)。 */

--- a/test/mcp/release-wave.test.ts
+++ b/test/mcp/release-wave.test.ts
@@ -73,13 +73,24 @@ function fakeHub(): {
   return { hub: spies as unknown as ReleaseWaveHub, spies };
 }
 
-function fakeEnv(hub: ReleaseWaveHub): Env {
+/** 空の COMPAT_KV stub (frontend:: / backend:: いずれも空)。 */
+function emptyCompatKv(): KVNamespace {
+  return {
+    list: async () => ({ keys: [], list_complete: true, cacheStatus: null }),
+    get: async () => null,
+    put: async () => undefined,
+    delete: async () => undefined,
+  } as unknown as KVNamespace;
+}
+
+function fakeEnv(hub: ReleaseWaveHub, compatKv?: KVNamespace): Env {
   const namespace = {
     idFromName: () => ({}),
     get: () => hub,
   } as unknown as DurableObjectNamespace;
   return {
     RELEASE_WAVE_HUB: namespace,
+    COMPAT_KV: compatKv ?? emptyCompatKv(),
   } as unknown as Env;
 }
 
@@ -250,6 +261,30 @@ describe("release_wave_status", () => {
     });
     expect(r.isError).toBe(true);
     expect(JSON.parse(r.content[0]!.text).code).toBe("NOT_FOUND");
+  });
+
+  it("includes a compatibility field for an ok result", async () => {
+    const { hub, spies } = fakeHub();
+    spies.get.mockResolvedValue({
+      ok: true,
+      data: {
+        wave_id: "w1",
+        state: "staging",
+        repos: [{ repo: "ippoan/rust-alc-api" }],
+      },
+    });
+    const server = fakeMcpServer();
+    registerReleaseWaveTools(
+      server as unknown as Parameters<typeof registerReleaseWaveTools>[0],
+      fakeEnv(hub),
+    );
+    const r = await server.tools
+      .get("release_wave_status")!
+      .handler({ wave_id: "w1" });
+    const payload = JSON.parse(r.content[0]!.text);
+    expect(payload.compatibility).toBeDefined();
+    expect(payload.compatibility.backends).toEqual([]);
+    expect(payload.compatibility.checked).toBe(false);
   });
 });
 

--- a/test/release-wave/compat.test.ts
+++ b/test/release-wave/compat.test.ts
@@ -5,6 +5,7 @@ import {
   recordBackendDeploy,
   getBackendCurrent,
   computeCompatibility,
+  computeWaveCompatibility,
   TESTED_AGAINST_MAX,
   WINDOW_DAYS,
   SCHEMA_VERSION,
@@ -339,5 +340,76 @@ describe("computeCompatibility", () => {
     const res = await computeCompatibility(kv(), "ippoan/rust-alc-api", "target");
     expect(res.verified).toBe(true);
     expect(res.matrix).toHaveLength(2);
+  });
+});
+
+describe("computeWaveCompatibility", () => {
+  it("ignores repos without a backend deploy record", async () => {
+    const res = await computeWaveCompatibility(kv(), [
+      "ippoan/auth-worker",
+      "ippoan/rust-alc-api",
+    ]);
+    expect(res.backends).toHaveLength(0);
+    expect(res.checked).toBe(false);
+    expect(res.verified).toBe(true); // vacuously true
+  });
+
+  it("checks against the backend's current recorded image", async () => {
+    await recordBackendDeploy(kv(), {
+      repo: "ippoan/rust-alc-api",
+      current_image: "cur",
+      deployed_by: "x",
+      now: daysAgo(1),
+    });
+    await recordFrontendTest(kv(), {
+      repo: "ippoan/auth-worker",
+      prod_version: "v1",
+      tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "cur" },
+      now: daysAgo(1),
+    });
+    const res = await computeWaveCompatibility(kv(), [
+      "ippoan/rust-alc-api",
+      "ippoan/auth-worker",
+    ]);
+    expect(res.backends).toHaveLength(1);
+    expect(res.backends[0]).toMatchObject({
+      backend_repo: "ippoan/rust-alc-api",
+      current_image: "cur",
+    });
+    expect(res.checked).toBe(true);
+    expect(res.verified).toBe(true);
+  });
+
+  it("verified=false when a consuming frontend has not tested the current image", async () => {
+    await recordBackendDeploy(kv(), {
+      repo: "ippoan/rust-alc-api",
+      current_image: "cur",
+      deployed_by: "x",
+      now: daysAgo(1),
+    });
+    await recordFrontendTest(kv(), {
+      repo: "ippoan/alc-app",
+      prod_version: "v1",
+      tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "stale" },
+      now: daysAgo(1),
+    });
+    const res = await computeWaveCompatibility(kv(), ["ippoan/rust-alc-api"]);
+    expect(res.checked).toBe(true);
+    expect(res.verified).toBe(false);
+    expect(res.backends[0]!.matrix[0]!.tested_against_target).toBe(false);
+  });
+
+  it("checked=false / verified=true when backend has a record but no consumers", async () => {
+    await recordBackendDeploy(kv(), {
+      repo: "ippoan/rust-alc-api",
+      current_image: "cur",
+      deployed_by: "x",
+      now: daysAgo(1),
+    });
+    const res = await computeWaveCompatibility(kv(), ["ippoan/rust-alc-api"]);
+    expect(res.backends).toHaveLength(1);
+    expect(res.backends[0]!.matrix).toHaveLength(0);
+    expect(res.checked).toBe(false);
+    expect(res.verified).toBe(true);
   });
 });

--- a/test/release-wave/do.test.ts
+++ b/test/release-wave/do.test.ts
@@ -1,6 +1,10 @@
 import { env, runInDurableObject } from "cloudflare:test";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { ReleaseWaveHub } from "../../src/release-wave/do";
+import {
+  recordBackendDeploy,
+  recordFrontendTest,
+} from "../../src/release-wave/compat";
 
 // 各テストで新しい DO ID を使って独立性を確保する。
 // (同一 ID を使い回すと前テストの storage が残り flaky になる。)
@@ -337,4 +341,110 @@ describe("ReleaseWaveHub.persistence", () => {
 // so test order is deterministic for debugging).
 beforeEach(() => {
   // no-op (idCounter は global、tests 間で increment 続行)
+});
+
+// ----------------------------------------------------------------------------
+// compatibility precheck warning (Refs #157 Phase A)
+// ----------------------------------------------------------------------------
+
+async function clearCompatKeys(): Promise<void> {
+  for (const prefix of ["frontend::", "backend::"]) {
+    const { keys } = await env.COMPAT_KV.list({ prefix });
+    await Promise.all(keys.map((k) => env.COMPAT_KV.delete(k.name)));
+  }
+}
+
+describe("ReleaseWaveHub.start compatibility precheck", () => {
+  beforeEach(clearCompatKeys);
+
+  const now = () => new Date().toISOString();
+
+  it("records a compatibility_warning when a frontend has not tested the current image", async () => {
+    await recordBackendDeploy(env.COMPAT_KV, {
+      repo: "ippoan/rust-alc-api",
+      current_image: "cur-img",
+      deployed_by: "x",
+      now: now(),
+    });
+    await recordFrontendTest(env.COMPAT_KV, {
+      repo: "ippoan/alc-app",
+      prod_version: "v1",
+      tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "stale-img" },
+      now: now(),
+    });
+
+    const hub = freshHub();
+    const result = await runInDurableObject(hub, (i) =>
+      i.start({
+        wave_id: "w-compat-red",
+        flip_policy: "manual-approval",
+        repos: [
+          { repo: "ippoan/rust-alc-api", target_tag: "v2", head_sha: "s" },
+        ],
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const warn = result.data.events.find(
+        (e) => e.kind === "compatibility_warning",
+      );
+      expect(warn).toBeDefined();
+      expect((warn!.detail as { reds: string[] }).reds[0]).toContain(
+        "ippoan/alc-app",
+      );
+      // precheck は block しない: state は staging のまま。
+      expect(result.data.state).toBe("staging");
+    }
+  });
+
+  it("does NOT record a warning when the frontend has tested the current image", async () => {
+    await recordBackendDeploy(env.COMPAT_KV, {
+      repo: "ippoan/rust-alc-api",
+      current_image: "cur-img",
+      deployed_by: "x",
+      now: now(),
+    });
+    await recordFrontendTest(env.COMPAT_KV, {
+      repo: "ippoan/alc-app",
+      prod_version: "v1",
+      tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "cur-img" },
+      now: now(),
+    });
+
+    const hub = freshHub();
+    const result = await runInDurableObject(hub, (i) =>
+      i.start({
+        wave_id: "w-compat-green",
+        flip_policy: "manual-approval",
+        repos: [
+          { repo: "ippoan/rust-alc-api", target_tag: "v2", head_sha: "s" },
+        ],
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(
+        result.data.events.some((e) => e.kind === "compatibility_warning"),
+      ).toBe(false);
+    }
+  });
+
+  it("does NOT record a warning when no backend deploy records exist", async () => {
+    const hub = freshHub();
+    const result = await runInDurableObject(hub, (i) =>
+      i.start({
+        wave_id: "w-compat-none",
+        flip_policy: "manual-approval",
+        repos: [
+          { repo: "ippoan/rust-alc-api", target_tag: "v2", head_sha: "s" },
+        ],
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(
+        result.data.events.some((e) => e.kind === "compatibility_warning"),
+      ).toBe(false);
+    }
+  });
 });

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -7,11 +7,38 @@ import type { Env } from "../../src/index";
 import type { ReleaseWaveHub } from "../../src/release-wave/do";
 import type { WaveState } from "../../src/release-wave/types";
 
+/** 簡易 in-memory KV。compat section 描画テスト用。 */
+function memKv(seed: Record<string, unknown> = {}): KVNamespace {
+  const store = new Map<string, string>(
+    Object.entries(seed).map(([k, v]) => [k, JSON.stringify(v)]),
+  );
+  return {
+    async get(key: string, type?: string) {
+      const raw = store.get(key);
+      if (raw === undefined) return null;
+      return type === "json" ? JSON.parse(raw) : raw;
+    },
+    async put(key: string, value: string) {
+      store.set(key, value);
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+    async list({ prefix = "" }: { prefix?: string } = {}) {
+      const keys = [...store.keys()]
+        .filter((k) => k.startsWith(prefix))
+        .map((name) => ({ name }));
+      return { keys, list_complete: true, cacheStatus: null };
+    },
+  } as unknown as KVNamespace;
+}
+
 function fakeEnv(opts: {
   listReturn?: WaveState[];
   getReturn?:
     | { ok: true; data: WaveState }
     | { ok: false; code: string; error: string };
+  compatKv?: KVNamespace;
 }): Env {
   const hub = {
     list: vi.fn().mockResolvedValue(opts.listReturn ?? []),
@@ -28,6 +55,7 @@ function fakeEnv(opts: {
       idFromName: () => ({}),
       get: () => hub,
     },
+    COMPAT_KV: opts.compatKv,
   } as unknown as Env;
 }
 
@@ -471,5 +499,98 @@ describe("handleReleaseWaveDetailPage", () => {
     const html = await resp.text();
     expect(html).not.toContain("<script>alert");
     expect(html).toContain("&lt;script&gt;");
+  });
+});
+
+// ============================================================================
+// compatibility matrix section (Refs #157 Phase A)
+// ============================================================================
+
+describe("handleReleaseWaveDetailPage compatibility section", () => {
+  it("omits the section entirely when COMPAT_KV is unbound", async () => {
+    const env = fakeEnv({ getReturn: { ok: true, data: makeWave() } });
+    const resp = await handleReleaseWaveDetailPage(env, "w1");
+    const html = await resp.text();
+    expect(html).not.toContain("Compatibility (frontend");
+  });
+
+  it("shows 'no backend deploy records' when KV has none", async () => {
+    const env = fakeEnv({
+      getReturn: { ok: true, data: makeWave() },
+      compatKv: memKv(),
+    });
+    const resp = await handleReleaseWaveDetailPage(env, "w1");
+    const html = await resp.text();
+    expect(html).toContain("Compatibility (frontend");
+    expect(html).toContain("No backend deploy records");
+  });
+
+  it("renders a red row for an untested frontend", async () => {
+    const env = fakeEnv({
+      getReturn: { ok: true, data: makeWave() },
+      compatKv: memKv({
+        "backend::ippoan/rust-alc-api": {
+          schema_version: 1,
+          repo: "ippoan/rust-alc-api",
+          current_image: "cur-img",
+          deployed_at: "2026-05-27T00:00:00Z",
+          deployed_by: "x",
+          wave_id: null,
+        },
+        "frontend::ippoan/alc-app": {
+          schema_version: 1,
+          repo: "ippoan/alc-app",
+          prod_version: "v1.2.10",
+          prod_deployed_at: "2026-05-27T00:00:00Z",
+          tested_against: [
+            {
+              backend_repo: "ippoan/rust-alc-api",
+              backend_image: "stale-img",
+              tested_at: "2026-05-27T00:00:00Z",
+            },
+          ],
+        },
+      }),
+    });
+    const resp = await handleReleaseWaveDetailPage(env, "w1");
+    const html = await resp.text();
+    expect(html).toContain("Compatibility (frontend");
+    expect(html).toContain("not verified");
+    expect(html).toContain("ippoan/alc-app");
+    expect(html).toContain("untested");
+    expect(html).toContain("stale-img");
+  });
+
+  it("renders verified when the frontend tested the current image", async () => {
+    const env = fakeEnv({
+      getReturn: { ok: true, data: makeWave() },
+      compatKv: memKv({
+        "backend::ippoan/rust-alc-api": {
+          schema_version: 1,
+          repo: "ippoan/rust-alc-api",
+          current_image: "cur-img",
+          deployed_at: "2026-05-27T00:00:00Z",
+          deployed_by: "x",
+          wave_id: null,
+        },
+        "frontend::ippoan/auth-worker": {
+          schema_version: 1,
+          repo: "ippoan/auth-worker",
+          prod_version: "v0.5.32",
+          prod_deployed_at: "2026-05-27T00:00:00Z",
+          tested_against: [
+            {
+              backend_repo: "ippoan/rust-alc-api",
+              backend_image: "cur-img",
+              tested_at: "2026-05-27T00:00:00Z",
+            },
+          ],
+        },
+      }),
+    });
+    const resp = await handleReleaseWaveDetailPage(env, "w1");
+    const html = await resp.text();
+    expect(html).toContain(">verified<");
+    expect(html).toContain("tested");
   });
 });


### PR DESCRIPTION
## 概要

#157 Phase A の残り 3 点を実装する。#160 で merge した compatibility データプレーン
(`compat.ts`) の上に、status / precheck / admin UI を載せる。read-only / 非 block で、
既存 wave state machine の遷移ロジックは変更しない。

## 変更点

- **`computeWaveCompatibility()`** (`compat.ts`)
  - wave 内の各 backend repo (= `backend::` record を持つもの) について、その
    **現 production image** (`current_image`) に対し既 deploy frontend が test 済みかを突合
  - Phase A では wave の flip 先 image を WaveState が持たないため、現 image を突合対象にする
    (= wave 起動時点で既 deploy frontend が現 backend と整合しているかの precheck)
- **`release_wave_start` precheck** (`do.ts`)
  - start 時に突合し、赤 (未 test の frontend) があれば `compatibility_warning` event を
    events[] に記録。**block しない** (state は staging のまま)
  - COMPAT_KV 未 bind / KV エラー時は best-effort で skip
  - `WaveEventRecord.kind` に監査専用の `compatibility_warning` を追加 (types.ts)
- **`release_wave_status`** (`mcp/tools/release-wave.ts`)
  - 返り値 JSON に `compatibility` field (`verified` / `checked` / `backends[].matrix`) を付与
- **admin UI** (`page.ts`, `GET /release-wave/:id`)
  - compatibility matrix セクションを追加。backend 毎に frontend を緑 (tested) / 赤 (untested)
    で表示。consumer や backend record が無い場合の空表示も対応

## 設計判断

- **突合対象 = 現 image**: 親 issue の例は flip 先 (target) image を想定するが、Phase A の
  WaveState は新 image を持たないため現 image で突合。target image 突合は wave に image を
  carry する plumbing が要るので Phase B/C 送り。
- **verified vs checked**: 認識 backend に赤が無ければ `verified=true` (consumer ゼロでも
  vacuously true)。consumer matrix が 1 件以上あるかは `checked` で区別。warning event は
  `checked && !verified` のときだけ発火 (consumer ゼロでは warning を出さない)。

## テスト

- `compat.test.ts`: `computeWaveCompatibility` の 4 ケース追加
- `do.test.ts`: start precheck の warning 発火 / 非発火 3 ケース
- `mcp/release-wave.test.ts`: status に compatibility field が乗る検証
- `page.test.ts`: matrix section の緑/赤/空 描画 4 ケース
- ローカルで全 498 件パス + `tsc --noEmit` 通過

## Phase A 完了後

これで #157 Phase A (可視化) は完了。次は Phase B (auto-retest による red→green self-service)。

Refs #157
Refs #137


---
_Generated by [Claude Code](https://claude.ai/code/session_01RaEpH3beN6Zed6PqNEieuH)_