### PR TITLE
feat(release-wave): track previewed CF Workers version for staged flip

### DIFF
--- a/src/mcp/tools/release-wave.ts
+++ b/src/mcp/tools/release-wave.ts
@@ -136,17 +136,24 @@ export function registerReleaseWaveTools(server: McpServer, env: Env): void {
           .describe(
             "Pre-flip latest revision (= rollback target). Set when ok=true.",
           ),
+        previewed_version_id: z
+          .string()
+          .optional()
+          .describe(
+            "CF Workers no-traffic version id that was previewed (= flip target). Set when ok=true.",
+          ),
         error: z.string().optional().describe("Error detail when ok=false."),
       },
       annotations: { readOnlyHint: false },
     },
-    async ({ wave_id, repo, ok, preview_url, flip_from_revision, error }) => {
+    async ({ wave_id, repo, ok, preview_url, flip_from_revision, previewed_version_id, error }) => {
       const result = await hubStub(env).stageReport({
         wave_id,
         repo,
         ok,
         preview_url: preview_url ?? null,
         flip_from_revision: flip_from_revision ?? null,
+        previewed_version_id: previewed_version_id ?? null,
         error: error ?? null,
       });
       return formatRpcResult(result);

--- a/src/release-wave/dispatch.ts
+++ b/src/release-wave/dispatch.ts
@@ -87,6 +87,11 @@ export function decideDispatches(
         wave_id: next.wave_id,
         target_tag: r.target_tag,
         head_sha: r.head_sha,
+        // CF Workers: stage で no-traffic upload した preview 済み version の id。
+        // flip handler はこれを `wrangler versions deploy <id>@100%` の対象にする
+        // = preview したまさにその version を 100% traffic へ昇格させる。
+        // cloudrun path では null (= handler 側は使わない)。Refs #174。
+        previewed_version_id: r.previewed_version_id,
       },
     }));
   }

--- a/src/release-wave/do.ts
+++ b/src/release-wave/do.ts
@@ -64,6 +64,7 @@ export interface StageReportInput {
   ok: boolean;
   preview_url?: string | null;
   flip_from_revision?: string | null;
+  previewed_version_id?: string | null;
   error?: string | null;
 }
 
@@ -196,6 +197,7 @@ export class ReleaseWaveHub extends DurableObject<Env> {
       ok: input.ok,
       preview_url: input.preview_url ?? null,
       flip_from_revision: input.flip_from_revision ?? null,
+      previewed_version_id: input.previewed_version_id ?? null,
       error: input.error ?? null,
     });
   }

--- a/src/release-wave/state.ts
+++ b/src/release-wave/state.ts
@@ -53,6 +53,7 @@ export function createWave(input: {
     flip_status: "pending",
     flip_error: null,
     flip_from_revision: null,
+    previewed_version_id: null,
     rolled_back_to_revision: null,
   }));
 
@@ -177,6 +178,7 @@ function applyStageReport(
     repoNext.stage_status = "done";
     repoNext.preview_url = event.preview_url ?? null;
     repoNext.flip_from_revision = event.flip_from_revision ?? null;
+    repoNext.previewed_version_id = event.previewed_version_id ?? null;
     repoNext.stage_error = null;
   } else {
     repoNext.stage_status = "failed";

--- a/src/release-wave/types.ts
+++ b/src/release-wave/types.ts
@@ -74,6 +74,14 @@ export interface RepoState {
    */
   flip_from_revision: string | null;
 
+  /**
+   * stage で no-traffic upload した「preview 済み version」の id (CF Workers のみ)。
+   * flip 時にこの version を狙って `wrangler versions deploy <id>@100%` する
+   * = preview で検証したまさにその version を 100% traffic に昇格させる。
+   * Cloud Run path では使わない (= null のまま)。Refs ippoan/ci-dashboard#174。
+   */
+  previewed_version_id: string | null;
+
   /** rollback 実行時、戻した先 revision。 */
   rolled_back_to_revision: string | null;
 }
@@ -150,6 +158,7 @@ export type WaveEvent =
       ok: boolean;
       preview_url?: string | null;
       flip_from_revision?: string | null;
+      previewed_version_id?: string | null;
       error?: string | null;
     }
   | { kind: "approve"; now: string; approved_by: string }

--- a/src/release-wave/webhook.ts
+++ b/src/release-wave/webhook.ts
@@ -169,7 +169,8 @@ export async function handleContractAppliedWebhook(
  *     "repo": "ippoan/rust-alc-api",
  *     "ok": true,
  *     "preview_url": "https://preview-rust-alc-api.ippoan.org",      // ok=true 時のみ意味あり
- *     "flip_from_revision": "rust-alc-api-00041-zzz",                // ok=true 時のみ
+ *     "flip_from_revision": "rust-alc-api-00041-zzz",                // ok=true 時のみ (rollback 戻し先)
+ *     "previewed_version_id": "1a2b3c4d-...",                        // CF Workers のみ (flip 対象 version)
  *     "error": "build failed"                                        // ok=false 時のみ
  *   }
  */
@@ -179,6 +180,7 @@ const stageReportSchema = z.object({
   ok: z.boolean(),
   preview_url: z.string().url().optional(),
   flip_from_revision: z.string().optional(),
+  previewed_version_id: z.string().optional(),
   error: z.string().optional(),
 });
 
@@ -194,6 +196,7 @@ export async function handleStageReportWebhook(
     ok: v.data.ok,
     preview_url: v.data.preview_url ?? null,
     flip_from_revision: v.data.flip_from_revision ?? null,
+    previewed_version_id: v.data.previewed_version_id ?? null,
     error: v.data.error ?? null,
   })) as RpcResult<WaveState>;
   return rpcResultToResponse(result);

--- a/test/mcp/release-wave.test.ts
+++ b/test/mcp/release-wave.test.ts
@@ -222,6 +222,7 @@ describe("release_wave_stage", () => {
       ok: true,
       preview_url: null,
       flip_from_revision: null,
+      previewed_version_id: null,
       error: null,
     });
   });

--- a/test/release-wave/dispatch.test.ts
+++ b/test/release-wave/dispatch.test.ts
@@ -153,6 +153,39 @@ describe("decideDispatches: approve", () => {
     expect(ds[0]!.event_type).toBe("release-wave-flip");
     expect(ds[0]!.client_payload.wave_id).toBe("w1");
   });
+
+  it("includes previewed_version_id per repo in flip payload (CF Workers staged flip)", () => {
+    let s = makeWave({ flip_policy: "manual-approval" });
+    s = ok(
+      transition(s, {
+        kind: "stage_report",
+        now: T1,
+        repo: "ippoan/rust-alc-api",
+        ok: true,
+        previewed_version_id: "11111111-2222-3333-4444-555555555555",
+      }),
+    ).state;
+    s = ok(
+      transition(s, {
+        kind: "stage_report",
+        now: T1,
+        repo: "ippoan/auth-worker",
+        ok: true,
+        previewed_version_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      }),
+    ).state;
+    const prev = s;
+    const next = ok(
+      transition(prev, { kind: "approve", now: T2, approved_by: "ops@example.com" }),
+    ).state;
+    const ds = decideDispatches(prev, next);
+    expect(ds[0]!.client_payload.previewed_version_id).toBe(
+      "11111111-2222-3333-4444-555555555555",
+    );
+    expect(ds[1]!.client_payload.previewed_version_id).toBe(
+      "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    );
+  });
 });
 
 // ============================================================================

--- a/test/release-wave/state.test.ts
+++ b/test/release-wave/state.test.ts
@@ -51,6 +51,7 @@ describe("createWave", () => {
     expect(w.repos[0]!.flip_status).toBe("pending");
     expect(w.repos[0]!.preview_url).toBeNull();
     expect(w.repos[0]!.flip_from_revision).toBeNull();
+    expect(w.repos[0]!.previewed_version_id).toBeNull();
     expect(w.rollback.safe).toBe(true);
     expect(w.rollback.unsafe_reason).toBeNull();
     expect(w.started_at).toBe(T0);
@@ -108,6 +109,7 @@ describe("transition: stage_report", () => {
         ok: true,
         preview_url: "https://preview-rust-alc-api.ippoan.org",
         flip_from_revision: "rust-alc-api-00041-zzz",
+        previewed_version_id: "11111111-2222-3333-4444-555555555555",
       }),
     );
     expect(r.state.state).toBe("staging");
@@ -116,6 +118,9 @@ describe("transition: stage_report", () => {
       "https://preview-rust-alc-api.ippoan.org",
     );
     expect(r.state.repos[0]!.flip_from_revision).toBe("rust-alc-api-00041-zzz");
+    expect(r.state.repos[0]!.previewed_version_id).toBe(
+      "11111111-2222-3333-4444-555555555555",
+    );
     expect(r.state.repos[1]!.stage_status).toBe("pending");
     expect(r.state.staged_at).toBeNull();
   });

--- a/test/release-wave/webhook.test.ts
+++ b/test/release-wave/webhook.test.ts
@@ -315,6 +315,7 @@ describe("handleStageReportWebhook", () => {
           ok: true,
           preview_url: "https://preview-a.ippoan.org/",
           flip_from_revision: "a-old-rev",
+          previewed_version_id: "11111111-2222-3333-4444-555555555555",
         },
       }),
       env,
@@ -326,6 +327,7 @@ describe("handleStageReportWebhook", () => {
       ok: true,
       preview_url: "https://preview-a.ippoan.org/",
       flip_from_revision: "a-old-rev",
+      previewed_version_id: "11111111-2222-3333-4444-555555555555",
       error: null,
     });
   });
@@ -370,6 +372,7 @@ describe("handleStageReportWebhook", () => {
       expect.objectContaining({
         preview_url: null,
         flip_from_revision: null,
+        previewed_version_id: null,
         error: null,
       }),
     );


### PR DESCRIPTION
## Summary

Release Wave Phase 5 (CF Workers staged flip) の ci-dashboard 側。stage で
preview した version を flip 対象にするためのデータフローを追加する。

- `RepoState` / `WaveEvent(stage_report)` に `previewed_version_id` を追加
  (CF Workers の no-traffic upload 済み version = flip 対象)。`flip_from_revision`
  は stage 前に active だった version (= rollback 戻し先) を表す本来の意味に分離。
- stage-report webhook / MCP tool / DO `stageReport` で `previewed_version_id`
  を受けて wave state に保持。
- flip dispatch の `client_payload` に repo ごとの `previewed_version_id` を
  載せる (handler 側が `wrangler versions deploy <id>@100%` の対象にする)。

handler 側 (`wrangler versions deploy`) の変更は ippoan/ci-workflows#（対の PR）。

## Test plan

- [x] `npx tsc --noEmit` green
- [x] `vitest run` release-wave / mcp 関連 221 tests green
- [x] dispatch.test: flip payload に previewed_version_id が repo 別に載る
- [x] state.test / webhook.test / mcp test: previewed_version_id の through を検証

Refs #174

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nz1uWLW1CdqFuazF2Th4nW)_