### PR TITLE
feat(mcp): add delete_issue tool to issues MCP surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ src/
 | `remove_label` | issues | write | Remove a single label from an issue or PR. |
 | `close_issue` | issues | write | Close an issue with optional `state_reason`. |
 | `reopen_issue` | issues | write | Reopen a closed issue. |
+| `delete_issue` | issues | write | Permanently delete an issue (irreversible; GraphQL `deleteIssue`). |
 | `get_job_logs` | logs | read | Get logs for a workflow job (tail or line range). |
 | `grep_job_logs` | logs | read | Search job logs with regex pattern. |
 | `list_pull_requests` | pulls | read | List pull requests for a repository. |

--- a/src/mcp/tools/issues.ts
+++ b/src/mcp/tools/issues.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { githubApi, parseRepo, tokenForOrg, validateOrg, AUTH_WORKER_ORIGIN } from "../../github-api";
+import { githubApi, githubGraphQL, parseRepo, tokenForOrg, validateOrg, AUTH_WORKER_ORIGIN } from "../../github-api";
 import { getGitHubToken, type AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
 
 /** Build the PATCH body for `update_issue` from optional fields. Strips
@@ -336,6 +336,53 @@ export function registerIssuesTools(server: McpServer, env: AuthClientWorkerEnv)
   );
 
   server.registerTool(
+    "delete_issue",
+    {
+      description:
+        "Permanently delete an issue. This is irreversible — the issue and its " +
+        "comments are removed and cannot be recovered. For normal workflows " +
+        "prefer close_issue. Requires admin/maintainer permission on the repo. " +
+        "(GitHub REST has no delete endpoint, so the GraphQL `deleteIssue` " +
+        "mutation is used.)",
+      inputSchema: {
+        repo: z.string().describe("Repository (e.g. 'rust-alc-api')"),
+        issue_number: z.number().describe("Issue number"),
+      },
+      annotations: { destructiveHint: true },
+    },
+    async ({ repo, issue_number }) => {
+      const { owner, repo: name } = parseRepo(repo);
+      const token = await tokenForOrg(env, owner);
+
+      // REST exposes no DELETE for issues; resolve the GraphQL node id first,
+      // then invoke the `deleteIssue` mutation with it.
+      const issue = await githubApi<Issue & { node_id: string }>(
+        token, "GET", `/repos/${owner}/${name}/issues/${issue_number}`,
+      );
+
+      const data = await githubGraphQL<{
+        deleteIssue: { repository: { nameWithOwner: string } | null } | null;
+      }>(
+        token,
+        `mutation($issueId: ID!) {
+          deleteIssue(input: { issueId: $issueId }) {
+            repository { nameWithOwner }
+          }
+        }`,
+        { issueId: issue.node_id },
+      );
+
+      const result = {
+        deleted: true,
+        number: issue_number,
+        repo: data.deleteIssue?.repository?.nameWithOwner ?? `${owner}/${name}`,
+      };
+
+      return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
+    },
+  );
+
+  server.registerTool(
     "list_org_issues",
     {
       description:
@@ -489,6 +536,7 @@ interface SearchIssueItem {
 
 interface Issue {
   number: number;
+  node_id?: string;
   title: string;
   state: string;
   user: { login: string };

--- a/test/mcp/tools.test.ts
+++ b/test/mcp/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { githubApi, githubApiRaw, parseRepo, validateOrg, GitHubApiError } from "../../src/github-api";
+import { githubApi, githubApiRaw, githubGraphQL, parseRepo, validateOrg, GitHubApiError } from "../../src/github-api";
 import { buildUpdateIssuePayload, fetchOrgIssues } from "../../src/mcp/tools/issues";
 import { appTestEnv } from "../_helpers/app-env";
 
@@ -468,6 +468,66 @@ describe("Issues write tool logic", () => {
     const body = JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string);
     expect(body.state).toBe("open");
     expect(body.state_reason).toBeUndefined();
+  });
+
+  it("delete_issue resolves node_id via REST then calls the deleteIssue mutation", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    // 1) REST GET resolves the GraphQL node id
+    fetchSpy.mockResolvedValueOnce(
+      Response.json({
+        number: 99,
+        node_id: "I_kwDONODE99",
+        title: "spam issue",
+        state: "open",
+        html_url: "https://github.com/ippoan/ci-dashboard/issues/99",
+      }),
+    );
+    // 2) GraphQL deleteIssue mutation
+    fetchSpy.mockResolvedValueOnce(
+      Response.json({
+        data: { deleteIssue: { repository: { nameWithOwner: "ippoan/ci-dashboard" } } },
+      }),
+    );
+
+    const { owner, repo } = parseRepo("ci-dashboard");
+    validateOrg(owner);
+    const issue = await githubApi<{ node_id: string }>(
+      "token", "GET", `/repos/${owner}/${repo}/issues/99`,
+    );
+    const data = await githubGraphQL<{
+      deleteIssue: { repository: { nameWithOwner: string } | null } | null;
+    }>(
+      "token",
+      `mutation($issueId: ID!) {
+        deleteIssue(input: { issueId: $issueId }) {
+          repository { nameWithOwner }
+        }
+      }`,
+      { issueId: issue.node_id },
+    );
+
+    // GraphQL hits the /graphql endpoint with the resolved node id in variables
+    const gqlUrl = fetchSpy.mock.calls[1]![0] as string;
+    expect(gqlUrl).toContain("/graphql");
+    const gqlBody = JSON.parse(fetchSpy.mock.calls[1]![1]!.body as string);
+    expect(gqlBody.variables.issueId).toBe("I_kwDONODE99");
+    expect(data.deleteIssue?.repository?.nameWithOwner).toBe("ippoan/ci-dashboard");
+  });
+
+  it("delete_issue surfaces GraphQL errors (e.g. insufficient permission)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({
+        errors: [{ message: "Must have admin access to delete an issue" }],
+      }),
+    );
+
+    await expect(
+      githubGraphQL(
+        "token",
+        `mutation($issueId: ID!) { deleteIssue(input: { issueId: $issueId }) { clientMutationId } }`,
+        { issueId: "I_kwDONODE99" },
+      ),
+    ).rejects.toThrow(GitHubApiError);
   });
 });
 


### PR DESCRIPTION
## 概要

ci-dashboard MCP の issue ツール群に削除操作 `delete_issue` を追加した。

`create_issue` (作成) / `update_issue` (修正) は既に存在していたため、CRUD のうち
不足していた **削除** のみを補完する形。

## なぜ GraphQL なのか

GitHub REST API には issue を削除するエンドポイントが存在しない。そのため
REST `GET /repos/{owner}/{name}/issues/{number}` で GraphQL の `node_id` を解決し、
`deleteIssue` mutation を呼び出す方式にした（`githubGraphQL` ヘルパーは Projects v2
ツールで既に使われている既存基盤）。

## 安全側の配慮

- `delete_issue` は不可逆 (issue 本体とコメントが完全削除され復元不可)。
  通常フローでは `close_issue` を使うよう description に明記。
- repo に対する admin/maintainer 権限が必要。
- `annotations: { destructiveHint: true }` を付与。

## 変更点

- `src/mcp/tools/issues.ts`: `delete_issue` tool 追加 / `githubGraphQL` import / `Issue.node_id` 追加
- `test/mcp/tools.test.ts`: 正常系 (node_id 解決 → mutation 呼び出し) と権限不足時の GraphQL error 系のテスト
- `README.md`: tool 一覧表に `delete_issue` を追記

## 補足

この CCoW コンテナでは private package `@ippoan/auth-client-worker` (GitHub Packages)
を認証無しで install できず、ローカルでの `tsc --noEmit` / `vitest` は未実行。
CI 側で auth 付きの検証に委ねる。

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnSNeX6FGAxgdTpmLaDbTm)_