### PR TITLE
feat(release-wave): compatibility auto-retest dispatcher + admin buttons (Phase B)

### DIFF
--- a/docs/release-wave-compatibility-kv.md
+++ b/docs/release-wave-compatibility-kv.md
@@ -262,6 +262,48 @@ frontend CI の `report-frontend-compat` action が staging 現 image を取り�
 `frontend::<repo>` は write の度に TTL がリセットされる (= putable で
 `expirationTtl: 90 * 24 * 3600` を毎回指定する)。
 
+## Phase B: auto-retest (red → green の self-service)
+
+赤 (= 現 backend image を未 test の frontend) を admin UI / API から再 test に
+かけて緑化する経路。
+
+### `POST /api/release-wave/:wave_id/retest` (admin / CF Access gated)
+
+admin UI の "Re-test all reds" / per-frontend "Re-test" ボタンが叩く。
+ci-dashboard が wave の compatibility matrix を算出し、赤 frontend に対し
+`release-wave-retest` の `repository_dispatch` を fan-out する。
+
+- form field `frontend` (optional): 指定時はその "owner/name" 1 件だけ。無ければ全 red。
+- dispatch は best-effort (1 件失敗で他を止めない)。完了後は wave 詳細に 303 redirect。
+
+### `repository_dispatch` (event_type: `release-wave-retest`)
+
+ci-dashboard → frontend repo に送る client_payload:
+
+```json
+{
+  "wave_id": "wave_2026_05_27_01",
+  "backend_repo": "ippoan/rust-alc-api",
+  "backend_image": "rust-alc-api-00042-abc",
+  "prod_version": "v0.5.32"
+}
+```
+
+frontend 側 (consumer 契約、別 repo / ci-workflows reusable で実装):
+
+1. `test.yml` に `on: repository_dispatch: types: [release-wave-retest]` を追加
+2. `${{ github.event.client_payload.backend_image }}` 相手に integration test を回す
+   (= Phase A で計画した `workflow_dispatch.inputs.backend_image` と同経路)
+3. green なら **既存の `frontend-test-report` webhook** を打つ
+   (`tested.backend_image` に渡された image を入れる)
+
+### retest-report は新設しない (設計判断)
+
+Phase A で `frontend-test-report` が KV write を server 側で担うため、retest 完了
+通知も同 endpoint を再利用する。matrix は admin UI / `release_wave_status` が KV を
+都度 read して算出するので、KV 更新後の次回表示で**自動 refresh** される
+(= 専用 `retest-report` endpoint や matrix push は不要)。
+
 ## 後続実装 issue
 
 本ドキュメントが approve された後、以下を別 issue / PR として進める:
@@ -272,6 +314,8 @@ frontend CI の `report-frontend-compat` action が staging 現 image を取り�
 - [ ] release-wave-gcp: flip-traffic 成功時の `backend-deploy-report` 呼び出し
 - [ ] 各 frontend repo の `test.yml` に `report-compatibility` job 追加
 - [ ] 各 backend repo の deploy workflow に `backend-deploy-report` 呼び出し追加
+- [ ] 各 frontend repo の `test.yml` に `repository_dispatch: [release-wave-retest]`
+  トリガー + `backend_image` 相手の integration test 経路追加 (Phase B consumer)
 
 ## 関連
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import {
   handleReleaseWaveApprove,
   handleReleaseWaveRollback,
   handleReleaseWaveAbort,
+  handleReleaseWaveRetest,
 } from "./release-wave/api";
 import {
   handlePwaManifest,
@@ -242,6 +243,11 @@ app.post("/api/release-wave/:wave_id/rollback", (c) =>
 );
 app.post("/api/release-wave/:wave_id/abort", (c) =>
   handleReleaseWaveAbort(c.req.raw, c.env, c.req.param("wave_id")),
+);
+// compatibility matrix の赤 frontend に release-wave-retest を fan-out
+// (Refs #157 Phase B)。form field `frontend` で 1 件指定可、無ければ全 red。
+app.post("/api/release-wave/:wave_id/retest", (c) =>
+  handleReleaseWaveRetest(c.req.raw, c.env, c.req.param("wave_id")),
 );
 
 export default app;

--- a/src/release-wave/api.ts
+++ b/src/release-wave/api.ts
@@ -12,6 +12,8 @@
 import type { Env } from "../index";
 import type { ReleaseWaveHub, RpcResult } from "./do";
 import type { WaveState } from "./types";
+import { computeWaveCompatibility } from "./compat";
+import { decideRetestDispatches, dispatchAll } from "./dispatch";
 
 function hubStub(env: Env): DurableObjectStub<ReleaseWaveHub> {
   const id = env.RELEASE_WAVE_HUB.idFromName("singleton");
@@ -135,6 +137,57 @@ export async function handleReleaseWaveAbort(
       code: result.code,
       error: result.error,
     });
+  }
+  return redirectToDetail(wave_id);
+}
+
+// ----------------------------------------------------------------------------
+// POST /api/release-wave/:wave_id/retest  (Refs #157 Phase B)
+// ----------------------------------------------------------------------------
+
+/**
+ * compatibility matrix の赤 frontend に `release-wave-retest` を fan-out する。
+ * form field `frontend` を渡せばその 1 件だけ ("Re-test against this image")、
+ * 無ければ全 red ("Re-test all reds")。
+ *
+ * dispatch は best-effort (dispatchAll は throw しない)。完了後は詳細ページに
+ * redirect する。matrix は SSR で KV を都度読むため、frontend CI が
+ * `frontend-test-report` を打ち KV が更新されれば次回表示で自動 refresh される。
+ */
+export async function handleReleaseWaveRetest(
+  req: Request,
+  env: Env,
+  wave_id: string,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return jsonResponse(405, { code: "METHOD_NOT_ALLOWED", error: "use POST" });
+  }
+  let onlyFrontend: string | undefined;
+  try {
+    const form = await req.formData();
+    const f = String(form.get("frontend") ?? "").trim();
+    if (f) onlyFrontend = f;
+  } catch {
+    // form-data 以外は全 red 対象
+  }
+
+  const result = (await hubStub(env).get(wave_id)) as RpcResult<WaveState>;
+  if (!result.ok) {
+    return jsonResponse(rpcErrorToHttpStatus(result.code), {
+      code: result.code,
+      error: result.error,
+    });
+  }
+
+  if (env.COMPAT_KV) {
+    const compat = await computeWaveCompatibility(
+      env.COMPAT_KV,
+      result.data.repos.map((r) => r.repo),
+    );
+    const dispatches = decideRetestDispatches(wave_id, compat, onlyFrontend);
+    if (dispatches.length > 0) {
+      await dispatchAll(env, dispatches);
+    }
   }
   return redirectToDetail(wave_id);
 }

--- a/src/release-wave/dispatch.ts
+++ b/src/release-wave/dispatch.ts
@@ -18,6 +18,7 @@
 import type { Env } from "../index";
 import { githubApi, parseRepo, tokenForOrg } from "../github-api";
 import type { WaveState } from "./types";
+import type { WaveCompatibility } from "./compat";
 
 // ----------------------------------------------------------------------------
 // Types
@@ -26,7 +27,8 @@ import type { WaveState } from "./types";
 export type DispatchEventType =
   | "release-wave-stage"
   | "release-wave-flip"
-  | "release-wave-rollback";
+  | "release-wave-rollback"
+  | "release-wave-retest";
 
 export interface Dispatch {
   /** "owner/name" 形式 */
@@ -115,6 +117,45 @@ export function decideDispatches(
   }
 
   return [];
+}
+
+// ----------------------------------------------------------------------------
+// Pure: decideRetestDispatches (Refs #157 Phase B)
+// ----------------------------------------------------------------------------
+
+/**
+ * compatibility matrix の赤 (= 現 backend image を未 test の frontend) に対し
+ * `release-wave-retest` dispatch を作る。frontend 側 workflow が
+ * `repository_dispatch: types: [release-wave-retest]` を受け、渡された
+ * `backend_image` 相手に integration test を回して green なら ci-dashboard の
+ * `frontend-test-report` webhook に report する想定。
+ *
+ * @param onlyFrontend 指定時はその "owner/name" 1 件だけに絞る (per-frontend
+ *   "Re-test" ボタン用)。未指定なら全 red を対象 ("Re-test all reds")。
+ */
+export function decideRetestDispatches(
+  wave_id: string,
+  compat: WaveCompatibility,
+  onlyFrontend?: string,
+): Dispatch[] {
+  const out: Dispatch[] = [];
+  for (const b of compat.backends) {
+    for (const m of b.matrix) {
+      if (m.tested_against_target) continue; // green は skip
+      if (onlyFrontend && m.frontend !== onlyFrontend) continue;
+      out.push({
+        repo: m.frontend,
+        event_type: "release-wave-retest",
+        client_payload: {
+          wave_id,
+          backend_repo: b.backend_repo,
+          backend_image: b.current_image,
+          prod_version: m.prod_version,
+        },
+      });
+    }
+  }
+  return out;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -311,7 +311,7 @@ export async function handleReleaseWaveDetailPage(
         env.COMPAT_KV,
         w.repos.map((r) => r.repo),
       );
-      compatHtml = renderCompatibilitySection(compat);
+      compatHtml = renderCompatibilitySection(compat, w.wave_id);
     } catch {
       compatHtml = "";
     }
@@ -401,7 +401,10 @@ export async function handleReleaseWaveDetailPage(
  * wave 内 backend の現 image に対する既 deploy frontend の突合 matrix を描画する。
  * 緑 (tested) / 赤 (untested) を highlight する。read-only / 非 block。
  */
-function renderCompatibilitySection(compat: WaveCompatibility): string {
+function renderCompatibilitySection(
+  compat: WaveCompatibility,
+  wave_id: string,
+): string {
   if (compat.backends.length === 0) {
     return `
     <div class="section">
@@ -417,11 +420,27 @@ function renderCompatibilitySection(compat: WaveCompatibility): string {
     ? `<span class="ok"><strong>verified</strong></span>`
     : `<span class="err"><strong>not verified</strong> — some frontends untested</span>`;
 
+  const retestAction = encodeURIComponent(wave_id);
+  // 赤が 1 つでもあれば "Re-test all reds" ボタンを出す。
+  const hasReds = compat.backends.some((b) =>
+    b.matrix.some((m) => !m.tested_against_target),
+  );
+  const retestAllBlock = hasReds
+    ? `<div class="actions">
+         <form method="post" action="/api/release-wave/${retestAction}/retest">
+           <button type="submit" class="warn"
+             title="Dispatch release-wave-retest to every untested frontend">
+             Re-test all reds
+           </button>
+         </form>
+       </div>`
+    : "";
+
   const blocks = compat.backends
     .map((b) => {
       const rows =
         b.matrix.length === 0
-          ? `<tr><td colspan="4" class="empty">No frontend has tested against this backend.</td></tr>`
+          ? `<tr><td colspan="5" class="empty">No frontend has tested against this backend.</td></tr>`
           : b.matrix
               .map((m) => {
                 const statusCell = m.tested_against_target
@@ -433,12 +452,20 @@ function renderCompatibilitySection(compat: WaveCompatibility): string {
                 const last = m.tested_against_target
                   ? `<span class="meta">—</span>`
                   : `<span class="meta">${escapeHtml(m.last_tested_image ?? "—")}</span>`;
+                // 赤行のみ per-frontend の Re-test ボタンを出す。
+                const actionCell = m.tested_against_target
+                  ? `<span class="meta">—</span>`
+                  : `<form method="post" action="/api/release-wave/${retestAction}/retest" style="margin:0">
+                       <input type="hidden" name="frontend" value="${escapeHtml(m.frontend)}">
+                       <button type="submit" class="warn" title="Re-test this frontend against the current image">Re-test</button>
+                     </form>`;
                 return `
                 <tr>
                   <td>${escapeHtml(m.frontend)}</td>
                   <td class="meta">${escapeHtml(m.prod_version ?? "—")}</td>
                   <td>${statusCell} ${at}</td>
                   <td>${last}</td>
+                  <td>${actionCell}</td>
                 </tr>`;
               })
               .join("");
@@ -453,6 +480,7 @@ function renderCompatibilitySection(compat: WaveCompatibility): string {
             <th>Prod Version</th>
             <th>Tested vs current image</th>
             <th>Last tested image</th>
+            <th>Action</th>
           </tr>
         </thead>
         <tbody>${rows}</tbody>
@@ -464,9 +492,11 @@ function renderCompatibilitySection(compat: WaveCompatibility): string {
     <div class="section">
       <h2>Compatibility (frontend ↔ backend) — ${verdict}</h2>
       <p class="meta">既 deploy frontend が wave 内 backend の<strong>現 production
-        image</strong>を integration test 済みか。赤は未検証 (Phase B の re-test で
-        緑化予定)。Refs
+        image</strong>を integration test 済みか。赤は未検証 — "Re-test" で
+        <code>release-wave-retest</code> を frontend に dispatch し、green 化後に
+        matrix が自動更新される。Refs
         <a href="https://github.com/ippoan/ci-dashboard/issues/157">#157</a>.</p>
+      ${retestAllBlock}
       ${blocks}
     </div>`;
 }

--- a/test/release-wave/api.test.ts
+++ b/test/release-wave/api.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   handleReleaseWaveApprove,
   handleReleaseWaveRollback,
   handleReleaseWaveAbort,
+  handleReleaseWaveRetest,
 } from "../../src/release-wave/api";
 import type { Env } from "../../src/index";
 import type { ReleaseWaveHub } from "../../src/release-wave/do";
@@ -243,5 +244,189 @@ describe("handleReleaseWaveAbort", () => {
     });
     const resp = await handleReleaseWaveAbort(req, env, "w1");
     expect(resp.status).toBe(409);
+  });
+});
+
+// ============================================================================
+// /api/release-wave/:wave_id/retest  (Refs #157 Phase B)
+// ============================================================================
+
+/** 簡易 in-memory KV (compat 突合用)。 */
+function memKv(seed: Record<string, unknown> = {}): KVNamespace {
+  const store = new Map<string, string>(
+    Object.entries(seed).map(([k, v]) => [k, JSON.stringify(v)]),
+  );
+  return {
+    async get(key: string, type?: string) {
+      const raw = store.get(key);
+      if (raw === undefined) return null;
+      return type === "json" ? JSON.parse(raw) : raw;
+    },
+    async put(key: string, value: string) {
+      store.set(key, value);
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+    async list({ prefix = "" }: { prefix?: string } = {}) {
+      const keys = [...store.keys()]
+        .filter((k) => k.startsWith(prefix))
+        .map((name) => ({ name }));
+      return { keys, list_complete: true, cacheStatus: null };
+    },
+  } as unknown as KVNamespace;
+}
+
+const FRESH_TOKEN = {
+  token: "ghs_retest_token",
+  expires_at_ms: Date.now() + 3600_000,
+};
+
+function retestEnv(opts: {
+  getReturn?: unknown;
+  compatKv?: KVNamespace;
+}): Env {
+  const hub = {
+    get: vi.fn().mockResolvedValue(
+      opts.getReturn ?? {
+        ok: true,
+        data: { wave_id: "w1", repos: [{ repo: "ippoan/rust-alc-api" }] },
+      },
+    ),
+  } as unknown as ReleaseWaveHub;
+  return {
+    RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => hub },
+    COMPAT_KV: opts.compatKv,
+    // getGitHubToken の KV cache hit 用 (introspect fetch を回避)。
+    CI_STATUS: memKv({ "auth-client-worker:gh-token": FRESH_TOKEN }),
+    INTERNAL_SHARED_SECRET: { get: async () => "secret" },
+  } as unknown as Env;
+}
+
+/** backend cur-img + frontend red を仕込んだ COMPAT_KV。 */
+function redCompatKv(): KVNamespace {
+  return memKv({
+    "backend::ippoan/rust-alc-api": {
+      schema_version: 1,
+      repo: "ippoan/rust-alc-api",
+      current_image: "cur-img",
+      deployed_at: "2026-05-27T00:00:00Z",
+      deployed_by: "x",
+      wave_id: null,
+    },
+    "frontend::ippoan/alc-app": {
+      schema_version: 1,
+      repo: "ippoan/alc-app",
+      prod_version: "v1.2.10",
+      prod_deployed_at: "2026-05-27T00:00:00Z",
+      tested_against: [
+        {
+          backend_repo: "ippoan/rust-alc-api",
+          backend_image: "stale-img",
+          tested_at: "2026-05-27T00:00:00Z",
+        },
+      ],
+    },
+  });
+}
+
+describe("handleReleaseWaveRetest", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns 405 on GET", async () => {
+    const env = retestEnv({});
+    const req = new Request("https://ci-dashboard.ippoan.org/api/release-wave/w1/retest", {
+      method: "GET",
+    });
+    const resp = await handleReleaseWaveRetest(req, env, "w1");
+    expect(resp.status).toBe(405);
+  });
+
+  it("maps NOT_FOUND to 404", async () => {
+    const env = retestEnv({
+      getReturn: { ok: false, code: "NOT_FOUND", error: "no wave" },
+    });
+    const resp = await handleReleaseWaveRetest(
+      postRequest("/api/release-wave/ghost/retest"),
+      env,
+      "ghost",
+    );
+    expect(resp.status).toBe(404);
+  });
+
+  it("redirects without dispatch when COMPAT_KV unbound", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    const env = retestEnv({ compatKv: undefined });
+    const resp = await handleReleaseWaveRetest(
+      postRequest("/api/release-wave/w1/retest"),
+      env,
+      "w1",
+    );
+    expect(resp.status).toBe(303);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("redirects without dispatch when there are no reds", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    // backend record 無し → matrix 空 → 赤無し
+    const env = retestEnv({ compatKv: memKv() });
+    const resp = await handleReleaseWaveRetest(
+      postRequest("/api/release-wave/w1/retest"),
+      env,
+      "w1",
+    );
+    expect(resp.status).toBe(303);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("dispatches release-wave-retest to a red frontend and redirects", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    const env = retestEnv({ compatKv: redCompatKv() });
+    const resp = await handleReleaseWaveRetest(
+      postRequest("/api/release-wave/w1/retest"),
+      env,
+      "w1",
+    );
+    expect(resp.status).toBe(303);
+    const dispatchCall = fetchSpy.mock.calls.find((c) =>
+      String(c[0]).includes("/repos/ippoan/alc-app/dispatches"),
+    );
+    expect(dispatchCall).toBeDefined();
+    const body = JSON.parse(dispatchCall![1].body);
+    expect(body.event_type).toBe("release-wave-retest");
+    expect(body.client_payload).toMatchObject({
+      wave_id: "w1",
+      backend_repo: "ippoan/rust-alc-api",
+      backend_image: "cur-img",
+      prod_version: "v1.2.10",
+    });
+  });
+
+  it("honors the `frontend` form field to target one repo", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    const env = retestEnv({ compatKv: redCompatKv() });
+    const resp = await handleReleaseWaveRetest(
+      postRequest("/api/release-wave/w1/retest", {
+        formBody: { frontend: "ippoan/does-not-match" },
+      }),
+      env,
+      "w1",
+    );
+    expect(resp.status).toBe(303);
+    // frontend が一致しないので dispatch されない。
+    const dispatchCall = fetchSpy.mock.calls.find((c) =>
+      String(c[0]).includes("/dispatches"),
+    );
+    expect(dispatchCall).toBeUndefined();
   });
 });

--- a/test/release-wave/dispatch.test.ts
+++ b/test/release-wave/dispatch.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { decideDispatches } from "../../src/release-wave/dispatch";
+import {
+  decideDispatches,
+  decideRetestDispatches,
+} from "../../src/release-wave/dispatch";
 import { createWave, transition } from "../../src/release-wave/state";
 import type { WaveState } from "../../src/release-wave/types";
+import type {
+  WaveCompatibility,
+  CompatMatrixEntry,
+} from "../../src/release-wave/compat";
 
 const T0 = "2026-05-28T00:00:00Z";
 const T1 = "2026-05-28T00:05:00Z";
@@ -281,5 +288,107 @@ describe("decideDispatches: silent transitions", () => {
       }),
     ).state;
     expect(decideDispatches(prev, next)).toEqual([]);
+  });
+});
+
+// ============================================================================
+// decideRetestDispatches (Refs #157 Phase B)
+// ============================================================================
+
+function entry(over: Partial<CompatMatrixEntry>): CompatMatrixEntry {
+  return {
+    frontend: "ippoan/alc-app",
+    prod_version: "v1",
+    tested_against_target: false,
+    tested_against_at: null,
+    last_tested_image: "stale",
+    ...over,
+  };
+}
+
+function compat(over: Partial<WaveCompatibility> = {}): WaveCompatibility {
+  return { verified: false, checked: true, backends: [], ...over };
+}
+
+describe("decideRetestDispatches", () => {
+  it("returns empty when there are no reds", () => {
+    const c = compat({
+      backends: [
+        {
+          backend_repo: "ippoan/rust-alc-api",
+          current_image: "cur",
+          matrix: [entry({ frontend: "ippoan/auth-worker", tested_against_target: true })],
+        },
+      ],
+    });
+    expect(decideRetestDispatches("w1", c)).toEqual([]);
+  });
+
+  it("dispatches release-wave-retest to each red frontend with payload", () => {
+    const c = compat({
+      backends: [
+        {
+          backend_repo: "ippoan/rust-alc-api",
+          current_image: "cur-img",
+          matrix: [
+            entry({ frontend: "ippoan/alc-app", prod_version: "v1.2.10" }),
+            entry({ frontend: "ippoan/auth-worker", tested_against_target: true }),
+          ],
+        },
+      ],
+    });
+    const ds = decideRetestDispatches("w1", c);
+    expect(ds).toHaveLength(1);
+    expect(ds[0]).toMatchObject({
+      repo: "ippoan/alc-app",
+      event_type: "release-wave-retest",
+      client_payload: {
+        wave_id: "w1",
+        backend_repo: "ippoan/rust-alc-api",
+        backend_image: "cur-img",
+        prod_version: "v1.2.10",
+      },
+    });
+  });
+
+  it("filters to a single frontend when onlyFrontend is given", () => {
+    const c = compat({
+      backends: [
+        {
+          backend_repo: "ippoan/rust-alc-api",
+          current_image: "cur",
+          matrix: [
+            entry({ frontend: "ippoan/alc-app" }),
+            entry({ frontend: "ippoan/nuxt-items" }),
+          ],
+        },
+      ],
+    });
+    const ds = decideRetestDispatches("w1", c, "ippoan/nuxt-items");
+    expect(ds).toHaveLength(1);
+    expect(ds[0]!.repo).toBe("ippoan/nuxt-items");
+  });
+
+  it("emits one dispatch per (frontend, backend) red across multiple backends", () => {
+    const c = compat({
+      backends: [
+        {
+          backend_repo: "ippoan/rust-alc-api",
+          current_image: "img-a",
+          matrix: [entry({ frontend: "ippoan/alc-app" })],
+        },
+        {
+          backend_repo: "ippoan/cc-relay",
+          current_image: "img-b",
+          matrix: [entry({ frontend: "ippoan/alc-app" })],
+        },
+      ],
+    });
+    const ds = decideRetestDispatches("w1", c);
+    expect(ds).toHaveLength(2);
+    expect(ds.map((d) => d.client_payload.backend_repo)).toEqual([
+      "ippoan/rust-alc-api",
+      "ippoan/cc-relay",
+    ]);
   });
 });


### PR DESCRIPTION
## 概要

#157 Phase B の ci-dashboard 側を実装する。Phase A で可視化した「赤 frontend
(= wave 内 backend の現 image を未 test)」を、admin UI / API から再 test にかけて
緑化する self-service 経路を追加する。

## 変更点 (ci-dashboard)

- **`decideRetestDispatches()`** (`dispatch.ts`, pure)
  - compatibility matrix の赤 entry から `release-wave-retest` の `Dispatch[]` を生成
  - `onlyFrontend` で 1 件に絞れる (per-frontend ボタン用)
  - `DispatchEventType` に `release-wave-retest` を追加
- **`POST /api/release-wave/:wave_id/retest`** (`api.ts`, admin / CF Access gated)
  - wave の compatibility を算出 → 赤 frontend に `repository_dispatch` を fan-out
  - form field `frontend` で 1 件指定可、無ければ全 red
  - dispatch は best-effort、完了後 wave 詳細に 303 redirect
- **admin UI** (`page.ts`)
  - compatibility section に "Re-test all reds" ボタン (赤が 1 件以上のとき)
  - 赤行ごとに per-frontend "Re-test" ボタン (Action 列を追加)

## repository_dispatch contract (frontend consumer 側)

`release-wave-retest` の client_payload:

```json
{ "wave_id": "...", "backend_repo": "ippoan/rust-alc-api",
  "backend_image": "rust-alc-api-00042-abc", "prod_version": "v0.5.32" }
```

frontend `test.yml` は `repository_dispatch: [release-wave-retest]` を受け、
`backend_image` 相手に integration test → green なら既存 `frontend-test-report`
webhook を打つ (= matrix が次回 SSR で自動 refresh)。frontend 側 / ci-workflows
reusable の実装は別 repo / 別 PR (docs に consumer 契約を記載)。

## 設計判断

- **`retest-report` は新設しない**: Phase A の `frontend-test-report` が KV write を
  server 側で担うため、retest 完了通知も同 endpoint を再利用。matrix は admin UI /
  `release_wave_status` が KV を都度読むため、KV 更新後の次回表示で自動 refresh
  される (専用 endpoint や push は不要)。
- **retest 対象 = matrix の赤**: `release-wave-targets.yaml` の `consumed_by` を
  別途持たずとも、Phase A の matrix (test 履歴 = consumer 近似) が赤 frontend を
  与えるのでそれを使う。

## テスト

- `dispatch.test.ts`: `decideRetestDispatches` の 4 ケース (赤なし / payload / onlyFrontend / 複数 backend)
- `api.test.ts`: retest handler の 6 ケース (405 / 404 / KV 未 bind / 赤なし / dispatch 発火 / frontend 絞り込み、global fetch stub で dispatch を検証)
- ローカルで全 508 件パス + `tsc --noEmit` 通過

Refs #157
Refs #137


---
_Generated by [Claude Code](https://claude.ai/code/session_01RaEpH3beN6Zed6PqNEieuH)_