### PR TITLE
feat(release-wave): compatibility approve gate (Phase C, opt-in)

### DIFF
--- a/docs/release-wave-compatibility-kv.md
+++ b/docs/release-wave-compatibility-kv.md
@@ -304,6 +304,42 @@ Phase A で `frontend-test-report` が KV write を server 側で担うため、
 都度 read して算出するので、KV 更新後の次回表示で**自動 refresh** される
 (= 専用 `retest-report` endpoint や matrix push は不要)。
 
+## Phase C: gate 化 (opt-in / 安全 default)
+
+`approve` を compatibility gate にする。opt-in (= default off) なので既存運用は不変。
+
+### `require_compatibility` フラグ
+
+`release-wave-targets.yaml` の registry はまだ無いため、Phase C では **wave 開始時の
+per-repo フラグ**として持たせる (`release_wave_start` の `repos[].require_compatibility`、
+default false)。backend repo に対して立てる。
+
+```jsonc
+// release_wave_start の repos entry
+{ "repo": "ippoan/rust-alc-api", "target_tag": "v1.43.0", "head_sha": "...",
+  "require_compatibility": true }
+```
+
+### approve gate
+
+`release_wave_approve` (MCP) / admin UI の Approve ボタンは、`require_compatibility=true`
+な backend に**未 test frontend (= matrix の赤) が 1 つ以上**ある場合に
+`COMPATIBILITY_GATE` で reject される。
+
+- `force=true` (MCP) / admin UI の override ボタン (gate blocked 時のみ `force` 付き) で
+  人手 override 可。
+- gate は **赤がある時だけ** 発火する。consumer が 1 つも居ない backend
+  (matrix 空) は「検証対象なし」として通す (= 内部 API backend を誤って block しない)。
+- COMPAT_KV 未 bind / 算出失敗時は best-effort で gate を素通り (= approve を妨げない)。
+
+### frontend 単独 wave の gate (未実装 / 保留)
+
+issue #157 Phase C の「frontend 単独 wave も現 production backend image との整合を
+gate する」は、frontend → backend の依存マップ (consumed_by) が未整備のため**保留**。
+現状は tested_against の履歴から consumer を逆算しているが、frontend 単独 wave では
+「どの backend の現 image と照合すべきか」を一意に決められない。consumed_by を
+`release-wave-targets.yaml` registry として導入する際に対応する。
+
 ## 後続実装 issue
 
 本ドキュメントが approve された後、以下を別 issue / PR として進める:

--- a/src/mcp/tools/release-wave.ts
+++ b/src/mcp/tools/release-wave.ts
@@ -89,6 +89,12 @@ export function registerReleaseWaveTools(server: McpServer, env: Env): void {
                 .string()
                 .describe("Tag to be cut for this wave (e.g. 'v1.42.0')"),
               head_sha: z.string().describe("HEAD SHA at wave start"),
+              require_compatibility: z
+                .boolean()
+                .optional()
+                .describe(
+                  "When true (backend repos), approve is rejected while any consuming frontend is untested against this backend's current image. Default false. Refs #157 Phase C.",
+                ),
             }),
           )
           .min(1)
@@ -195,7 +201,7 @@ export function registerReleaseWaveTools(server: McpServer, env: Env): void {
     "release_wave_approve",
     {
       description:
-        "Admin approves a pending-approval wave to proceed to flipping. Required for manual-approval policy.",
+        "Admin approves a pending-approval wave to proceed to flipping. Required for manual-approval policy. Rejected with COMPATIBILITY_GATE if a require_compatibility backend has untested frontends — pass force=true to override.",
       inputSchema: {
         wave_id: z.string().min(1),
         approved_by: z
@@ -204,11 +210,21 @@ export function registerReleaseWaveTools(server: McpServer, env: Env): void {
           .describe(
             "Email or identifier of the admin approving (recorded in audit trail)",
           ),
+        force: z
+          .boolean()
+          .optional()
+          .describe(
+            "Override the compatibility gate (Refs #157 Phase C). Default false (gate enforced).",
+          ),
       },
       annotations: { readOnlyHint: false },
     },
-    async ({ wave_id, approved_by }) => {
-      const result = await hubStub(env).approve({ wave_id, approved_by });
+    async ({ wave_id, approved_by, force }) => {
+      const result = await hubStub(env).approve({
+        wave_id,
+        approved_by,
+        force: force === true,
+      });
       return formatRpcResult(result);
     },
   );

--- a/src/release-wave/api.ts
+++ b/src/release-wave/api.ts
@@ -58,9 +58,19 @@ export async function handleReleaseWaveApprove(
   if (req.method !== "POST") {
     return jsonResponse(405, { code: "METHOD_NOT_ALLOWED", error: "use POST" });
   }
+  // form body 内 `force=true` で compatibility gate を override する経路
+  // (Refs #157 Phase C)。UI 側は gate blocked 時のみ force 付きボタンを出す。
+  let force = false;
+  try {
+    const form = await req.formData();
+    force = String(form.get("force") ?? "") === "true";
+  } catch {
+    // form-data 以外は force なし
+  }
   const result = (await hubStub(env).approve({
     wave_id,
     approved_by: actorEmail(req),
+    force,
   })) as RpcResult<WaveState>;
   if (!result.ok) {
     return jsonResponse(rpcErrorToHttpStatus(result.code), {

--- a/src/release-wave/do.ts
+++ b/src/release-wave/do.ts
@@ -50,7 +50,12 @@ export interface StartInput {
   wave_id: string;
   flip_policy: FlipPolicy;
   note?: string;
-  repos: Array<{ repo: string; target_tag: string; head_sha: string }>;
+  repos: Array<{
+    repo: string;
+    target_tag: string;
+    head_sha: string;
+    require_compatibility?: boolean;
+  }>;
 }
 
 export interface StageReportInput {
@@ -65,6 +70,8 @@ export interface StageReportInput {
 export interface ApproveInput {
   wave_id: string;
   approved_by: string;
+  /** compatibility gate を override する (Refs #157 Phase C)。default false。 */
+  force?: boolean;
 }
 
 export interface FlipReportInput {
@@ -104,7 +111,8 @@ export type RpcErrorCode =
   | TransitionErrorCode
   | "NOT_FOUND"
   | "ALREADY_EXISTS"
-  | "WAVE_IN_PROGRESS";
+  | "WAVE_IN_PROGRESS"
+  | "COMPATIBILITY_GATE";
 
 export interface RpcError {
   code: RpcErrorCode;
@@ -193,11 +201,64 @@ export class ReleaseWaveHub extends DurableObject<Env> {
   }
 
   async approve(input: ApproveInput): Promise<RpcResult<WaveState>> {
+    // compatibility gate (Refs #157 Phase C): require_compatibility=true な
+    // backend に未 test frontend が居る場合、force でなければ approve を拒否。
+    if (input.force !== true) {
+      const wave = await this.loadWave(input.wave_id);
+      if (!wave) {
+        return { ok: false, code: "NOT_FOUND", error: `wave ${input.wave_id} not found` };
+      }
+      const blockers = await this.compatibilityGateBlockers(wave);
+      if (blockers.length > 0) {
+        return {
+          ok: false,
+          code: "COMPATIBILITY_GATE",
+          error: `compatibility gate blocked approve: ${blockers.join("; ")} (pass force=true to override)`,
+        };
+      }
+    }
     return this.applyEvent(input.wave_id, {
       kind: "approve",
       now: new Date().toISOString(),
       approved_by: input.approved_by,
     });
+  }
+
+  /**
+   * `require_compatibility=true` な backend のうち、未 test frontend を持つものの
+   * 説明文字列配列を返す (空 = gate 通過)。COMPAT_KV 未 bind / 算出失敗時は
+   * best-effort で空 (= gate を素通り) にする。
+   */
+  private async compatibilityGateBlockers(wave: WaveState): Promise<string[]> {
+    const required = wave.repos
+      .filter((r) => r.require_compatibility)
+      .map((r) => r.repo);
+    if (required.length === 0 || !this.env.COMPAT_KV) return [];
+
+    let compat;
+    try {
+      compat = await computeWaveCompatibility(
+        this.env.COMPAT_KV,
+        wave.repos.map((r) => r.repo),
+      );
+    } catch (e) {
+      console.warn(`[release-wave] compat gate eval failed: ${String(e)}`);
+      return [];
+    }
+
+    const blockers: string[] = [];
+    for (const b of compat.backends) {
+      if (!required.includes(b.backend_repo)) continue;
+      const reds = b.matrix
+        .filter((m) => !m.tested_against_target)
+        .map((m) => m.frontend);
+      if (reds.length > 0) {
+        blockers.push(
+          `${b.backend_repo}@${b.current_image ?? "?"}: untested frontend(s) ${reds.join(", ")}`,
+        );
+      }
+    }
+    return blockers;
   }
 
   async flipReport(input: FlipReportInput): Promise<RpcResult<WaveState>> {

--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -215,6 +215,21 @@ export async function handleReleaseWaveDetailPage(
   }
   const w = result.data;
 
+  // ---- Compatibility (matrix section + gate 判定で共有) ----
+  let compat: WaveCompatibility | null = null;
+  if (env.COMPAT_KV) {
+    try {
+      compat = await computeWaveCompatibility(
+        env.COMPAT_KV,
+        w.repos.map((r) => r.repo),
+      );
+    } catch {
+      compat = null;
+    }
+  }
+  const gateBlockers = computeGateBlockers(w, compat);
+  const gateBlocked = gateBlockers.length > 0;
+
   // ---- Actions (state-dependent) ----
   const canApprove = w.state === "pending-approval";
   const canRollback = w.state === "flipped";
@@ -228,12 +243,24 @@ export async function handleReleaseWaveDetailPage(
        </div>`
     : "";
 
+  // compatibility gate (Refs #157 Phase C): blocked 時は approve に force を
+  // 付けて override 可にし、警告を出す。
+  const gateNote = gateBlocked
+    ? `<div class="unsafe">
+         Compatibility gate <strong>blocks approve</strong>:
+         ${escapeHtml(gateBlockers.join("; "))}.
+         The button below passes <code>force=true</code> to override —
+         flipping with untested frontends is your call.
+       </div>`
+    : "";
+
   const actionsBlock = `
     <div class="actions">
       <form method="post" action="/api/release-wave/${encodeURIComponent(w.wave_id)}/approve">
+        ${gateBlocked ? `<input type="hidden" name="force" value="true">` : ""}
         <button type="submit" ${canApprove ? "" : "disabled"}
           title="Approve a pending-approval wave to proceed to flipping">
-          Approve &amp; Flip
+          Approve &amp; Flip${gateBlocked ? " (override compat gate)" : ""}
         </button>
       </form>
       <form method="post" action="/api/release-wave/${encodeURIComponent(w.wave_id)}/rollback">
@@ -250,6 +277,7 @@ export async function handleReleaseWaveDetailPage(
         </button>
       </form>
     </div>
+    ${gateNote}
     ${rollbackDisabledNote}
   `;
 
@@ -303,19 +331,10 @@ export async function handleReleaseWaveDetailPage(
     .join("");
 
   // ---- Compatibility matrix (Refs #157 Phase A) ----
-  // COMPAT_KV 未 bind / 算出失敗時は section を出さない。
-  let compatHtml = "";
-  if (env.COMPAT_KV) {
-    try {
-      const compat = await computeWaveCompatibility(
-        env.COMPAT_KV,
-        w.repos.map((r) => r.repo),
-      );
-      compatHtml = renderCompatibilitySection(compat, w.wave_id);
-    } catch {
-      compatHtml = "";
-    }
-  }
+  // 上で算出した compat を再利用。null (未 bind / 失敗) 時は section を出さない。
+  const compatHtml = compat
+    ? renderCompatibilitySection(compat, w.wave_id)
+    : "";
 
   const rollbackSafetyHtml = w.rollback.safe
     ? `<p class="ok">rollback.safe = <strong>true</strong> (no contract migration applied yet)</p>`
@@ -500,6 +519,33 @@ function renderCompatibilitySection(
       ${retestAllBlock}
       ${blocks}
     </div>`;
+}
+
+/**
+ * compatibility gate (Refs #157 Phase C) の blocker 説明配列を返す。
+ * `require_compatibility=true` な backend のうち未 test frontend を持つもの。
+ * compat が無い (COMPAT_KV 未 bind) 場合は gate を素通り ([])。
+ */
+function computeGateBlockers(
+  w: WaveState,
+  compat: WaveCompatibility | null,
+): string[] {
+  if (!compat) return [];
+  const required = w.repos
+    .filter((r) => r.require_compatibility)
+    .map((r) => r.repo);
+  if (required.length === 0) return [];
+  const blockers: string[] = [];
+  for (const b of compat.backends) {
+    if (!required.includes(b.backend_repo)) continue;
+    const reds = b.matrix
+      .filter((m) => !m.tested_against_target)
+      .map((m) => m.frontend);
+    if (reds.length > 0) {
+      blockers.push(`${b.backend_repo}: ${reds.join(", ")}`);
+    }
+  }
+  return blockers;
 }
 
 /** 長い識別子を省略表示 (full 値は <title> 等に別途載せる)。 */

--- a/src/release-wave/state.ts
+++ b/src/release-wave/state.ts
@@ -34,13 +34,19 @@ export function createWave(input: {
   wave_id: string;
   flip_policy: FlipPolicy;
   note: string;
-  repos: Array<{ repo: string; target_tag: string; head_sha: string }>;
+  repos: Array<{
+    repo: string;
+    target_tag: string;
+    head_sha: string;
+    require_compatibility?: boolean;
+  }>;
   now: string;
 }): WaveState {
   const repos: RepoState[] = input.repos.map((r) => ({
     repo: r.repo,
     target_tag: r.target_tag,
     head_sha: r.head_sha,
+    require_compatibility: r.require_compatibility ?? false,
     stage_status: "pending",
     preview_url: null,
     stage_error: null,

--- a/src/release-wave/types.ts
+++ b/src/release-wave/types.ts
@@ -49,6 +49,12 @@ export interface RepoState {
   readonly target_tag: string;
   /** 本 wave 開始時点の HEAD SHA。stage handler 起動先 commit。 */
   readonly head_sha: string;
+  /**
+   * compatibility gate 対象 backend か (Refs #157 Phase C)。true の場合、
+   * この repo (backend) に未 test の frontend が居る状態では `approve` が
+   * reject される (force override 可)。default false (= opt-in)。
+   */
+  readonly require_compatibility: boolean;
 
   /** stage handler 完了 callback の進捗。 */
   stage_status: RepoPhaseStatus;

--- a/test/mcp/release-wave.test.ts
+++ b/test/mcp/release-wave.test.ts
@@ -299,6 +299,7 @@ describe("release_wave_approve", () => {
     expect(spies.approve).toHaveBeenCalledWith({
       wave_id: "w1",
       approved_by: "ops@example.com",
+      force: false,
     });
   });
 });

--- a/test/release-wave/api.test.ts
+++ b/test/release-wave/api.test.ts
@@ -68,6 +68,7 @@ describe("handleReleaseWaveApprove", () => {
     expect(spies.approve).toHaveBeenCalledWith({
       wave_id: "w1",
       approved_by: "ops@example.com",
+      force: false,
     });
   });
 
@@ -78,7 +79,20 @@ describe("handleReleaseWaveApprove", () => {
     expect(spies.approve).toHaveBeenCalledWith({
       wave_id: "w1",
       approved_by: "operator",
+      force: false,
     });
+  });
+
+  it("passes force=true when form sets it (compat gate override)", async () => {
+    const { env, spies } = fakeEnv();
+    const req = postRequest("/api/release-wave/w1/approve", {
+      actorEmail: "ops@x",
+      formBody: { force: "true" },
+    });
+    await handleReleaseWaveApprove(req, env, "w1");
+    expect(spies.approve).toHaveBeenCalledWith(
+      expect.objectContaining({ force: true }),
+    );
   });
 
   it("returns 405 on non-POST", async () => {

--- a/test/release-wave/do.test.ts
+++ b/test/release-wave/do.test.ts
@@ -448,3 +448,101 @@ describe("ReleaseWaveHub.start compatibility precheck", () => {
     }
   });
 });
+
+// ----------------------------------------------------------------------------
+// compatibility gate on approve (Refs #157 Phase C)
+// ----------------------------------------------------------------------------
+
+describe("ReleaseWaveHub.approve compatibility gate", () => {
+  beforeEach(clearCompatKeys);
+  const now = () => new Date().toISOString();
+
+  async function stageToPendingApproval(
+    i: { start: Function; stageReport: Function },
+    wave_id: string,
+    require_compatibility: boolean,
+  ) {
+    await i.start({
+      wave_id,
+      flip_policy: "manual-approval",
+      repos: [
+        {
+          repo: "ippoan/rust-alc-api",
+          target_tag: "v2",
+          head_sha: "s",
+          require_compatibility,
+        },
+      ],
+    });
+    await i.stageReport({ wave_id, repo: "ippoan/rust-alc-api", ok: true });
+  }
+
+  async function seedRed() {
+    await recordBackendDeploy(env.COMPAT_KV, {
+      repo: "ippoan/rust-alc-api",
+      current_image: "cur-img",
+      deployed_by: "x",
+      now: now(),
+    });
+    await recordFrontendTest(env.COMPAT_KV, {
+      repo: "ippoan/alc-app",
+      prod_version: "v1",
+      tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "stale-img" },
+      now: now(),
+    });
+  }
+
+  it("rejects approve with COMPATIBILITY_GATE when a required backend has reds", async () => {
+    await seedRed();
+    const hub = freshHub();
+    const res = await runInDurableObject(hub, async (i) => {
+      await stageToPendingApproval(i as never, "w-gate-red", true);
+      return i.approve({ wave_id: "w-gate-red", approved_by: "ops" });
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.code).toBe("COMPATIBILITY_GATE");
+  });
+
+  it("force=true overrides the gate and approves", async () => {
+    await seedRed();
+    const hub = freshHub();
+    const res = await runInDurableObject(hub, async (i) => {
+      await stageToPendingApproval(i as never, "w-gate-force", true);
+      return i.approve({ wave_id: "w-gate-force", approved_by: "ops", force: true });
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.data.state).toBe("flipping");
+  });
+
+  it("does not gate when require_compatibility is false (default)", async () => {
+    await seedRed();
+    const hub = freshHub();
+    const res = await runInDurableObject(hub, async (i) => {
+      await stageToPendingApproval(i as never, "w-gate-off", false);
+      return i.approve({ wave_id: "w-gate-off", approved_by: "ops" });
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.data.state).toBe("flipping");
+  });
+
+  it("does not gate a required backend that is all-green", async () => {
+    await recordBackendDeploy(env.COMPAT_KV, {
+      repo: "ippoan/rust-alc-api",
+      current_image: "cur-img",
+      deployed_by: "x",
+      now: now(),
+    });
+    await recordFrontendTest(env.COMPAT_KV, {
+      repo: "ippoan/alc-app",
+      prod_version: "v1",
+      tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "cur-img" },
+      now: now(),
+    });
+    const hub = freshHub();
+    const res = await runInDurableObject(hub, async (i) => {
+      await stageToPendingApproval(i as never, "w-gate-green", true);
+      return i.approve({ wave_id: "w-gate-green", approved_by: "ops" });
+    });
+    expect(res.ok).toBe(true);
+  });
+});

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -71,6 +71,7 @@ function makeWave(over: Partial<WaveState> = {}): WaveState {
         repo: "ippoan/rust-alc-api",
         target_tag: "v1.1.0",
         head_sha: "abc",
+        require_compatibility: false,
         stage_status: "pending",
         preview_url: null,
         stage_error: null,
@@ -631,6 +632,58 @@ describe("handleReleaseWaveDetailPage compatibility section", () => {
     expect(html).toContain("stale-img");
     // 凡例
     expect(html).toContain("untested (red)");
+  });
+
+  it("shows compat gate override on approve button when a required backend has reds", async () => {
+    const wave = makeWave({
+      state: "pending-approval",
+      repos: [
+        {
+          repo: "ippoan/rust-alc-api",
+          target_tag: "v2",
+          head_sha: "s",
+          require_compatibility: true,
+          stage_status: "done",
+          preview_url: null,
+          stage_error: null,
+          flip_status: "pending",
+          flip_error: null,
+          flip_from_revision: null,
+          rolled_back_to_revision: null,
+        },
+      ],
+    });
+    const env = fakeEnv({
+      getReturn: { ok: true, data: wave },
+      compatKv: memKv({
+        "backend::ippoan/rust-alc-api": {
+          schema_version: 1,
+          repo: "ippoan/rust-alc-api",
+          current_image: "cur-img",
+          deployed_at: "2026-05-27T00:00:00Z",
+          deployed_by: "x",
+          wave_id: null,
+        },
+        "frontend::ippoan/alc-app": {
+          schema_version: 1,
+          repo: "ippoan/alc-app",
+          prod_version: "v1",
+          prod_deployed_at: "2026-05-27T00:00:00Z",
+          tested_against: [
+            {
+              backend_repo: "ippoan/rust-alc-api",
+              backend_image: "stale-img",
+              tested_at: "2026-05-20T00:00:00Z",
+            },
+          ],
+        },
+      }),
+    });
+    const resp = await handleReleaseWaveDetailPage(env, "w1");
+    const html = await resp.text();
+    expect(html).toContain("override compat gate");
+    expect(html).toContain("Compatibility gate");
+    expect(html).toContain('name="force" value="true"');
   });
 
   it("omits the SVG when there are no edges (backend record but no consumers)", async () => {


### PR DESCRIPTION
## 概要

#157 Phase C。compatibility を実際の **approve gate** にする。opt-in (default off)
なので既存 wave 運用は不変。

## 変更点

- **`require_compatibility` フラグ** (per-repo, default false)
  - `RepoState` / `release_wave_start` の `repos[].require_compatibility` に追加
  - `release-wave-targets.yaml` registry は未整備のため wave 開始時の per-repo
    フラグとして持たせる (self-contained)
- **approve gate** (`do.ts` `approve()`)
  - `require_compatibility=true` な backend に未 test frontend (matrix の赤) が
    あれば `COMPATIBILITY_GATE` で reject
  - `force=true` で override 可
  - 赤がある時だけ発火 (consumer ゼロの backend は通す)。COMPAT_KV 未 bind /
    算出失敗時は素通り (best-effort)
- **`release_wave_approve` MCP tool**: `force` input 追加
- **admin UI** (`page.ts`): gate blocked 時のみ Approve ボタンに `force=true` を付け、
  override ラベル + 警告ボックス (untested frontend 一覧) を表示。既存 rollback の
  unsafe-force UX と同パターン

## 設計判断 / 保留

- **config location**: `release-wave-targets.yaml` registry は未存在のため per-repo
  フラグで実装。registry 導入時に移行可能。
- **frontend 単独 wave の gate は保留**: frontend→backend の依存マップ (consumed_by)
  が無く「どの backend の現 image と照合するか」を一意に決められないため。registry
  導入時に対応 (docs に明記)。
- **gate 条件**: 「verified==false」ではなく「赤 (未 test consumer) が存在」で判定。
  consumer ゼロ (= 検証対象なし) で誤 block しないため。

## テスト

- `do.test.ts`: gate reject / force override / require=false で素通り / all-green で通す (4)
- `api.test.ts` / `mcp`: approve に force が伝播 (期待値更新 + 新規)
- `page.test.ts`: gate blocked 時に override ボタン + 警告 + hidden force が出る
- ローカルで全 516 件パス + `tsc --noEmit` 通過

## Phase 残り

これで Phase A/B/C 完了。残るは Phase D (preventive auto-retest, backend staging deploy
hook + nightly cron) と frontend consumer 側 (各 repo の `test.yml`)。

Refs #157
Refs #137


---
_Generated by [Claude Code](https://claude.ai/code/session_01RaEpH3beN6Zed6PqNEieuH)_