### PR TITLE
feat(release-wave): show preview URLs + per-wave Approve & Flip on list page

### DIFF
--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -166,10 +166,36 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
   const compatSection = renderGlobalCompatibilitySection(globalCompat);
 
   const rows = waves.length === 0
-    ? `<tr><td colspan="5" class="empty">No release waves yet.</td></tr>`
+    ? `<tr><td colspan="7" class="empty">No release waves yet.</td></tr>`
     : waves
         .map((w) => {
           const repos = w.repos.map((r) => escapeHtml(r.repo)).join(", ");
+
+          // preview URL は repo ごとに stage callback で報告される。set 済みの
+          // ものだけ http/https に絞って link 化し、repo 名付きで列挙する。
+          const previewLines = w.repos
+            .map((r) => {
+              const safe = safeHttpUrl(r.preview_url);
+              if (!safe) return null;
+              return `<a href="${escapeHtml(safe)}" target="_blank" rel="noopener noreferrer">${escapeHtml(r.repo)}</a>`;
+            })
+            .filter((x): x is string => x !== null);
+          const previewCell = previewLines.length > 0
+            ? previewLines.join("<br>")
+            : `<span class="meta">—</span>`;
+
+          // 一括 flip = Approve & Flip。pending-approval の時だけ有効。
+          // 一覧では force を付けない (compat gate ブロック時は失敗 → 詳細ページで
+          // override する運用)。CSP 上 JS 無しで POST form として動かす。
+          const canApprove = w.state === "pending-approval";
+          const flipButton = `
+            <form method="post" action="/api/release-wave/${encodeURIComponent(w.wave_id)}/approve" style="margin:0">
+              <button type="submit" ${canApprove ? "" : "disabled"}
+                title="Approve & flip this wave (enabled only in pending-approval; no compat-gate override here)">
+                Approve &amp; Flip
+              </button>
+            </form>`;
+
           return `
             <tr>
               <td><a href="/release-wave/${encodeURIComponent(w.wave_id)}">${escapeHtml(w.wave_id)}</a></td>
@@ -177,6 +203,8 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
               <td class="meta">${escapeHtml(w.started_at)}</td>
               <td class="meta">${escapeHtml(w.flip_policy)}</td>
               <td class="meta">${repos}</td>
+              <td>${previewCell}</td>
+              <td class="actions">${flipButton}</td>
             </tr>`;
         })
         .join("");
@@ -205,6 +233,8 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
           <th>Started At</th>
           <th>Flip Policy</th>
           <th>Repos</th>
+          <th>Preview</th>
+          <th>Actions</th>
         </tr>
       </thead>
       <tbody>${rows}</tbody>

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -149,6 +149,94 @@ describe("handleReleaseWaveListPage", () => {
     expect(html).not.toContain("<script>");
     expect(html).toContain("evil&lt;script&gt;");
   });
+
+  it("renders preview URL links per repo in the list", async () => {
+    const env = fakeEnv({
+      listReturn: [
+        makeWave({
+          wave_id: "w1",
+          state: "pending-approval",
+          repos: [
+            {
+              repo: "ippoan/auth-worker",
+              target_tag: "v0.5.0",
+              head_sha: "abc",
+              require_compatibility: false,
+              stage_status: "done",
+              preview_url: "https://preview-auth.ippoan.org/",
+              stage_error: null,
+              flip_status: "pending",
+              flip_error: null,
+              flip_from_revision: null,
+              previewed_version_id: null,
+              rolled_back_to_revision: null,
+            },
+          ],
+        }),
+      ],
+    });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    expect(html).toContain('href="https://preview-auth.ippoan.org/"');
+  });
+
+  it("rejects javascript: scheme preview_url in the list (XSS regression)", async () => {
+    const env = fakeEnv({
+      listReturn: [
+        makeWave({
+          wave_id: "w1",
+          repos: [
+            {
+              repo: "ippoan/auth-worker",
+              target_tag: "v0.5.0",
+              head_sha: "abc",
+              require_compatibility: false,
+              stage_status: "done",
+              preview_url: "javascript:alert(1)",
+              stage_error: null,
+              flip_status: "pending",
+              flip_error: null,
+              flip_from_revision: null,
+              previewed_version_id: null,
+              rolled_back_to_revision: null,
+            },
+          ],
+        }),
+      ],
+    });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    expect(html).not.toContain("javascript:alert(1)");
+  });
+
+  it("enables the per-wave Approve & Flip button only in pending-approval", async () => {
+    const env = fakeEnv({
+      listReturn: [
+        makeWave({ wave_id: "w-pending", state: "pending-approval" }),
+        makeWave({ wave_id: "w-staging", state: "staging" }),
+      ],
+    });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    expect(html).toContain("Approve &amp; Flip");
+    // pending-approval wave の form は approve endpoint を向く
+    expect(html).toContain(
+      'action="/api/release-wave/w-pending/approve"',
+    );
+    // staging wave のボタンは disabled
+    const stagingFormIdx = html.indexOf(
+      'action="/api/release-wave/w-staging/approve"',
+    );
+    const stagingButton = html.slice(stagingFormIdx, stagingFormIdx + 200);
+    expect(stagingButton).toContain("disabled");
+  });
+
+  it("does not pass force=true from the list flip button", async () => {
+    const env = fakeEnv({
+      listReturn: [makeWave({ wave_id: "w1", state: "pending-approval" })],
+    });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    const formIdx = html.indexOf('action="/api/release-wave/w1/approve"');
+    const formChunk = html.slice(formIdx, formIdx + 300);
+    expect(formChunk).not.toContain('name="force"');
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Release Wave 一覧ページ (`/release-wave`) を強化し、詳細ページに入らず一覧から
wave を flip できるようにする。

- **Preview 列**: 各 wave の repo ごとに stage callback で報告された preview URL を
  link 表示。`http`/`https` のみ許可し `javascript:`/`data:` 等は除外(XSS 対策、
  詳細ページと同じ `safeHttpUrl`)。
- **Actions 列(Approve & Flip ボタン)**: wave 行ごとに配置。state が
  `pending-approval` の時だけ有効。**一覧では `force=true` を付けない** —
  compatibility gate にブロックされている場合は失敗するので、その時は詳細ページで
  override する運用(安全側)。
- CSP (`connect-src 'none'`、JS 無し)を維持するため POST form として実装。

## Test plan

- [x] `npx tsc --noEmit` green
- [x] `vitest run test/release-wave/page.test.ts` 29 tests green
- [x] preview URL の link 化 / `javascript:` scheme 除外を test
- [x] flip ボタンが pending-approval のみ有効 (他 state は disabled) を test
- [x] 一覧の flip form に `force` が含まれないことを test

Refs #137

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nz1uWLW1CdqFuazF2Th4nW)_