### PR TITLE
refactor(wrangler): consolidate operational vars into env.staging (drop dead top-level TAGLESS)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,14 +7,12 @@
   "observability": {
     "enabled": true
   },
-  "vars": {
-    // Comma-separated `owner/name` repos that do NOT cut release tags. For these
-    // repos the dashboard treats each PR merge into the default branch as a
-    // mini-release: it scans the merged PR for `Refs #N` and surfaces any still-
-    // open issues on the dashboard banner + /releases synthetic blocks. Repos
-    // not listed here keep the original tag-driven flow.
-    "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs"
-  },
+  // 運用 vars (TAGLESS_REPOS 等) は env.staging に一本化した。staging が
+  // `ci-dashboard.ippoan.org` を bind する実稼働 env (= staging=prod) で、
+  // top-level は `wrangler dev` / 予約 production 用。Wrangler は named env に
+  // top-level `vars` を継承しないため、ここに TAGLESS を重複定義しても staging
+  // には効かず、二重メンテの footgun になっていた。ローカル dev で TAGLESS の
+  // 挙動を見たい時は `wrangler dev --env staging` を使う。
   "kv_namespaces": [
     {
       "binding": "CI_STATUS",
@@ -122,6 +120,10 @@
         }
       ],
       "vars": {
+        // 運用 vars の単一 SoT。Comma-separated `owner/name` repos that do NOT
+        // cut release tags: dashboard はこれらの PR merge を mini-release 扱いし、
+        // merged PR の `Refs #N` を逆引きして /releases synthetic block + banner に
+        // 出す (= stable tag 前でも早期 close 可能)。未掲載 repo は tag-driven flow。
         "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs"
       },
       "kv_namespaces": [


### PR DESCRIPTION
## 概要

`wrangler.jsonc` の運用 vars (`TAGLESS_REPOS`) を **env.staging に一本化**し、top-level の重複定義（実質 dead）を削除する。

## 背景

ci-dashboard は **env.staging (`ci-dashboard-staging`)** が `ci-dashboard.ippoan.org` を bind する実稼働 env（= staging=prod）。top-level (`ci-dashboard`) は `wrangler dev` / 予約 production 用。

Wrangler は named environment に top-level `vars` を**継承しない**ため、top-level の `TAGLESS_REPOS` は実稼働 staging に元々効いておらず、env.staging 側と二重にメンテする footgun になっていた（claude-md / mcp-relay-rs 追加時に両方を編集する必要があった）。

## 変更

- top-level の `vars` ブロックを削除し、理由を comment 化（ローカルで TAGLESS 挙動を見たい時は `wrangler dev --env staging`）。
- env.staging の `vars` を運用 vars の単一 SoT として comment 整理。
- **機能変更なし**: 実稼働は env.staging のままで挙動不変。

## 検証

- comment 除去 + trailing-comma 正規化で `JSON.parse` が通ることを確認（JSONC 構造 valid）。
- wrangler.jsonc を読むコード/テストは無く（`src`/`test` は env を inline 構築）、deploy は `wrangler deploy --env staging`（README:103）なので production 無影響。

Refs ippoan/ci-dashboard

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUQfm4bx7KwuBtB82MoZJM)_