### PR TITLE
feat(releases): add ippoan/claude-md to TAGLESS_REPOS (closeable from /releases)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,7 +13,7 @@
     // mini-release: it scans the merged PR for `Refs #N` and surfaces any still-
     // open issues on the dashboard banner + /releases synthetic blocks. Repos
     // not listed here keep the original tag-driven flow.
-    "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker"
+    "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md"
   },
   "kv_namespaces": [
     {
@@ -122,7 +122,7 @@
         }
       ],
       "vars": {
-        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker"
+        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md"
       },
       "kv_namespaces": [
         {


### PR DESCRIPTION
## 概要

`ci-dashboard.ippoan.org/releases` から **claude-md の issue を close できるようにする**。

claude-md は version tag を切らない (template repo。`stamp-install-sh-version.yml` が main 直 push する都合で tag 運用しない) ため、これまで `/releases` に出ず、release 時の目視 close UI から issue を close できなかった。

## 変更

`wrangler.jsonc` の `TAGLESS_REPOS` (top-level + env.staging の両方) に `ippoan/claude-md` を追加。

`TAGLESS_REPOS` に入った repo は、default branch の直近 commit から `Refs #N` を逆引きした **synthetic block** が `/releases` に描画され、close 候補一覧 + close ボタン (`POST /api/release-close{,-batch}`) が出る (`releases-page.ts` の watched-repo source (c))。close endpoint (`release-close.ts` / `release-close-batch.ts`) は org 検証のみで repo allowlist gate は無いため、`ippoan/claude-md` (validateOrg 通過) はそのまま close できる。コード変更は不要。

`ci-dashboard.ippoan.org` は staging env (`ci-dashboard-staging`) が提供しているため env.staging 側が実効。top-level も将来の production 用に揃えて更新。

## 検証

- config 変更のみ。`tagless-repos.ts::parseTaglessRepos` は任意の comma list を扱う pure parser で、テストは env を inline 構築する (wrangler.jsonc を読まない) ため既存テストへの影響なし。
- ローカルに node_modules が無く vitest 未実行 (CI で test.yml が走る)。

Refs ippoan/claude-md

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUQfm4bx7KwuBtB82MoZJM)_