### PR TITLE
feat(release-wave): show short SHA on both nodes to verify the match visually

### DIFF
--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -635,6 +635,14 @@ function renderCompatibilitySvg(compat: WaveCompatibility): string {
   const frontendVersion = new Map<string, string | null>();
   // frontend が 1 つでも赤 edge を持てば赤扱い (node 枠色)。
   const frontendHasRed = new Map<string, boolean>();
+  // frontend が突合した backend image (= 緑なら current と同一 SHA、赤なら最後に
+  // test した stale SHA)。両ノードに short SHA を出して一致を目視できるようにする。
+  const frontendTestedImg = new Map<string, string | null>();
+
+  // 長い image 識別子 (git SHA / revision) を先頭 12 文字に短縮する。完全値は
+  // hover (title) 側に出す。
+  const shortSha = (s: string | null | undefined): string =>
+    !s ? "—" : s.length > 14 ? `${s.slice(0, 12)}…` : s;
 
   for (const b of compat.backends) {
     if (!backendOrder.includes(b.backend_repo)) {
@@ -648,6 +656,13 @@ function renderCompatibilitySvg(compat: WaveCompatibility): string {
         frontendHasRed.set(m.frontend, false);
       }
       if (!m.tested_against_target) frontendHasRed.set(m.frontend, true);
+      // 突合 SHA を表示用に記録。緑 (current image を test 済) があればそれを
+      // 優先し、無ければ最後に test した image を出す。
+      if (m.tested_against_target) {
+        frontendTestedImg.set(m.frontend, b.current_image);
+      } else if (!frontendTestedImg.has(m.frontend)) {
+        frontendTestedImg.set(m.frontend, m.last_tested_image ?? null);
+      }
 
       const histLines = m.history.length
         ? m.history
@@ -738,9 +753,9 @@ function renderCompatibilitySvg(compat: WaveCompatibility): string {
         leftX,
         bY(repo),
         repo,
-        `@ ${img}`,
+        `@ ${shortSha(img)}`,
         BLUE,
-        `${repo}\ncurrent image: ${img}`,
+        `${repo}\ncurrent image: ${img ?? "—"}`,
       );
     })
     .join("");
@@ -748,17 +763,21 @@ function renderCompatibilitySvg(compat: WaveCompatibility): string {
   const frontendSvg = frontendOrder
     .map((repo) => {
       const ver = frontendVersion.get(repo) ?? "—";
+      const testedImg = frontendTestedImg.get(repo) ?? null;
       const border = frontendHasRed.get(repo) ? RED : GREEN;
       const verdictTxt = frontendHasRed.get(repo)
         ? "has untested edge(s)"
         : "all tested";
+      // line2 に突合 SHA を出して backend ノードの @<sha> と目視照合できるように
+      // する。tested 済 image が無ければ prod version に fallback。
+      const line2 = testedImg ? `${ver} · vs @${shortSha(testedImg)}` : `prod ${ver}`;
       return node(
         rightX,
         fY(repo),
         repo,
-        `prod ${ver}`,
+        line2,
         border,
-        `${repo}\nprod version: ${ver}\n${verdictTxt}`,
+        `${repo}\nprod version: ${ver}\ntested vs image: ${testedImg ?? "—"}\n${verdictTxt}`,
       );
     })
     .join("");

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -634,6 +634,43 @@ describe("handleReleaseWaveDetailPage compatibility section", () => {
     expect(html).toContain("untested (red)");
   });
 
+  it("shows short SHA on both nodes (full SHA in hover) so the match is visible", async () => {
+    const longSha = "3212fa882f9567ad22c661659cbf204ecafe1234";
+    const env = fakeEnv({
+      getReturn: { ok: true, data: makeWave() },
+      compatKv: memKv({
+        "backend::ippoan/rust-alc-api": {
+          schema_version: 1,
+          repo: "ippoan/rust-alc-api",
+          current_image: longSha,
+          deployed_at: "2026-05-27T00:00:00Z",
+          deployed_by: "x",
+          wave_id: null,
+        },
+        "frontend::ippoan/nuxt-notify": {
+          schema_version: 1,
+          repo: "ippoan/nuxt-notify",
+          prod_version: "main",
+          prod_deployed_at: "2026-05-27T00:00:00Z",
+          tested_against: [
+            {
+              backend_repo: "ippoan/rust-alc-api",
+              backend_image: longSha,
+              tested_at: "2026-05-27T00:00:00Z",
+            },
+          ],
+        },
+      }),
+    });
+    const resp = await handleReleaseWaveDetailPage(env, "w1");
+    const html = await resp.text();
+    // node ラベルは short SHA (先頭 12 + …)、両ノードに出るので目視照合できる
+    expect(html).toContain(`${longSha.slice(0, 12)}…`);
+    expect(html).toContain(`vs @${longSha.slice(0, 12)}…`);
+    // 完全 SHA は hover (title) に残る
+    expect(html).toContain(longSha);
+  });
+
   it("shows compat gate override on approve button when a required backend has reds", async () => {
     const wave = makeWave({
       state: "pending-approval",


### PR DESCRIPTION
## 背景

#170 で「consumer edge が無くても backend ノードを出す」ようにしたが、グラフ上では:
- backend ノード = truncate された長い SHA
- frontend ノード = `prod main` (SHA 無し)

のため、**緑 edge が「同じ SHA で突合した」結果なのかが目視で確認できなかった** (「あってるか見えない」)。

## 変更 (`src/release-wave/page.ts`)

- backend / frontend **両ノードのラベルに突合 SHA を short 形式 (先頭 12 + `…`) で表示**:
  - backend: `@ 3212fa882f95…`
  - frontend: `main · vs @3212fa882f95…`
  - → 両者の short SHA が一致していれば緑 edge の根拠が一目で分かる。
- **完全 SHA は hover (`<title>`) に**: backend = `current image: <full>`、frontend = `tested vs image: <full>`。edge hover も従来どおり full SHA + history。
- `frontendTestedImg` を収集 (緑なら current image、赤なら `last_tested_image`)。

## test

long SHA + 緑 edge のケースで、両ノードに short SHA が出ること + hover に full SHA が残ることを assert (`test/release-wave/page.test.ts`)。既存の `cur-img` テストは短いので影響なし。

Refs #157

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPNy9CVxrt1JgUZzDgAwYN)_