### PR TITLE
feat(release-wave): surface staged previews + flip in compat graph section

### DIFF
--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -163,7 +163,10 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
       globalCompat = null;
     }
   }
-  const compatSection = renderGlobalCompatibilitySection(globalCompat);
+  const compatSection = renderGlobalCompatibilitySection(
+    globalCompat,
+    buildActiveWaveInfo(waves),
+  );
 
   const rows = waves.length === 0
     ? `<tr><td colspan="7" class="empty">No release waves yet.</td></tr>`
@@ -469,8 +472,41 @@ export async function handleReleaseWaveDetailPage(
  * 全 `backend::` record とその consumer frontend の突合グラフ (SVG) を出す。
  * backend record が無ければ案内文のみ。
  */
+/**
+ * 全体俯瞰グラフ (wave 非依存) に重ねる「現在進行中の wave」由来の情報。
+ *
+ * - `preview`:  frontend repo → 今 staging / pending-approval 中の wave の
+ *   preview URL。複数 active wave がある場合は list 末尾 (= 最新) が勝つ。
+ * - `waveOf`:   frontend repo → その active wave の wave_id (node を詳細ページへ
+ *   link するため)。
+ * - `pendingFlips`: pending-approval の wave 群 (Approve & Flip ボタン用)。
+ */
+interface ActiveWaveInfo {
+  preview: Map<string, { url: string; wave_id: string }>;
+  waveOf: Map<string, string>;
+  pendingFlips: Array<{ wave_id: string }>;
+}
+
+/** active な (staging / pending-approval) wave から ActiveWaveInfo を組む。 */
+function buildActiveWaveInfo(waves: WaveState[]): ActiveWaveInfo {
+  const preview = new Map<string, { url: string; wave_id: string }>();
+  const waveOf = new Map<string, string>();
+  const pendingFlips: Array<{ wave_id: string }> = [];
+  for (const w of waves) {
+    if (w.state !== "staging" && w.state !== "pending-approval") continue;
+    if (w.state === "pending-approval") pendingFlips.push({ wave_id: w.wave_id });
+    for (const r of w.repos) {
+      waveOf.set(r.repo, w.wave_id);
+      const safe = safeHttpUrl(r.preview_url);
+      if (safe) preview.set(r.repo, { url: safe, wave_id: w.wave_id });
+    }
+  }
+  return { preview, waveOf, pendingFlips };
+}
+
 function renderGlobalCompatibilitySection(
   compat: WaveCompatibility | null,
+  active?: ActiveWaveInfo,
 ): string {
   if (!compat || compat.backends.length === 0) {
     return `
@@ -488,7 +524,7 @@ function renderGlobalCompatibilitySection(
     : compat.verified
     ? `<span class="ok"><strong>all consumers tested</strong></span>`
     : `<span class="err"><strong>some consumers untested</strong></span>`;
-  const svg = renderCompatibilitySvg(compat);
+  const svg = renderCompatibilitySvg(compat, active);
   const body = svg
     ? svg
     : `<p class="meta">backend record はあるが、まだどの frontend も test 履歴を
@@ -501,7 +537,51 @@ function renderGlobalCompatibilitySection(
         個別 wave の retest 操作は各 wave 詳細ページで。
         Refs <a href="https://github.com/ippoan/ci-dashboard/issues/157">#157</a>.</p>
       ${body}
+      ${renderActiveWaveOverlay(active)}
     </div>`;
+}
+
+/**
+ * 俯瞰グラフ直下に、進行中 wave の preview link と Approve & Flip ボタンを出す。
+ * SVG node に直接埋めると anchor のネストや座標管理が破綻するため、HTML として
+ * グラフの下にまとめて描画する (= preview を「ここ (compat section)」に出す)。
+ */
+function renderActiveWaveOverlay(active?: ActiveWaveInfo): string {
+  if (!active) return "";
+
+  const previews = [...active.preview.entries()]
+    .map(
+      ([repo, p]) =>
+        `<li><code>${escapeHtml(repo)}</code> →
+          <a href="${escapeHtml(p.url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(p.url)}</a>
+          <span class="meta">(${escapeHtml(p.wave_id)})</span></li>`,
+    )
+    .join("");
+  const previewBlock = previews
+    ? `<div style="margin-top:10px">
+         <strong class="meta">Staged previews (active waves)</strong>
+         <ul style="margin:4px 0 0; padding-left:20px">${previews}</ul>
+       </div>`
+    : "";
+
+  // pending-approval の wave ごとに Approve & Flip ボタン。一覧 (list page) と
+  // 同じく force は付けない (compat gate ブロック時は詳細ページで override)。
+  const flips = active.pendingFlips
+    .map(
+      (f) => `
+        <form method="post" action="/api/release-wave/${encodeURIComponent(f.wave_id)}/approve" style="margin:0">
+          <button type="submit"
+            title="Approve & flip ${escapeHtml(f.wave_id)} (no compat-gate override here)">
+            Approve &amp; Flip: ${escapeHtml(f.wave_id)}
+          </button>
+        </form>`,
+    )
+    .join("");
+  const flipBlock = flips
+    ? `<div class="actions" style="margin-top:10px">${flips}</div>`
+    : "";
+
+  return previewBlock + flipBlock;
 }
 
 /**
@@ -651,7 +731,10 @@ function truncLabel(s: string, max = 30): string {
  * JS を使わず SVG + inline style のみ (= ページの strict CSP `default-src 'none'`
  * のまま動く)。
  */
-function renderCompatibilitySvg(compat: WaveCompatibility): string {
+function renderCompatibilitySvg(
+  compat: WaveCompatibility,
+  active?: ActiveWaveInfo,
+): string {
   type Edge = {
     backend: string;
     frontend: string;
@@ -765,8 +848,9 @@ function renderCompatibilitySvg(compat: WaveCompatibility): string {
     line2: string,
     border: string,
     fullTitle: string,
+    href?: string,
   ): string => {
-    return `<g><title>${escapeHtml(fullTitle)}</title>
+    const g = `<g><title>${escapeHtml(fullTitle)}</title>
       <rect x="${x}" y="${y}" width="${boxW}" height="${boxH}" rx="6"
         fill="#ffffff" stroke="${border}" stroke-width="1.5"/>
       <text x="${x + 10}" y="${y + 15}" font-family="monospace" font-size="12"
@@ -774,6 +858,10 @@ function renderCompatibilitySvg(compat: WaveCompatibility): string {
       <text x="${x + 10}" y="${y + 29}" font-family="monospace" font-size="10.5"
         fill="${GRAY}">${escapeHtml(truncLabel(line2, 36))}</text>
     </g>`;
+    // active wave 中の frontend node は詳細ページへの link にする (node link 化)。
+    return href
+      ? `<a href="${escapeHtml(href)}" style="cursor:pointer">${g}</a>`
+      : g;
   };
 
   const backendSvg = backendOrder
@@ -801,13 +889,21 @@ function renderCompatibilitySvg(compat: WaveCompatibility): string {
       // line2 に突合 SHA を出して backend ノードの @<sha> と目視照合できるように
       // する。tested 済 image が無ければ prod version に fallback。
       const line2 = testedImg ? `${ver} · vs @${shortSha(testedImg)}` : `prod ${ver}`;
+      const waveId = active?.waveOf.get(repo);
+      const href = waveId
+        ? `/release-wave/${encodeURIComponent(waveId)}`
+        : undefined;
+      const previewNote = active?.preview.has(repo)
+        ? `\npreview: ${active.preview.get(repo)!.url}`
+        : "";
       return node(
         rightX,
         fY(repo),
         repo,
         line2,
         border,
-        `${repo}\nprod version: ${ver}\ntested vs image: ${testedImg ?? "—"}\n${verdictTxt}`,
+        `${repo}\nprod version: ${ver}\ntested vs image: ${testedImg ?? "—"}\n${verdictTxt}${previewNote}`,
+        href,
       );
     })
     .join("");

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -834,3 +834,127 @@ describe("handleReleaseWaveDetailPage compatibility section", () => {
     expect(html).toContain("cur-img");
   });
 });
+
+// ============================================================================
+// global compat section overlay: staged previews + flip + node link (Refs #174)
+// ============================================================================
+
+describe("handleReleaseWaveListPage global compat overlay", () => {
+  const compatSeed = {
+    "backend::ippoan/rust-alc-api": {
+      schema_version: 1,
+      repo: "ippoan/rust-alc-api",
+      current_image: "cur-img",
+      deployed_at: "2026-05-27T00:00:00Z",
+      deployed_by: "x",
+      wave_id: null,
+    },
+    "frontend::ippoan/alc-app": {
+      schema_version: 1,
+      repo: "ippoan/alc-app",
+      prod_version: "v1.2.10",
+      prod_deployed_at: "2026-05-27T00:00:00Z",
+      tested_against: [
+        {
+          backend_repo: "ippoan/rust-alc-api",
+          backend_image: "cur-img",
+          tested_at: "2026-05-27T00:00:00Z",
+        },
+      ],
+    },
+  };
+
+  function activeWave(over: Partial<WaveState> = {}): WaveState {
+    return makeWave({
+      wave_id: "w-active",
+      state: "pending-approval",
+      repos: [
+        {
+          repo: "ippoan/alc-app",
+          target_tag: "v1.3.0",
+          head_sha: "abc",
+          require_compatibility: false,
+          stage_status: "done",
+          preview_url: "https://preview-alc.ippoan.org/",
+          stage_error: null,
+          flip_status: "pending",
+          flip_error: null,
+          flip_from_revision: null,
+          rolled_back_to_revision: null,
+        },
+      ],
+      ...over,
+    });
+  }
+
+  it("shows staged preview links + Approve & Flip for active waves", async () => {
+    const env = fakeEnv({
+      listReturn: [activeWave()],
+      compatKv: memKv(compatSeed),
+    });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    expect(html).toContain("Staged previews");
+    expect(html).toContain('href="https://preview-alc.ippoan.org/"');
+    expect(html).toContain("Approve &amp; Flip: w-active");
+    expect(html).toContain('action="/api/release-wave/w-active/approve"');
+  });
+
+  it("does not pass force=true from the compat-section flip button", async () => {
+    const env = fakeEnv({
+      listReturn: [activeWave()],
+      compatKv: memKv(compatSeed),
+    });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    const idx = html.indexOf('action="/api/release-wave/w-active/approve"');
+    expect(html.slice(idx, idx + 300)).not.toContain('name="force"');
+  });
+
+  it("links the frontend graph node to its active wave detail page", async () => {
+    const env = fakeEnv({
+      listReturn: [activeWave()],
+      compatKv: memKv(compatSeed),
+    });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    // SVG node が active wave の詳細ページへの anchor になっている
+    expect(html).toMatch(/<a href="\/release-wave\/w-active"[^>]*>\s*<g>/);
+  });
+
+  it("rejects javascript: preview_url in the overlay (XSS regression)", async () => {
+    const env = fakeEnv({
+      listReturn: [
+        activeWave({
+          repos: [
+            {
+              repo: "ippoan/alc-app",
+              target_tag: "v1.3.0",
+              head_sha: "abc",
+              require_compatibility: false,
+              stage_status: "done",
+              preview_url: "javascript:alert(1)",
+              stage_error: null,
+              flip_status: "pending",
+              flip_error: null,
+              flip_from_revision: null,
+              rolled_back_to_revision: null,
+            },
+          ],
+        }),
+      ],
+      compatKv: memKv(compatSeed),
+    });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    expect(html).not.toContain("javascript:alert(1)");
+    // 危険 scheme の場合は preview link を出さない (Staged previews ブロック自体無し)
+    expect(html).not.toContain("Staged previews");
+  });
+
+  it("omits previews + flip when no active waves (flipped only)", async () => {
+    const env = fakeEnv({
+      listReturn: [makeWave({ wave_id: "w-done", state: "flipped" })],
+      compatKv: memKv(compatSeed),
+    });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    expect(html).not.toContain("Staged previews");
+    expect(html).not.toContain("Approve &amp; Flip:");
+  });
+});


### PR DESCRIPTION
## Summary

ご要望どおり、Compatibility (all consumers) 俯瞰グラフ section に進行中 wave の
情報を重ねました。

- **frontend ノードの link 化**: active wave (staging / pending-approval) に
  含まれる frontend graph node を、その wave 詳細ページ (`/release-wave/<wave_id>`)
  への `<a>` link にしました(クリックで遷移、tooltip に preview URL も併記)。
- **Staged previews(preview URL link)**: グラフ直下に、active wave の repo ごとの
  preview URL を link 列挙。`http`/`https` のみ許可し `javascript:`/`data:` は除外。
  データは **active wave (staging/pending-approval) から取得**(複数あれば最新)。
- **Approve & Flip ボタン**: pending-approval の wave ごとにボタンを配置。一覧
  ページと同じく **`force` は付けない**(compat gate ブロック時は詳細ページで
  override)。

SVG node への anchor ネストや座標破綻を避けるため、preview / flip は HTML として
グラフ下にまとめて描画し、`buildActiveWaveInfo(waves)` が wave list から
preview / waveOf / pendingFlips を構築します。CSP(`default-src 'none'`、JS 無し)は維持。

## Test plan

- [x] `npx tsc --noEmit` green
- [x] `vitest run test/release-wave` 212 tests green(うち overlay 用 5 件新規)
- [x] preview link 表示 / `javascript:` scheme 除外 / Approve & Flip ボタン /
      force 無し / frontend node → wave 詳細 anchor / active wave 無し時は非表示 を test

Refs #157 #137

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nz1uWLW1CdqFuazF2Th4nW)_