### PR TITLE
feat(release-wave): show wave-independent compatibility graph on list page

### DIFF
--- a/src/release-wave/compat.ts
+++ b/src/release-wave/compat.ts
@@ -328,6 +328,34 @@ export async function computeWaveCompatibility(
   return { verified, checked, backends };
 }
 
+/**
+ * 全 `backend::*` repo を list する (wave 非依存)。
+ */
+async function listBackendRepos(kv: KVNamespace): Promise<string[]> {
+  const out: string[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await kv.list({ prefix: BACKEND_PREFIX, cursor });
+    for (const key of page.keys) {
+      out.push(key.name.slice(BACKEND_PREFIX.length));
+    }
+    cursor = page.list_complete ? undefined : page.cursor;
+  } while (cursor);
+  return out;
+}
+
+/**
+ * 全 `backend::` record に対する compatibility を構築する wave 非依存の
+ * グローバルビュー。Release Wave 一覧ページの俯瞰グラフ用。
+ * backend record が 1 つも無ければ空の WaveCompatibility を返す。
+ */
+export async function computeGlobalCompatibility(
+  kv: KVNamespace,
+): Promise<WaveCompatibility> {
+  const repos = await listBackendRepos(kv);
+  return computeWaveCompatibility(kv, repos);
+}
+
 /** `frontend::*` を全件 list して parse する。schema 不一致は除外。 */
 async function listFrontendRecords(
   kv: KVNamespace,

--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -16,7 +16,11 @@ import type { Env } from "../index";
 import type { ReleaseWaveHub, RpcResult } from "./do";
 import type { WaveState, WaveStateName } from "./types";
 import { renderTabs, TAB_STYLES } from "../nav-tabs";
-import { computeWaveCompatibility, type WaveCompatibility } from "./compat";
+import {
+  computeWaveCompatibility,
+  computeGlobalCompatibility,
+  type WaveCompatibility,
+} from "./compat";
 
 // ----------------------------------------------------------------------------
 // Small HTML helpers
@@ -148,6 +152,19 @@ function hubStub(env: Env): DurableObjectStub<ReleaseWaveHub> {
 export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
   const waves = (await hubStub(env).list()) as WaveState[];
 
+  // 全 backend:: record に対する wave 非依存の compatibility 俯瞰グラフ。
+  // 個別 wave に入っていない既 deploy frontend (consumer) も含めて、現
+  // production backend image を test 済みか一目で見える (Refs #157)。
+  let globalCompat: WaveCompatibility | null = null;
+  if (env.COMPAT_KV) {
+    try {
+      globalCompat = await computeGlobalCompatibility(env.COMPAT_KV);
+    } catch {
+      globalCompat = null;
+    }
+  }
+  const compatSection = renderGlobalCompatibilitySection(globalCompat);
+
   const rows = waves.length === 0
     ? `<tr><td colspan="5" class="empty">No release waves yet.</td></tr>`
     : waves
@@ -179,6 +196,7 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
       Cross-repo coordinated release flows. Refs
       <a href="https://github.com/ippoan/ci-dashboard/issues/137">#137</a>.
     </p>
+    ${compatSection}
     <table>
       <thead>
         <tr>
@@ -415,6 +433,46 @@ export async function handleReleaseWaveDetailPage(
 // ----------------------------------------------------------------------------
 // Compatibility matrix section (Refs #157 Phase A)
 // ----------------------------------------------------------------------------
+
+/**
+ * Release Wave 一覧ページ用の wave 非依存 compatibility 俯瞰セクション。
+ * 全 `backend::` record とその consumer frontend の突合グラフ (SVG) を出す。
+ * backend record が無ければ案内文のみ。
+ */
+function renderGlobalCompatibilitySection(
+  compat: WaveCompatibility | null,
+): string {
+  if (!compat || compat.backends.length === 0) {
+    return `
+    <div class="section">
+      <h2>Compatibility (all consumers)</h2>
+      <p class="meta">No backend deploy records yet. backend deploy が
+        <code>backend-deploy-report</code> を打ち、consumer frontend が
+        integration test green で <code>frontend-test-report</code> を打つと、
+        ここに wave 横断の俯瞰グラフが出る。
+        Refs <a href="https://github.com/ippoan/ci-dashboard/issues/157">#157</a>.</p>
+    </div>`;
+  }
+  const verdict = !compat.checked
+    ? `<span class="meta">no consuming frontends recorded</span>`
+    : compat.verified
+    ? `<span class="ok"><strong>all consumers tested</strong></span>`
+    : `<span class="err"><strong>some consumers untested</strong></span>`;
+  const svg = renderCompatibilitySvg(compat);
+  const body = svg
+    ? svg
+    : `<p class="meta">backend record はあるが、まだどの frontend も test 履歴を
+        report していない (consumer edge 無し)。</p>`;
+  return `
+    <div class="section">
+      <h2>Compatibility (all consumers) — ${verdict}</h2>
+      <p class="meta">全 backend の<strong>現 production image</strong>を既 deploy
+        frontend が integration test 済みか (wave 横断)。緑 = tested / 赤 = untested。
+        個別 wave の retest 操作は各 wave 詳細ページで。
+        Refs <a href="https://github.com/ippoan/ci-dashboard/issues/157">#157</a>.</p>
+      ${body}
+    </div>`;
+}
 
 /**
  * wave 内 backend の現 image に対する既 deploy frontend の突合 matrix を描画する。

--- a/test/release-wave/compat.test.ts
+++ b/test/release-wave/compat.test.ts
@@ -6,6 +6,7 @@ import {
   getBackendCurrent,
   computeCompatibility,
   computeWaveCompatibility,
+  computeGlobalCompatibility,
   TESTED_AGAINST_MAX,
   WINDOW_DAYS,
   SCHEMA_VERSION,
@@ -411,5 +412,62 @@ describe("computeWaveCompatibility", () => {
     expect(res.backends[0]!.matrix).toHaveLength(0);
     expect(res.checked).toBe(false);
     expect(res.verified).toBe(true);
+  });
+});
+
+describe("computeGlobalCompatibility", () => {
+  it("returns empty (no backends) when no backend records exist", async () => {
+    await recordFrontendTest(kv(), {
+      repo: "ippoan/nuxt-notify",
+      prod_version: "v1",
+      tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "img" },
+      now: daysAgo(1),
+    });
+    const res = await computeGlobalCompatibility(kv());
+    expect(res.backends).toHaveLength(0);
+    expect(res.checked).toBe(false);
+  });
+
+  it("aggregates all backend:: records and their consumers", async () => {
+    await recordBackendDeploy(kv(), {
+      repo: "ippoan/rust-alc-api",
+      current_image: "cur-rust",
+      deployed_by: "x",
+      now: daysAgo(1),
+    });
+    await recordBackendDeploy(kv(), {
+      repo: "ippoan/auth-worker",
+      current_image: "cur-auth",
+      deployed_by: "x",
+      now: daysAgo(1),
+    });
+    // nuxt-notify は rust-alc-api を現 image で test 済 (green)。
+    await recordFrontendTest(kv(), {
+      repo: "ippoan/nuxt-notify",
+      prod_version: "v1",
+      tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "cur-rust" },
+      now: daysAgo(1),
+    });
+    // alc-app は rust-alc-api を旧 image でしか test していない (red)。
+    await recordFrontendTest(kv(), {
+      repo: "ippoan/alc-app",
+      prod_version: "v2",
+      tested: { backend_repo: "ippoan/rust-alc-api", backend_image: "old-rust" },
+      now: daysAgo(2),
+    });
+
+    const res = await computeGlobalCompatibility(kv());
+    const repos = res.backends.map((b) => b.backend_repo).sort();
+    expect(repos).toEqual(["ippoan/auth-worker", "ippoan/rust-alc-api"]);
+
+    const rust = res.backends.find((b) => b.backend_repo === "ippoan/rust-alc-api")!;
+    const notify = rust.matrix.find((m) => m.frontend === "ippoan/nuxt-notify")!;
+    const alc = rust.matrix.find((m) => m.frontend === "ippoan/alc-app")!;
+    expect(notify.tested_against_target).toBe(true);
+    expect(alc.tested_against_target).toBe(false);
+
+    // 1 つでも赤があれば verified=false、consumer がいるので checked=true。
+    expect(res.checked).toBe(true);
+    expect(res.verified).toBe(false);
   });
 });


### PR DESCRIPTION
## 概要

`/release-wave` 一覧ページに、**wave 非依存の compatibility 俯瞰グラフ (SVG)** を追加する。これまで compat の matrix / SVG は wave 詳細ページ (`/release-wave/:wave_id`) にしか無く、個別 wave に含まれない既 deploy frontend (consumer) が一覧から見えなかった。

## 変更

- `compat.ts`: `computeGlobalCompatibility(kv)` を追加。全 `backend::*` repo を列挙し既存の `computeWaveCompatibility` に委譲する (= 全 backend の現 prod image に対する consumer frontend の突合)。補助 `listBackendRepos` も追加。
- `page.ts`: `renderGlobalCompatibilitySection` を追加し、一覧ページの見出し直下に描画。既存の SVG renderer (`renderCompatibilitySvg`) を再利用。backend record が無い / consumer edge が無い時は案内文を出す。
- test: `computeGlobalCompatibility` の集約ケース (green/red 混在) と空ケースを追加。

## 表示について (重要)

このグラフに consumer (例: **nuxt-notify ↔ rust-alc-api**) が出るには **データが流れている**必要がある:

1. backend が `backend-deploy-report` を打って `backend::ippoan/rust-alc-api` record が存在する
2. consumer frontend が integration test green で `frontend-test-report` を打って `frontend::*` record が存在する

現時点では rust-alc-api の backend record が未作成 (single deploy report 未配線) で、nuxt-notify の report も CF Access 302 修正 (#165) 前の実行だったため、まだ空グラフ (案内文) が出る。データが入り次第、自動で edge が描画される。

Refs #157

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPNy9CVxrt1JgUZzDgAwYN)_