### PR TITLE
feat(webhook): accept GitHub deliveries on /webhooks (plural) alias

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,12 @@ app.post("/api/release-close-batch",
 app.get("/ws", (c) => getHub(c.env).fetch(c.req.raw));
 
 // Webhook
+// `/webhooks` (複数) は CF Access の bypass 対象 prefix (Access app は
+// `/webhooks` で始まるパスを edge auth から除外) に合わせたエイリアス。
+// 単数 `/webhook` は CF Access 配下のため GitHub 配信が 302 で到達できない。
+// handleWebhook は X-Hub-Signature-256 を自前検証するので edge auth 不要。
 app.post("/webhook", (c) => handleWebhook(c.req.raw, c.env, getHub(c.env)));
+app.post("/webhooks", (c) => handleWebhook(c.req.raw, c.env, getHub(c.env)));
 
 // Status
 app.get("/status", async (c) => {

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -239,6 +239,29 @@ describe("POST /webhook", () => {
     expect(res.status).toBe(404); // Hono: no GET route defined for /webhook
   });
 
+  // `/webhooks` (複数) は CF Access bypass prefix に合わせたエイリアス。
+  // 単数 `/webhook` と同一 handler に届くことを保証する。
+  it("accepts the same payload on /webhooks (plural alias)", async () => {
+    const body = makePayload();
+    const signature = await sign(body, WEBHOOK_SECRET);
+    const req = new Request("http://localhost/webhooks", {
+      method: "POST",
+      body,
+      headers: {
+        "X-Hub-Signature-256": signature,
+        "X-GitHub-Event": "workflow_run",
+      },
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(200);
+
+    const stored = await env.CI_STATUS.get("run:12345");
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored!).repo).toBe("ippoan/rust-alc-api");
+  });
+
   it("stores workflow_job and attaches to existing run", async () => {
     const te = testEnv();
     // First, create a workflow_run


### PR DESCRIPTION
## 背景

issue #175 で「全 repo に webhook を設定してもカードが出ない」原因を調べたところ、**CF Access のパスと Worker ルートの不一致**が真因でした。

| レイヤー | パス |
|---|---|
| Worker の GitHub 受け口 | `POST /webhook`（**単数**, `src/index.ts`） |
| CF Access bypass（本日 MCP で設定） | `/webhooks`（**複数**） |

- GitHub → `/webhook`（単数）: CF Access が bypass されず 302 → handler に届かない
- GitHub → `/webhooks`（複数）: CF Access は通るが Worker に bare `/webhooks` ルートが無く 404（`/webhooks/release-wave/*` のみ）

どちらでも必ず片方で落ちて CI run カードが生成されませんでした。

## 変更

`handleWebhook` への `/webhooks`（複数）エイリアスルートを追加。既存の CF Access bypass(`/webhooks`) をそのまま活かせるようにします。`handleWebhook` は `X-Hub-Signature-256` を自前で HMAC 検証するため edge auth は不要で、公開パスに生やしても安全です。

これにより GitHub webhook を `/webhooks` 宛てにしたまま（= 既存 bypass と一致）カードが生成されるようになります。issue #175 が想定した「`/webhook` 単数へ統一」とは逆方向ですが、本日設定済みの CF Access bypass(`/webhooks`) と各 repo の webhook 設定を維持できる分こちらを採用しました。

## テスト

- `test/webhook.test.ts` に `/webhooks`（複数）へ同一 payload を POST して単数と同じく KV に保存されることを検証するケースを追加。
- ローカルでは private npm package `@ippoan/auth-client-worker` の認証（NODE_AUTH_TOKEN）が CCoW セッションに無く typecheck/vitest をローカル実行できなかったため、CI 上での green を確認予定。

## 確認手順

1. merge & deploy 後、任意の repo で workflow を 1 回走らせる（または Recent Deliveries で redeliver）。
2. https://ci-dashboard.ippoan.org/ に CI run カードが出る → Deploy ボタンが付く。

Refs #175

---
_Generated by [Claude Code](https://claude.ai/code/session_018ojqQ42GM4ingy4zwtocKA)_