### PR TITLE
feat(release-wave): pending-release 一覧 + Flip ボタン (no-traffic release を ci-dashboard で flip)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import {
   handleFrontendTestReportWebhook,
   handleBackendDeployReportWebhook,
   handleBackendCurrentImageWebhook,
+  handlePendingReleaseWebhook,
 } from "./release-wave/webhook";
 import {
   handleCompatibility,
@@ -38,6 +39,7 @@ import {
   handleReleaseWaveRollback,
   handleReleaseWaveAbort,
   handleReleaseWaveRetest,
+  handleReleaseWavePendingReleaseFlip,
 } from "./release-wave/api";
 import {
   handlePwaManifest,
@@ -225,6 +227,11 @@ app.post("/webhooks/release-wave/frontend-test-report", (c) =>
 app.post("/webhooks/release-wave/backend-deploy-report", (c) =>
   handleBackendDeployReportWebhook(c.req.raw, c.env),
 );
+// frontend-ci の release deploy が `wrangler versions upload` (no-traffic) 後に
+// version_id / tag / preview_url を報告する (Refs #181 / #174)。
+app.post("/webhooks/release-wave/pending-release", (c) =>
+  handlePendingReleaseWebhook(c.req.raw, c.env),
+);
 // 認証付き read (CF Access が bypass する /webhooks/* 配下)。frontend CI が
 // 現 prod backend image を解決する用 — CF Access 下の /backend-current-image は
 // GitHub Actions runner から 302 で到達不能なため。Refs #157。
@@ -260,6 +267,13 @@ app.post("/api/release-wave/:wave_id/abort", (c) =>
 // (Refs #157 Phase B)。form field `frontend` で 1 件指定可、無ければ全 red。
 app.post("/api/release-wave/:wave_id/retest", (c) =>
   handleReleaseWaveRetest(c.req.raw, c.env, c.req.param("wave_id")),
+);
+// 単独 v* リリースの no-traffic version を 100% へ flip (Refs #181 / #174)。
+// wave を起こさず form field `repo` の pending-release record を promote する。
+// `:wave_id` を取る上の route とは action segment (`flip` vs approve/.../retest)
+// で区別されるため衝突しない。
+app.post("/api/release-wave/pending-release/flip", (c) =>
+  handleReleaseWavePendingReleaseFlip(c.req.raw, c.env),
 );
 
 export default app;

--- a/src/release-wave/api.ts
+++ b/src/release-wave/api.ts
@@ -13,7 +13,8 @@ import type { Env } from "../index";
 import type { ReleaseWaveHub, RpcResult } from "./do";
 import type { WaveState } from "./types";
 import { computeWaveCompatibility } from "./compat";
-import { decideRetestDispatches, dispatchAll } from "./dispatch";
+import { decideRetestDispatches, dispatchAll, type Dispatch } from "./dispatch";
+import { getPendingRelease, clearPendingRelease } from "./pending-release";
 
 function hubStub(env: Env): DurableObjectStub<ReleaseWaveHub> {
   const id = env.RELEASE_WAVE_HUB.idFromName("singleton");
@@ -31,6 +32,14 @@ function redirectToDetail(wave_id: string): Response {
   return new Response(null, {
     status: 303,
     headers: { Location: `/release-wave/${encodeURIComponent(wave_id)}` },
+  });
+}
+
+/** action 完了後、一覧ページに 303 redirect。 */
+function redirectToList(): Response {
+  return new Response(null, {
+    status: 303,
+    headers: { Location: `/release-wave` },
   });
 }
 
@@ -200,4 +209,91 @@ export async function handleReleaseWaveRetest(
     }
   }
   return redirectToDetail(wave_id);
+}
+
+// ----------------------------------------------------------------------------
+// POST /api/release-wave/pending-release/flip  (Refs #181 / #174)
+// ----------------------------------------------------------------------------
+
+/**
+ * 単独 v* リリースの no-traffic version を 100% へ flip する。release-wave
+ * (stage→approve→flip) を起こさずに、frontend-ci が report した pending release
+ * を `release-wave-flip` dispatch で promote する。
+ *
+ * - form field `repo` ("owner/name") を受け、KV の pending-release record を引く。
+ *   record が無い repo は 404 (= flip 対象が存在しない)。
+ * - dispatch の client_payload に `previewed_version_id` (= upload した version) と
+ *   `pending_release: true` マーカーを載せる。handler は marker を見て wave
+ *   flip-report callback を skip する (対応する wave が無いため)。
+ * - dispatch 成功なら record を clear (= 一覧から消える)。dispatch 自体が失敗
+ *   したら record を残す (operator が再試行できる)。
+ *
+ * 実 flip の成否は GitHub Actions 側で確認する (callback は来ない)。
+ */
+export async function handleReleaseWavePendingReleaseFlip(
+  req: Request,
+  env: Env,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return jsonResponse(405, { code: "METHOD_NOT_ALLOWED", error: "use POST" });
+  }
+  if (!env.COMPAT_KV) {
+    return jsonResponse(500, {
+      code: "KV_NOT_CONFIGURED",
+      error: "COMPAT_KV is not bound",
+    });
+  }
+
+  let repo = "";
+  try {
+    const form = await req.formData();
+    repo = String(form.get("repo") ?? "").trim();
+  } catch {
+    // form-data 以外は repo 無し → 下で 400
+  }
+  if (!repo) {
+    return jsonResponse(400, {
+      code: "BAD_REQUEST",
+      error: "form field 'repo' is required",
+    });
+  }
+
+  const record = await getPendingRelease(env.COMPAT_KV, repo);
+  if (!record) {
+    return jsonResponse(404, {
+      code: "NOT_FOUND",
+      error: `no pending release for ${repo}`,
+    });
+  }
+
+  // synthetic wave_id: handler の dispatch job の wave_id 形式検証
+  // (^[a-zA-Z0-9._-]{1,128}$) を満たすよう `/` を `-` に潰す。
+  const wave_id = `pending-${repo.replace(/[^a-zA-Z0-9._-]/g, "-")}-${Date.now()}`;
+  const dispatch: Dispatch = {
+    repo,
+    event_type: "release-wave-flip",
+    client_payload: {
+      wave_id,
+      target_tag: record.tag,
+      head_sha: "",
+      previewed_version_id: record.version_id,
+      // handler が wave flip-report を skip するためのマーカー。
+      pending_release: true,
+    },
+  };
+
+  const results = await dispatchAll(env, [dispatch]);
+  const ok = results.length > 0 && results[0]!.ok;
+  if (ok) {
+    // dispatch が着火できたら record を消す (optimistic)。実 flip の成否は
+    // GitHub Actions 側で確認する。着火失敗時は record を残し再試行可能にする。
+    await clearPendingRelease(env.COMPAT_KV, repo);
+  } else {
+    const err = results.length > 0 && !results[0]!.ok ? results[0]!.error : "dispatch failed";
+    return jsonResponse(502, {
+      code: "DISPATCH_FAILED",
+      error: `failed to dispatch flip for ${repo}: ${err}`,
+    });
+  }
+  return redirectToList();
 }

--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -21,6 +21,10 @@ import {
   computeGlobalCompatibility,
   type WaveCompatibility,
 } from "./compat";
+import {
+  listPendingReleases,
+  type PendingReleaseRecord,
+} from "./pending-release";
 
 // ----------------------------------------------------------------------------
 // Small HTML helpers
@@ -168,6 +172,17 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
     buildActiveWaveInfo(waves),
   );
 
+  // 単独 v* リリースで upload された no-traffic version の一覧 (Refs #181)。
+  let pendingReleases: PendingReleaseRecord[] = [];
+  if (env.COMPAT_KV) {
+    try {
+      pendingReleases = await listPendingReleases(env.COMPAT_KV);
+    } catch {
+      pendingReleases = [];
+    }
+  }
+  const pendingReleaseSection = renderPendingReleaseSection(pendingReleases);
+
   const rows = waves.length === 0
     ? `<tr><td colspan="7" class="empty">No release waves yet.</td></tr>`
     : waves
@@ -228,6 +243,7 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
       <a href="https://github.com/ippoan/ci-dashboard/issues/137">#137</a>.
     </p>
     ${compatSection}
+    ${pendingReleaseSection}
     <table>
       <thead>
         <tr>
@@ -461,6 +477,73 @@ export async function handleReleaseWaveDetailPage(
 </html>`;
 
   return htmlResponse(html);
+}
+
+// ----------------------------------------------------------------------------
+// Pending releases section (Refs #181 / #174)
+// ----------------------------------------------------------------------------
+
+/**
+ * 単独 v* リリースで upload された no-traffic version の一覧 + Flip ボタン。
+ *
+ * frontend-ci の release deploy が `wrangler versions upload` した version を
+ * `pending-release::<repo>` として KV に持つ。各行の Flip ボタンは
+ * `/api/release-wave/pending-release/flip` に repo を POST し、handler 経由で
+ * `wrangler versions deploy <version_id>@100%` を発火する。
+ *
+ * record が無ければセクション自体は出すが「pending release はありません」を表示
+ * (= 「ここで単独リリースを flip できる」affordance を常設)。
+ */
+function renderPendingReleaseSection(records: PendingReleaseRecord[]): string {
+  const rows = records
+    .map((r) => {
+      const safe = safeHttpUrl(r.preview_url);
+      const previewCell = safe
+        ? `<a href="${escapeHtml(safe)}" target="_blank" rel="noopener noreferrer">preview</a>`
+        : `<span class="meta">—</span>`;
+      const shortVid =
+        r.version_id.length > 8 ? r.version_id.slice(0, 8) : r.version_id;
+      return `
+        <tr>
+          <td>${escapeHtml(r.repo)}</td>
+          <td class="meta">${escapeHtml(r.tag)}</td>
+          <td class="meta" title="${escapeHtml(r.version_id)}">${escapeHtml(shortVid)}…</td>
+          <td>${previewCell}</td>
+          <td class="meta">${escapeHtml(r.uploaded_at)}</td>
+          <td class="actions">
+            <form method="post" action="/api/release-wave/pending-release/flip" style="margin:0">
+              <input type="hidden" name="repo" value="${escapeHtml(r.repo)}">
+              <button type="submit"
+                title="Promote this no-traffic version to 100% (wrangler versions deploy ${escapeHtml(r.version_id)}@100%)">
+                Flip to 100%
+              </button>
+            </form>
+          </td>
+        </tr>`;
+    })
+    .join("");
+
+  const body = records.length > 0
+    ? `<table>
+        <thead>
+          <tr>
+            <th>Repo</th><th>Tag</th><th>Version</th><th>Preview</th>
+            <th>Uploaded</th><th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>`
+    : `<p class="meta">no-traffic でアップロード済みの単独リリースはありません。
+        v* tag を打つと frontend-ci がここに version を登録する。</p>`;
+
+  return `
+    <div class="section">
+      <h2>Pending releases (no-traffic)</h2>
+      <p class="meta">単独 <code>v*</code> リリースで <code>wrangler versions upload</code>
+        した no-traffic version。Flip で 100% traffic へ promote する。
+        Refs <a href="https://github.com/ippoan/ci-dashboard/issues/181">#181</a>.</p>
+      ${body}
+    </div>`;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/release-wave/pending-release.ts
+++ b/src/release-wave/pending-release.ts
@@ -1,0 +1,97 @@
+/**
+ * Pending release (no-traffic version) の KV 永続化。
+ *
+ * 設計の親 issue: ippoan/ci-dashboard#181 (Refs #174)
+ *
+ * frontend-ci.yml の release deploy が `wrangler versions upload` (no-traffic)
+ * した後、その version_id / tag / preview_url を
+ * `POST /webhooks/release-wave/pending-release` に報告する。ci-dashboard は
+ * `pending-release::<repo>` を COMPAT_KV に upsert し、/release-wave 一覧の
+ * 「Pending releases」セクションに出して Flip ボタンで 100% promote させる。
+ *
+ * release-wave (stage→approve→flip) とは独立した、単独 v* リリースの
+ * no-traffic version を flip する経路。
+ */
+
+const PENDING_RELEASE_PREFIX = "pending-release::";
+const SCHEMA_VERSION = 1 as const;
+
+/** no-traffic version の昇格待ち record。`repo` 単位で最新 1 件のみ保持。 */
+export interface PendingReleaseRecord {
+  schema_version: typeof SCHEMA_VERSION;
+  /** "owner/name"。 */
+  repo: string;
+  /** `wrangler versions upload` が返した version id (UUID)。flip 対象。 */
+  version_id: string;
+  /** リリース tag (e.g. v0.2.38)。表示 / compat current_image 用。 */
+  tag: string;
+  /** version preview URL (workers.dev)。無ければ null。 */
+  preview_url: string | null;
+  /** upload 報告を受けた UTC ISO。 */
+  uploaded_at: string;
+}
+
+function pendingReleaseKey(repo: string): string {
+  return `${PENDING_RELEASE_PREFIX}${repo}`;
+}
+
+/** upsert: repo ごとに最新 upload で上書きする (古い未 flip version は捨てる)。 */
+export async function recordPendingRelease(
+  kv: KVNamespace,
+  input: {
+    repo: string;
+    version_id: string;
+    tag: string;
+    preview_url?: string | null;
+    now: string;
+  },
+): Promise<PendingReleaseRecord> {
+  const record: PendingReleaseRecord = {
+    schema_version: SCHEMA_VERSION,
+    repo: input.repo,
+    version_id: input.version_id,
+    tag: input.tag,
+    preview_url: input.preview_url ?? null,
+    uploaded_at: input.now,
+  };
+  await kv.put(pendingReleaseKey(input.repo), JSON.stringify(record));
+  return record;
+}
+
+/** 単一 repo の pending release を取得 (無ければ null)。 */
+export async function getPendingRelease(
+  kv: KVNamespace,
+  repo: string,
+): Promise<PendingReleaseRecord | null> {
+  const v = await kv.get<PendingReleaseRecord>(pendingReleaseKey(repo), "json");
+  if (!v || v.schema_version !== SCHEMA_VERSION) return null;
+  return v;
+}
+
+/** 全 pending release を列挙 (uploaded_at 降順)。 */
+export async function listPendingReleases(
+  kv: KVNamespace,
+): Promise<PendingReleaseRecord[]> {
+  const out: PendingReleaseRecord[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await kv.list({ prefix: PENDING_RELEASE_PREFIX, cursor });
+    for (const key of page.keys) {
+      const rec = await kv.get<PendingReleaseRecord>(key.name, "json");
+      if (rec && rec.schema_version === SCHEMA_VERSION) {
+        out.push(rec);
+      }
+    }
+    cursor = page.list_complete ? undefined : page.cursor;
+  } while (cursor);
+  out.sort((a, b) => (a.uploaded_at < b.uploaded_at ? 1 : -1));
+  return out;
+}
+
+/** flip 完了後に record を消す。 */
+export async function clearPendingRelease(
+  kv: KVNamespace,
+  repo: string,
+): Promise<void> {
+  await kv.delete(pendingReleaseKey(repo));
+}

--- a/src/release-wave/webhook.ts
+++ b/src/release-wave/webhook.ts
@@ -23,6 +23,7 @@ import type { Env } from "../index";
 import type { ReleaseWaveHub, RpcResult } from "./do";
 import type { WaveState } from "./types";
 import { recordFrontendTest, recordBackendDeploy, getBackendCurrent } from "./compat";
+import { recordPendingRelease } from "./pending-release";
 
 // ----------------------------------------------------------------------------
 // Common helpers
@@ -319,6 +320,56 @@ export async function handleBackendDeployReportWebhook(
     current_image: v.data.current_image,
     deployed_by: v.data.deployed_by,
     wave_id: v.data.wave_id ?? null,
+    now: new Date().toISOString(),
+  });
+  return jsonResponse(200, { ok: true, record });
+}
+
+// ----------------------------------------------------------------------------
+// /webhooks/release-wave/pending-release  (Refs #181 / #174)
+// ----------------------------------------------------------------------------
+
+/**
+ * frontend-ci.yml の release deploy が `wrangler versions upload` (no-traffic)
+ * 後に打つ。ci-dashboard 側で `pending-release::<repo>` を upsert し、
+ * /release-wave 一覧の「Pending releases」セクションに出して Flip させる。
+ *
+ * best-effort 報告 (失敗してもリリースは止めない) なので、shared secret 認証は
+ * 他 webhook と同じだが、対応する wave は存在しない (= 単独 release)。
+ *
+ * body:
+ *   {
+ *     "repo": "ippoan/auth-worker",
+ *     "version_id": "530b908c-5385-451c-b163-747caaedafd3",  // wrangler version id (UUID)
+ *     "tag": "v0.2.38",
+ *     "preview_url": "https://<hash>-auth-worker.<sub>.workers.dev"   // optional
+ *   }
+ */
+const pendingReleaseSchema = z.object({
+  repo: z.string().min(1),
+  // version_id は wrangler の version id (UUID)。flip 時に
+  // `wrangler versions deploy <id>@100%` に渡るため UUID 形式を強制する。
+  version_id: z
+    .string()
+    .regex(
+      /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/,
+      "version_id must be a UUID",
+    ),
+  tag: z.string().min(1),
+  preview_url: z.string().url().optional(),
+});
+
+export async function handlePendingReleaseWebhook(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  const v = await validateAndAuth(request, env, pendingReleaseSchema);
+  if (!v.ok) return v.response;
+  const record = await recordPendingRelease(env.COMPAT_KV, {
+    repo: v.data.repo,
+    version_id: v.data.version_id,
+    tag: v.data.tag,
+    preview_url: v.data.preview_url ?? null,
     now: new Date().toISOString(),
   });
   return jsonResponse(200, { ok: true, record });

--- a/test/release-wave/api.test.ts
+++ b/test/release-wave/api.test.ts
@@ -4,7 +4,9 @@ import {
   handleReleaseWaveRollback,
   handleReleaseWaveAbort,
   handleReleaseWaveRetest,
+  handleReleaseWavePendingReleaseFlip,
 } from "../../src/release-wave/api";
+import { getPendingRelease } from "../../src/release-wave/pending-release";
 import type { Env } from "../../src/index";
 import type { ReleaseWaveHub } from "../../src/release-wave/do";
 
@@ -442,5 +444,109 @@ describe("handleReleaseWaveRetest", () => {
       String(c[0]).includes("/dispatches"),
     );
     expect(dispatchCall).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// /api/release-wave/pending-release/flip  (Refs #181 / #174)
+// ============================================================================
+
+const PENDING_VID = "530b908c-5385-451c-b163-747caaedafd3";
+
+function pendingFlipEnv(compatKv: KVNamespace): Env {
+  return {
+    RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({}) },
+    COMPAT_KV: compatKv,
+    CI_STATUS: memKv({ "auth-client-worker:gh-token": FRESH_TOKEN }),
+    INTERNAL_SHARED_SECRET: { get: async () => "secret" },
+  } as unknown as Env;
+}
+
+function pendingKv(): KVNamespace {
+  return memKv({
+    "pending-release::ippoan/auth-worker": {
+      schema_version: 1,
+      repo: "ippoan/auth-worker",
+      version_id: PENDING_VID,
+      tag: "v0.2.38",
+      preview_url: "https://abc-auth-worker.example.workers.dev",
+      uploaded_at: "2026-05-28T12:00:00Z",
+    },
+  });
+}
+
+describe("handleReleaseWavePendingReleaseFlip", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns 405 on GET", async () => {
+    const req = new Request(
+      "https://ci-dashboard.ippoan.org/api/release-wave/pending-release/flip",
+      { method: "GET" },
+    );
+    const resp = await handleReleaseWavePendingReleaseFlip(req, pendingFlipEnv(pendingKv()));
+    expect(resp.status).toBe(405);
+  });
+
+  it("returns 400 when repo form field missing", async () => {
+    const resp = await handleReleaseWavePendingReleaseFlip(
+      postRequest("/api/release-wave/pending-release/flip"),
+      pendingFlipEnv(pendingKv()),
+    );
+    expect(resp.status).toBe(400);
+  });
+
+  it("returns 404 when no pending release for repo", async () => {
+    const resp = await handleReleaseWavePendingReleaseFlip(
+      postRequest("/api/release-wave/pending-release/flip", {
+        formBody: { repo: "ippoan/no-such" },
+      }),
+      pendingFlipEnv(pendingKv()),
+    );
+    expect(resp.status).toBe(404);
+  });
+
+  it("dispatches release-wave-flip with previewed_version_id + pending_release marker, then clears record", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    const kv = pendingKv();
+    const resp = await handleReleaseWavePendingReleaseFlip(
+      postRequest("/api/release-wave/pending-release/flip", {
+        formBody: { repo: "ippoan/auth-worker" },
+      }),
+      pendingFlipEnv(kv),
+    );
+    expect(resp.status).toBe(303);
+    const dispatchCall = fetchSpy.mock.calls.find((c) =>
+      String(c[0]).includes("/repos/ippoan/auth-worker/dispatches"),
+    );
+    expect(dispatchCall).toBeDefined();
+    const body = JSON.parse(dispatchCall![1].body);
+    expect(body.event_type).toBe("release-wave-flip");
+    expect(body.client_payload).toMatchObject({
+      target_tag: "v0.2.38",
+      previewed_version_id: PENDING_VID,
+      pending_release: true,
+    });
+    // wave_id は synthetic で `/` を含まない (handler の形式検証を満たす)
+    expect(body.client_payload.wave_id).toMatch(/^[a-zA-Z0-9._-]{1,128}$/);
+    // dispatch 成功で record は消える
+    expect(await getPendingRelease(kv, "ippoan/auth-worker")).toBeNull();
+  });
+
+  it("keeps the record when dispatch fails", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response("boom", { status: 500 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    const kv = pendingKv();
+    const resp = await handleReleaseWavePendingReleaseFlip(
+      postRequest("/api/release-wave/pending-release/flip", {
+        formBody: { repo: "ippoan/auth-worker" },
+      }),
+      pendingFlipEnv(kv),
+    );
+    expect(resp.status).toBe(502);
+    // 着火失敗時は record を残す (operator が再試行可能)
+    expect(await getPendingRelease(kv, "ippoan/auth-worker")).not.toBeNull();
   });
 });

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -123,6 +123,38 @@ describe("handleReleaseWaveListPage", () => {
     expect(html).toContain("No release waves yet");
   });
 
+  it("shows the Pending releases section placeholder when none (Refs #181)", async () => {
+    const env = fakeEnv({ listReturn: [], compatKv: memKv() });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    expect(html).toContain("Pending releases (no-traffic)");
+    expect(html).toContain("単独");
+    expect(html).not.toContain("Flip to 100%");
+  });
+
+  it("lists a pending release with Flip button + preview link (Refs #181)", async () => {
+    const env = fakeEnv({
+      listReturn: [],
+      compatKv: memKv({
+        "pending-release::ippoan/auth-worker": {
+          schema_version: 1,
+          repo: "ippoan/auth-worker",
+          version_id: "530b908c-5385-451c-b163-747caaedafd3",
+          tag: "v0.2.38",
+          preview_url: "https://abc-auth-worker.example.workers.dev",
+          uploaded_at: "2026-05-28T12:00:00Z",
+        },
+      }),
+    });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    expect(html).toContain("ippoan/auth-worker");
+    expect(html).toContain("v0.2.38");
+    expect(html).toContain("Flip to 100%");
+    expect(html).toContain('action="/api/release-wave/pending-release/flip"');
+    expect(html).toContain('name="repo" value="ippoan/auth-worker"');
+    // safeHttpUrl は new URL().toString() で末尾スラッシュを正規化する
+    expect(html).toContain('href="https://abc-auth-worker.example.workers.dev/"');
+  });
+
   it("lists each wave with state badge + detail link", async () => {
     const env = fakeEnv({
       listReturn: [

--- a/test/release-wave/webhook.test.ts
+++ b/test/release-wave/webhook.test.ts
@@ -3,9 +3,37 @@ import {
   handleContractAppliedWebhook,
   handleStageReportWebhook,
   handleFlipReportWebhook,
+  handlePendingReleaseWebhook,
 } from "../../src/release-wave/webhook";
+import { getPendingRelease } from "../../src/release-wave/pending-release";
 import type { Env } from "../../src/index";
 import type { ReleaseWaveHub } from "../../src/release-wave/do";
+
+/** in-memory KVNamespace for COMPAT_KV-backed handlers. */
+function memKv(seed: Record<string, unknown> = {}): KVNamespace {
+  const store = new Map<string, string>(
+    Object.entries(seed).map(([k, v]) => [k, JSON.stringify(v)]),
+  );
+  return {
+    async get(key: string, type?: string) {
+      const raw = store.get(key);
+      if (raw === undefined) return null;
+      return type === "json" ? JSON.parse(raw) : raw;
+    },
+    async put(key: string, value: string) {
+      store.set(key, value);
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+    async list({ prefix = "" }: { prefix?: string } = {}) {
+      const keys = [...store.keys()]
+        .filter((k) => k.startsWith(prefix))
+        .map((name) => ({ name }));
+      return { keys, list_complete: true, cacheStatus: null };
+    },
+  } as unknown as KVNamespace;
+}
 
 // ----------------------------------------------------------------------------
 // Fake env / request builder (3 endpoint 共通)
@@ -28,6 +56,7 @@ function fakeEnv(opts: {
   flipReportReturn?:
     | { ok: true; data: unknown }
     | { ok: false; code: string; error: string };
+  compatKv?: KVNamespace;
 } = {}): { env: Env; spies: FakeSpies } {
   const okState = { wave_id: "w1", state: "staging" };
   const spies: FakeSpies = {
@@ -51,6 +80,7 @@ function fakeEnv(opts: {
       get: async () =>
         opts.secret === undefined ? "expected-secret" : opts.secret,
     },
+    COMPAT_KV: opts.compatKv,
   } as unknown as Env;
   return { env, spies };
 }
@@ -528,5 +558,84 @@ describe("handleFlipReportWebhook", () => {
       env,
     );
     expect(resp.status).toBe(409);
+  });
+});
+
+// ============================================================================
+// /webhooks/release-wave/pending-release  (Refs #181 / #174)
+// ============================================================================
+
+const PENDING_URL =
+  "https://ci-dashboard.ippoan.org/webhooks/release-wave/pending-release";
+const VALID_VID = "530b908c-5385-451c-b163-747caaedafd3";
+
+describe("handlePendingReleaseWebhook", () => {
+  it("stores a pending release record (ok=true)", async () => {
+    const kv = memKv();
+    const { env } = fakeEnv({ compatKv: kv });
+    const resp = await handlePendingReleaseWebhook(
+      jsonRequest({
+        url: PENDING_URL,
+        secret: "expected-secret",
+        body: {
+          repo: "ippoan/auth-worker",
+          version_id: VALID_VID,
+          tag: "v0.2.38",
+          preview_url: "https://abc-auth-worker.example.workers.dev",
+        },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(200);
+    const rec = await getPendingRelease(kv, "ippoan/auth-worker");
+    expect(rec).not.toBeNull();
+    expect(rec!.version_id).toBe(VALID_VID);
+    expect(rec!.tag).toBe("v0.2.38");
+    expect(rec!.preview_url).toBe("https://abc-auth-worker.example.workers.dev");
+  });
+
+  it("accepts missing preview_url (nullified)", async () => {
+    const kv = memKv();
+    const { env } = fakeEnv({ compatKv: kv });
+    const resp = await handlePendingReleaseWebhook(
+      jsonRequest({
+        url: PENDING_URL,
+        secret: "expected-secret",
+        body: { repo: "ippoan/auth-worker", version_id: VALID_VID, tag: "v1.0.0" },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(200);
+    const rec = await getPendingRelease(kv, "ippoan/auth-worker");
+    expect(rec!.preview_url).toBeNull();
+  });
+
+  it("rejects non-UUID version_id with 400", async () => {
+    const kv = memKv();
+    const { env } = fakeEnv({ compatKv: kv });
+    const resp = await handlePendingReleaseWebhook(
+      jsonRequest({
+        url: PENDING_URL,
+        secret: "expected-secret",
+        body: { repo: "ippoan/auth-worker", version_id: "not-a-uuid", tag: "v1.0.0" },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(400);
+    expect(await getPendingRelease(kv, "ippoan/auth-worker")).toBeNull();
+  });
+
+  it("rejects bad webhook secret with 401", async () => {
+    const kv = memKv();
+    const { env } = fakeEnv({ compatKv: kv });
+    const resp = await handlePendingReleaseWebhook(
+      jsonRequest({
+        url: PENDING_URL,
+        secret: "wrong-secret",
+        body: { repo: "ippoan/auth-worker", version_id: VALID_VID, tag: "v1.0.0" },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(401);
   });
 });


### PR DESCRIPTION
## Summary

ci-workflows#78 で全 frontend の `v*` リリースが no-traffic になったが、その
version を ci-dashboard 上で見て flip する surface が無かった。これを実装する
(release-wave を起こさない単独リリースの flip 経路)。Refs #174。

### 変更 (ci-dashboard)

- **`src/release-wave/pending-release.ts`** (新規): `pending-release::<repo>` の
  KV record (`version_id` / `tag` / `preview_url` / `uploaded_at`) を
  record / get / list / clear。
- **webhook.ts**: `POST /webhooks/release-wave/pending-release` を追加。
  frontend-ci の release deploy が `wrangler versions upload` 後に報告する。
  `version_id` は UUID 形式を zod で強制 (flip 時に `wrangler versions deploy
  <id>@100%` に渡るため)。shared secret 認証。
- **api.ts**: `POST /api/release-wave/pending-release/flip` を追加。form の `repo`
  の pending record を引いて `release-wave-flip` dispatch を発火
  (`previewed_version_id` + `pending_release: true` マーカー + synthetic wave_id)。
  dispatch 成功で record を clear、着火失敗時は残して再試行可能に。
- **page.ts**: `/release-wave` 一覧に「**Pending releases (no-traffic)**」
  section + 各行の **Flip to 100%** ボタン。preview link は http/https のみ。
  record 無しでも placeholder を常設。
- **index.ts**: 2 route を wire (webhook + flip API)。

### handler 側 (対の PR)

ci-workflows の **#__CIW_PR__**:
- frontend-ci.yml が no-traffic upload 後に version_id/preview を本 webhook へ report
- release-wave-handler.yml が `pending_release: true` の flip で wave callback を skip

## フロー

```
v* tag → frontend-ci (versions upload, no-traffic) → /webhooks/.../pending-release
  → /release-wave に "Pending releases" として出る
  → Flip to 100% ボタン → release-wave-flip dispatch → handler が
     wrangler versions deploy <id>@100% → 本番反映
```

## Test plan

- [x] `npx tsc --noEmit` green
- [x] `vitest run test/release-wave` 223 tests green (webhook 4 + api 5 + page 2 新規)
  - webhook: 保存 / preview 省略 / 非 UUID 400 / bad secret 401
  - api flip: 405 / repo 無し 400 / record 無し 404 / dispatch (payload + record clear) / dispatch 失敗時 record 保持
  - page: section placeholder / Flip ボタン + preview link
- [ ] 実 v* リリースで pending 登録 → Flip → 本番反映 (E2E、対の handler PR merge 後)

Refs #181

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nz1uWLW1CdqFuazF2Th4nW)_