### PR TITLE
feat(releases): add ippoan/mcp-relay-rs to TAGLESS_REPOS (closeable from /releases)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,7 +13,7 @@
     // mini-release: it scans the merged PR for `Refs #N` and surfaces any still-
     // open issues on the dashboard banner + /releases synthetic blocks. Repos
     // not listed here keep the original tag-driven flow.
-    "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md"
+    "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs"
   },
   "kv_namespaces": [
     {
@@ -122,7 +122,7 @@
         }
       ],
       "vars": {
-        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md"
+        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs"
       },
       "kv_namespaces": [
         {


### PR DESCRIPTION
## 概要

`ippoan/mcp-relay-rs` を `TAGLESS_REPOS` に追加し、`/releases` から issue を close できるようにする。

## 背景（調査）

- mcp-relay-rs の tag は **`dev-N` のみで stable `v*` が未発行**。`dev-*` は semver 非該当 (`release-helpers.ts::SEMVER_RE`) のため releases ページの tag-driven flow では拾われない。
- かつ `TAGLESS_REPOS` にも居なかったため、merged-PR が `Refs #N` で参照する issue を `/releases` の close UI から close できなかった。
- mcp-relay-rs は `release.yml`（`v*` / `<bin>-v*`）を持つ tag 運用設計だが、**ci-dashboard / secrets-inventory も tag 運用なのに TAGLESS_REPOS に入っている**（tag release ブロック + 「Unreleased」synthetic block の両方を出し、stable tag 発行前でも早期 close できる運用）。同じ扱いに揃える。

## 変更

`wrangler.jsonc` の `TAGLESS_REPOS` に `ippoan/mcp-relay-rs` を追加（top-level + env.staging 両方）。

`ci-dashboard.ippoan.org` の実稼働は **env.staging (`ci-dashboard-staging`)** が bind しているため line 125 が実効。top-level (line 16) は `wrangler dev` / 予約 production 用だが同期して更新。

## 備考

- `ippoan/ci-dashboard` は既に `TAGLESS_REPOS` に在籍済み（追加不要）。
- 純 config 変更。`parseTaglessRepos` は任意 comma list を扱う pure parser で、テストは env を inline 構築するため既存テストへの影響なし。

Refs ippoan/mcp-relay-rs

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUQfm4bx7KwuBtB82MoZJM)_