### PR TITLE
feat(release-wave): show backend node + current image SHA when no consumer edges

### DIFF
--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -666,7 +666,9 @@ function renderCompatibilitySvg(compat: WaveCompatibility): string {
     }
   }
 
-  if (edges.length === 0) return ""; // edge が無ければグラフは出さない
+  // backend も frontend も無ければ描かない。backend record だけある (consumer
+  // edge 0) 場合は backend ノードだけ描画して現 image (SHA) を見せる。
+  if (backendOrder.length === 0 && frontendOrder.length === 0) return "";
 
   // ---- layout ----
   const boxW = 250;

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -686,7 +686,7 @@ describe("handleReleaseWaveDetailPage compatibility section", () => {
     expect(html).toContain('name="force" value="true"');
   });
 
-  it("omits the SVG when there are no edges (backend record but no consumers)", async () => {
+  it("renders the backend node (with current image) even when there are no consumer edges", async () => {
     const env = fakeEnv({
       getReturn: { ok: true, data: makeWave() },
       compatKv: memKv({
@@ -703,6 +703,9 @@ describe("handleReleaseWaveDetailPage compatibility section", () => {
     const resp = await handleReleaseWaveDetailPage(env, "w1");
     const html = await resp.text();
     expect(html).toContain("Compatibility (frontend");
-    expect(html).not.toContain("<svg");
+    // backend record があれば consumer edge が 0 でも backend ノードを描画し、
+    // 現 image (SHA) を見せる。
+    expect(html).toContain("<svg");
+    expect(html).toContain("cur-img");
   });
 });


### PR DESCRIPTION
## 背景

`/release-wave` の「Compatibility (all consumers)」で、**backend record はあるが consumer frontend が未 report** の状態だと、グラフではなく「backend record はあるが、まだどの frontend も test 履歴を report していない (consumer edge 無し)」というテキストだけが出ていた。これだと「どの backend image (SHA) が現在 deploy されているか」が一目で分からない。

原因: `renderCompatibilitySvg` が `edges.length === 0` で早期 return していた。

## 変更

`src/release-wave/page.ts`:
- 早期 return 条件を `backendOrder.length === 0 && frontendOrder.length === 0` に変更（= 本当に何も無い時だけ空）。
- backend record があれば **backend ノードを必ず描画**。ノードは `@ <current_image>` で現 image (SHA) を表示、hover で full SHA。consumer edge は frontend が `frontend-test-report` を打つと後から生える。

`test/release-wave/page.test.ts`:
- 「no edges なら SVG を出さない」テストを「backend ノード + 現 image (SHA) を描画する」に更新。

## 効果

backend deploy 直後（まだ frontend が再 test していない段階）でも、`/release-wave` で rust-alc-api ノードと現 image SHA が見えるようになる。frontend が report すれば緑/赤 edge が後から追加される。

Refs #157

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPNy9CVxrt1JgUZzDgAwYN)_