### PR TITLE
feat(release-wave): always render preview/flip overlay in compat section

### DIFF
--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -545,11 +545,15 @@ function renderGlobalCompatibilitySection(
  * 俯瞰グラフ直下に、進行中 wave の preview link と Approve & Flip ボタンを出す。
  * SVG node に直接埋めると anchor のネストや座標管理が破綻するため、HTML として
  * グラフの下にまとめて描画する (= preview を「ここ (compat section)」に出す)。
+ *
+ * active wave が無い時も block 自体は常に描画し、placeholder / disabled ボタンを
+ * 出す (= UI affordance を常設して「ここで flip できる」ことを見せる)。
  */
 function renderActiveWaveOverlay(active?: ActiveWaveInfo): string {
-  if (!active) return "";
+  const previewEntries = active ? [...active.preview.entries()] : [];
+  const pendingFlips = active ? active.pendingFlips : [];
 
-  const previews = [...active.preview.entries()]
+  const previews = previewEntries
     .map(
       ([repo, p]) =>
         `<li><code>${escapeHtml(repo)}</code> →
@@ -557,16 +561,18 @@ function renderActiveWaveOverlay(active?: ActiveWaveInfo): string {
           <span class="meta">(${escapeHtml(p.wave_id)})</span></li>`,
     )
     .join("");
-  const previewBlock = previews
-    ? `<div style="margin-top:10px">
-         <strong class="meta">Staged previews (active waves)</strong>
-         <ul style="margin:4px 0 0; padding-left:20px">${previews}</ul>
-       </div>`
-    : "";
+  const previewBlock = `
+    <div style="margin-top:10px">
+      <strong class="meta">Staged previews (active waves)</strong>
+      ${previews
+        ? `<ul style="margin:4px 0 0; padding-left:20px">${previews}</ul>`
+        : `<p class="meta" style="margin:4px 0 0">active な wave (staging / pending-approval) はありません。</p>`}
+    </div>`;
 
   // pending-approval の wave ごとに Approve & Flip ボタン。一覧 (list page) と
   // 同じく force は付けない (compat gate ブロック時は詳細ページで override)。
-  const flips = active.pendingFlips
+  // 対象 wave が無い時は disabled ボタンを 1 つ出して affordance を残す。
+  const flips = pendingFlips
     .map(
       (f) => `
         <form method="post" action="/api/release-wave/${encodeURIComponent(f.wave_id)}/approve" style="margin:0">
@@ -577,9 +583,13 @@ function renderActiveWaveOverlay(active?: ActiveWaveInfo): string {
         </form>`,
     )
     .join("");
-  const flipBlock = flips
-    ? `<div class="actions" style="margin-top:10px">${flips}</div>`
-    : "";
+  const flipBlock = `
+    <div class="actions" style="margin-top:10px">
+      ${flips
+        ? flips
+        : `<button type="button" disabled
+             title="pending-approval の wave がありません">Approve &amp; Flip</button>`}
+    </div>`;
 
   return previewBlock + flipBlock;
 }

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -944,17 +944,24 @@ describe("handleReleaseWaveListPage global compat overlay", () => {
     });
     const html = await (await handleReleaseWaveListPage(env)).text();
     expect(html).not.toContain("javascript:alert(1)");
-    // 危険 scheme の場合は preview link を出さない (Staged previews ブロック自体無し)
-    expect(html).not.toContain("Staged previews");
+    expect(html).not.toContain('href="javascript');
+    // heading は常設だが危険 scheme の preview link 自体は出さない
+    expect(html).toContain("Staged previews");
   });
 
-  it("omits previews + flip when no active waves (flipped only)", async () => {
+  it("always renders the overlay with placeholder + disabled flip when no active waves", async () => {
     const env = fakeEnv({
       listReturn: [makeWave({ wave_id: "w-done", state: "flipped" })],
       compatKv: memKv(compatSeed),
     });
     const html = await (await handleReleaseWaveListPage(env)).text();
-    expect(html).not.toContain("Staged previews");
-    expect(html).not.toContain("Approve &amp; Flip:");
+    // block 自体は常に出る
+    expect(html).toContain("Staged previews");
+    expect(html).toContain("active な wave");
+    // 具体的な flip 対象 (wave_id 付きボタン) は無く、disabled ボタンが出る
+    expect(html).not.toContain("Approve &amp; Flip: ");
+    const idx = html.indexOf("Approve &amp; Flip</button>");
+    expect(idx).toBeGreaterThan(-1);
+    expect(html.slice(Math.max(0, idx - 120), idx)).toContain("disabled");
   });
 });


### PR DESCRIPTION
## Summary

active wave が無い時も Compatibility (all consumers) section の overlay block を
**常設**するように変更しました(ご要望「ないときも出して」)。

これまでは active wave (staging / pending-approval) が無いと preview / flip ブロックを
丸ごと隠していたため、wave が無い間はあのグラフ section が以前と変わらず見えていました。

- **Staged previews**: preview が無ければ「active な wave (staging / pending-approval)
  はありません。」の placeholder を常に表示。
- **Approve & Flip**: pending-approval の wave が無ければ **disabled** の
  Approve & Flip ボタンを 1 つ表示(affordance を常設)。wave があれば従来どおり
  `Approve & Flip: <wave_id>` ボタン(force なし)。

これで wave が無い状態でも「ここで flip できる」ことが常に見えます。

## Test plan

- [x] `npx tsc --noEmit` green
- [x] `vitest run test/release-wave/page.test.ts` 34 tests green
- [x] active wave 無し時に Staged previews placeholder + disabled flip ボタンが出る test
- [x] `javascript:` scheme は link 化しない(heading は常設)test を更新

Refs #157 #137

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nz1uWLW1CdqFuazF2Th4nW)_