### PR TITLE
feat(release-wave): authed backend-current-image read under /webhooks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
   handleFlipReportWebhook,
   handleFrontendTestReportWebhook,
   handleBackendDeployReportWebhook,
+  handleBackendCurrentImageWebhook,
 } from "./release-wave/webhook";
 import {
   handleCompatibility,
@@ -218,6 +219,12 @@ app.post("/webhooks/release-wave/frontend-test-report", (c) =>
 );
 app.post("/webhooks/release-wave/backend-deploy-report", (c) =>
   handleBackendDeployReportWebhook(c.req.raw, c.env),
+);
+// 認証付き read (CF Access が bypass する /webhooks/* 配下)。frontend CI が
+// 現 prod backend image を解決する用 — CF Access 下の /backend-current-image は
+// GitHub Actions runner から 302 で到達不能なため。Refs #157。
+app.get("/webhooks/release-wave/backend-current-image", (c) =>
+  handleBackendCurrentImageWebhook(c.req.raw, c.env),
 );
 
 // Compatibility read endpoints (CF Access edge gate に認証を委譲、read-only)。

--- a/src/release-wave/webhook.ts
+++ b/src/release-wave/webhook.ts
@@ -22,7 +22,7 @@ import { z } from "zod";
 import type { Env } from "../index";
 import type { ReleaseWaveHub, RpcResult } from "./do";
 import type { WaveState } from "./types";
-import { recordFrontendTest, recordBackendDeploy } from "./compat";
+import { recordFrontendTest, recordBackendDeploy, getBackendCurrent } from "./compat";
 
 // ----------------------------------------------------------------------------
 // Common helpers
@@ -319,4 +319,62 @@ export async function handleBackendDeployReportWebhook(
     now: new Date().toISOString(),
   });
   return jsonResponse(200, { ok: true, record });
+}
+
+// ----------------------------------------------------------------------------
+// GET /webhooks/release-wave/backend-current-image  (compatibility, Refs #157)
+// ----------------------------------------------------------------------------
+
+/**
+ * frontend CI が「現 production backend image」を解決する用の read endpoint。
+ *
+ * compat-api.ts の `GET /backend-current-image` と機能等価だが、そちらは
+ * ci-dashboard host 全体に被さる Cloudflare Access edge gate の背後にあり
+ * GitHub Actions runner からは 302 で到達できない。本 endpoint は CF Access が
+ * bypass している `/webhooks/*` prefix 配下に置き、代わりに shared secret
+ * (`X-Release-Wave-Webhook-Secret`) で認証する。
+ */
+export async function handleBackendCurrentImageWebhook(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  if (request.method !== "GET") {
+    return jsonResponse(405, { code: "METHOD_NOT_ALLOWED", error: "use GET" });
+  }
+  const provided = request.headers.get("X-Release-Wave-Webhook-Secret") ?? "";
+  const expected = await env.RELEASE_WAVE_WEBHOOK_SECRET.get();
+  if (!expected) {
+    return jsonResponse(500, {
+      code: "SECRET_NOT_CONFIGURED",
+      error: "RELEASE_WAVE_WEBHOOK_SECRET is not bound",
+    });
+  }
+  if (!constantTimeEqual(provided, expected)) {
+    return jsonResponse(401, {
+      code: "UNAUTHORIZED",
+      error: "invalid webhook secret",
+    });
+  }
+
+  const url = new URL(request.url);
+  const repo = url.searchParams.get("repo")?.trim();
+  if (!repo) {
+    return jsonResponse(400, {
+      code: "BAD_REQUEST",
+      error: "repo query param is required",
+    });
+  }
+
+  const record = await getBackendCurrent(env.COMPAT_KV, repo);
+  if (!record) {
+    return jsonResponse(404, {
+      code: "NOT_FOUND",
+      error: `no backend deploy record for ${repo}`,
+    });
+  }
+  return jsonResponse(200, {
+    repo: record.repo,
+    current_image: record.current_image,
+    deployed_at: record.deployed_at,
+  });
 }

--- a/test/release-wave/compat-http.test.ts
+++ b/test/release-wave/compat-http.test.ts
@@ -3,6 +3,7 @@ import { env as testEnv } from "cloudflare:test";
 import {
   handleFrontendTestReportWebhook,
   handleBackendDeployReportWebhook,
+  handleBackendCurrentImageWebhook,
 } from "../../src/release-wave/webhook";
 import {
   handleCompatibility,
@@ -215,5 +216,74 @@ describe("handleBackendCurrentImage (GET /backend-current-image)", () => {
     expect(resp.status).toBe(200);
     const body = (await resp.json()) as { current_image: string };
     expect(body.current_image).toBe("img-9");
+  });
+});
+
+describe("handleBackendCurrentImageWebhook (authed GET under /webhooks)", () => {
+  const BCI_URL =
+    "https://ci-dashboard.ippoan.org/webhooks/release-wave/backend-current-image?repo=ippoan/rust-alc-api";
+
+  function getReq(url: string, secret: string | null = SECRET): Request {
+    const headers: Record<string, string> = {};
+    if (secret !== null) headers["X-Release-Wave-Webhook-Secret"] = secret;
+    return new Request(url, { method: "GET", headers });
+  }
+
+  it("rejects non-GET with 405", async () => {
+    const resp = await handleBackendCurrentImageWebhook(
+      new Request(BCI_URL, {
+        method: "POST",
+        headers: { "X-Release-Wave-Webhook-Secret": SECRET },
+      }),
+      compatEnv(),
+    );
+    expect(resp.status).toBe(405);
+  });
+
+  it("500 when secret not configured", async () => {
+    const resp = await handleBackendCurrentImageWebhook(
+      getReq(BCI_URL),
+      compatEnv(null),
+    );
+    expect(resp.status).toBe(500);
+  });
+
+  it("rejects wrong secret with 401", async () => {
+    const resp = await handleBackendCurrentImageWebhook(
+      getReq(BCI_URL, "wrong"),
+      compatEnv(),
+    );
+    expect(resp.status).toBe(401);
+  });
+
+  it("400 when repo missing", async () => {
+    const resp = await handleBackendCurrentImageWebhook(
+      getReq("https://ci-dashboard.ippoan.org/webhooks/release-wave/backend-current-image"),
+      compatEnv(),
+    );
+    expect(resp.status).toBe(400);
+  });
+
+  it("404 when no record", async () => {
+    const resp = await handleBackendCurrentImageWebhook(
+      getReq("https://ci-dashboard.ippoan.org/webhooks/release-wave/backend-current-image?repo=ippoan/nope"),
+      compatEnv(),
+    );
+    expect(resp.status).toBe(404);
+  });
+
+  it("returns current image when present", async () => {
+    await handleBackendDeployReportWebhook(
+      postReq(BD_URL, {
+        repo: "ippoan/rust-alc-api",
+        current_image: "img-authed",
+        deployed_by: "x",
+      }),
+      compatEnv(),
+    );
+    const resp = await handleBackendCurrentImageWebhook(getReq(BCI_URL), compatEnv());
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as { current_image: string };
+    expect(body.current_image).toBe("img-authed");
   });
 });


### PR DESCRIPTION
## 背景

`#157` の compat 配線を nuxt-notify で end-to-end 検証したところ (`ippoan/nuxt-notify#75`)、frontend CI の `report-frontend-compat` action が現 prod backend image を解決するために叩く `GET /backend-current-image` が **CF Access で 302 遮断**され、GitHub Actions runner から到達できないことが判明した。

```
GET /backend-current-image for ippoan/rust-alc-api returned 302; skipping compatibility report
```

ci-dashboard host 全体が Cloudflare Access edge gate の背後にあり、`/webhooks/*` prefix だけが bypass されている (= webhook POST は shared secret で通るが read endpoint は通らない)。docs では `/backend-current-image` を「認証なし read-only」想定としていたが、実デプロイの CF Access 構成と噛み合っていなかった。

## 変更

CF Access が bypass している `/webhooks/*` 配下に、shared secret 認証付きの read endpoint を新設する:

```
GET /webhooks/release-wave/backend-current-image?repo=<owner/name>
    X-Release-Wave-Webhook-Secret: <secret>
```

- `handleBackendCurrentImageWebhook` (webhook.ts): method=GET チェック + `X-Release-Wave-Webhook-Secret` の constant-time 比較 + `getBackendCurrent` で既存 `/backend-current-image` と同一 body を返す
- index.ts に route 登録 + import
- 既存の `/backend-current-image` (CF Access、admin/browser 用) は**そのまま残す**
- test: 405 / 500(secret未設定) / 401(wrong secret) / 400(repo欠落) / 404(record無) / 200 を追加

frontend CI 側 (`report-frontend-compat` action) をこの新 path に向ける変更は ci-workflows 側の別 PR で行う。ci-dashboard 未デプロイの間も新 path は 404 → action は no-op になり安全。

## セキュリティ

read endpoint だが public にはせず、write webhook と同じ shared secret で認証する。値は header のみで body を取らない。

Refs #157

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPNy9CVxrt1JgUZzDgAwYN)_