### PR TITLE
feat(release-wave): repo の tag 状況を可視化し直接 Tag Release できるようにする

### DIFF
--- a/docs/release-wave.md
+++ b/docs/release-wave.md
@@ -257,3 +257,25 @@ caller repo (e.g. `rust-alc-api`) の migration deploy workflow に以下 step �
 | 通知 webhook が 401 | secret 不一致 / 古い rotation 値 | secrets-rotate-pipe で 3 所同期再投入 |
 | preview-*.ippoan.org が 403 | CF Access policy 未追加 / email allowlist 外 | 本ドキュメントの "preview-* wildcard" セクション参照 |
 | flip 後 rollback が refuse | contract migration 適用済 | Admin UI の警告を確認、必要なら force 押下 (DB 手動復旧前提) |
+
+## Repo リリース状況 / 直接 Tag Release (Refs #137)
+
+`/release-wave` ページ上部の「Repo リリース状況」セクションで、監視対象 repo の
+tag 状況を一覧する。
+
+- **tag あり / なしを明示**: 最新 tag を緑 badge、未tag (= main しか無い repo) を
+  赤 badge で表示。行頭の左帯色でも状態が分かる (緑 = 最新 / 黄 = 要リリース /
+  赤 = 未tag / 灰 = tagless・取得失敗)。
+- 上部サマリに「未tag N / 要リリース N / 最新 N / tagless N」を表示。
+- **直接 Tag Release**: 未tag、または tag が default branch から離れている
+  (commits 未リリース) repo には `Tag Release` ボタンが出る。押すと
+  `POST /api/release-wave/tag-release` 経由で各 repo の `tag-release.yml`
+  workflow を `main` で `workflow_dispatch` する (tag 採番 + GitHub Release 作成は
+  workflow 側に委譲)。`/release-wave` は strict CSP (JS 無効) のため、素の
+  `<form method="post">` + Post/Redirect/Get (303 → `/release-wave`) で動く。
+- `TAGLESS_REPOS` 指定 repo は `tagless` 表示でボタンを出さない
+  (merge into default branch が release event 扱いのため)。
+
+repo 一覧の出所は `/releases` と同じ 3 ソース (Hub status / direct-push
+allowlist / `TAGLESS_REPOS`)。tag / compare / repo-meta の GitHub 呼び出しは
+release-cache の KV キャッシュ層を共用する。

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ import { handleReleaseCloseBatch } from "./release-close-batch";
 import { handleRecheck } from "./recheck";
 import { handleSecretGenPage } from "./secret-gen-page";
 import { handleTagRelease } from "./tag-release";
+import { handleReleaseWaveTagRelease } from "./release-wave/tag-release-action";
+import { handleReleaseWaveListPageWithRepoStatus } from "./release-wave/repo-status-section";
 import { handleMcpRequest } from "./mcp/server";
 import {
   handleContractAppliedWebhook,
@@ -31,7 +33,6 @@ import {
   handleBackendCurrentImage,
 } from "./release-wave/compat-api";
 import {
-  handleReleaseWaveListPage,
   handleReleaseWaveDetailPage,
 } from "./release-wave/page";
 import {
@@ -173,6 +174,11 @@ app.get("/snapshot", async (c) => {
 
 // Tag release
 app.post("/api/tag-release", (c) => handleTagRelease(c.req.raw, c.env));
+// Release Wave ページ (strict CSP / JS 無効) からの form-POST 用。dispatch 後
+// 303 で /release-wave へ戻す。
+app.post("/api/release-wave/tag-release", (c) =>
+  handleReleaseWaveTagRelease(c.req.raw, c.env),
+);
 
 // Recheck
 app.post("/api/recheck", (c) => handleRecheck(c.req.raw, c.env, getHub(c.env)));
@@ -248,7 +254,7 @@ app.get("/backend-current-image", (c) =>
 // Release Wave admin UI (Refs #137 Phase 3e)。
 // Auth は ci-dashboard 全体に被さる Cloudflare Access (Google OAuth + email
 // allowlist) edge gate に委譲。/releases ページと同じトラストモデル。
-app.get("/release-wave", (c) => handleReleaseWaveListPage(c.env));
+app.get("/release-wave", (c) => handleReleaseWaveListPageWithRepoStatus(c.env));
 app.get("/release-wave/:wave_id", (c) =>
   handleReleaseWaveDetailPage(c.env, c.req.param("wave_id")),
 );

--- a/src/release-wave/repo-release-status.ts
+++ b/src/release-wave/repo-release-status.ts
@@ -1,0 +1,129 @@
+/**
+ * 監視対象 repo の「リリース状況」算出 (Release Wave ページの Repo 状況 section 用)。
+ *
+ * 各 repo について以下を求める:
+ *   - latestTag    : 最新 semver tag (無ければ null = 未tag)
+ *   - hasTag       : tag が 1 つでもあるか
+ *   - behind       : 最新 tag から default branch HEAD までの commit 数
+ *                    (= まだ release されていない変更量)。-1 は取得失敗。
+ *   - tagless      : TAGLESS_REPOS 指定の repo か (tag を打たない方針)
+ *
+ * repo 一覧の出所は /releases ページと同じ 3 ソース (Hub status / direct-push
+ * allowlist / TAGLESS_REPOS)。tag / compare / repo-meta の GitHub 呼び出しは
+ * release-cache の KV キャッシュ層を共用するので /releases と同じ rcache: entry を
+ * 再利用する (二重 fetch にならない)。
+ */
+
+import type { Env } from "../index";
+import { parseRepo, tokenForOrg } from "../github-api";
+import { cachedTags, cachedCompare, cachedRepoMeta } from "../release-cache";
+import { loadDirectPushAllowlist } from "../direct-push-allowlist";
+import { parseTaglessRepos } from "../tagless-repos";
+import { sortSemverDesc } from "../release-helpers";
+
+export interface RepoReleaseStatus {
+  repo: string;
+  latestTag: string | null;
+  /** tag が 1 つでも存在するか (false = 未tag = main しか無い)。 */
+  hasTag: boolean;
+  /** 最新 tag から default branch HEAD までの commit 数。-1 = 取得失敗。 */
+  behind: number;
+  /** TAGLESS_REPOS 指定 (tag を打たない方針の repo)。 */
+  tagless: boolean;
+}
+
+/** 監視対象 repo の集合と tagless set を /releases と同じ 3 ソースから組む。 */
+async function discoverRepos(
+  env: Env,
+): Promise<{ repos: string[]; tagless: Set<string> }> {
+  const watched = new Set<string>();
+
+  // (a) Hub status cache — これまで CI run を 1 度でも起こした repo。
+  try {
+    const hubId = env.CI_HUB.idFromName("singleton");
+    const hub = env.CI_HUB.get(hubId);
+    const res = await hub.fetch(new Request("http://hub/statuses"));
+    if (res.ok) {
+      const statuses = await res.json<Array<{ repo: string }>>();
+      for (const s of statuses) watched.add(s.repo);
+    }
+  } catch {
+    // Hub 不在 → 他ソースに委ねる
+  }
+
+  // (b) direct-push-OK allowlist。
+  try {
+    for (const r of await loadDirectPushAllowlist(env, env.CI_STATUS)) {
+      watched.add(r);
+    }
+  } catch {
+    // allowlist 取得失敗 → 既存挙動を壊さず空のまま
+  }
+
+  // (c) TAGLESS_REPOS wrangler var。
+  const tagless = parseTaglessRepos(env.TAGLESS_REPOS);
+  for (const r of tagless) watched.add(r);
+
+  return { repos: [...watched].sort(), tagless };
+}
+
+/** 1 repo のリリース状況を算出。archived repo は null (= 一覧から除外)。 */
+async function computeOne(
+  env: Env,
+  repo: string,
+  taglessSet: Set<string>,
+): Promise<RepoReleaseStatus | null> {
+  const { owner, repo: name } = parseRepo(repo);
+  const full = `${owner}/${name}`;
+  const tagless = taglessSet.has(repo) || taglessSet.has(full);
+
+  let token: string;
+  try {
+    token = await tokenForOrg(env, owner);
+  } catch {
+    return { repo: full, latestTag: null, hasTag: false, behind: -1, tagless };
+  }
+
+  // archived repo は /releases と同様に一覧から外す (release も cut されない)。
+  try {
+    const meta = await cachedRepoMeta(token, env.CI_STATUS, owner, name);
+    if (meta.archived === true) return null;
+
+    const tags = await cachedTags(token, env.CI_STATUS, owner, name, 10);
+    const sorted = sortSemverDesc(tags.map((t) => t.name));
+    const latestTag = sorted[0] ?? null;
+    if (!latestTag) {
+      return { repo: full, latestTag: null, hasTag: false, behind: 0, tagless };
+    }
+
+    // 最新 tag → default branch の compare で未 release commit 数を数える。
+    let behind = 0;
+    try {
+      const cmp = await cachedCompare(
+        token,
+        env.CI_STATUS,
+        owner,
+        name,
+        latestTag,
+        meta.default_branch,
+      );
+      behind = cmp.commits.length;
+    } catch {
+      behind = 0; // compare 失敗時は behind 不明 → 0 扱い (release は促さない)
+    }
+    return { repo: full, latestTag, hasTag: true, behind, tagless };
+  } catch {
+    return { repo: full, latestTag: null, hasTag: false, behind: -1, tagless };
+  }
+}
+
+/** 全監視対象 repo のリリース状況を repo 名昇順で返す。 */
+export async function getRepoReleaseStatuses(
+  env: Env,
+): Promise<RepoReleaseStatus[]> {
+  const { repos, tagless } = await discoverRepos(env);
+  const results = await Promise.all(
+    repos.map((r) => computeOne(env, r, tagless)),
+  );
+  return results.filter((r): r is RepoReleaseStatus => r !== null);
+}

--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -1,0 +1,171 @@
+/**
+ * Release Wave 一覧ページに「Repo リリース状況」セクションを足す薄い wrapper。
+ *
+ * 監視対象 repo の tag 有無 (tag あり / 未tag) と main HEAD からの乖離を一覧し、
+ * 未tag (main しか無い) repo や tag が離れた repo を直接 Tag Release できる
+ * ボタンを出す (tag 採番は各 repo の tag-release.yml workflow 側)。
+ *
+ * page.ts の template を直接いじらず、レンダリング済み HTML に section を string
+ * 注入する構成にしている。これは:
+ *   - page.ts が CSP header と COMMON_STYLES (badge / actions 等) を所有しており、
+ *     同じページに足せば追加 CSS / header 変更が不要なため。
+ *   - section は strict CSP (`default-src 'none'`, JS 無効) でも動くよう、素の
+ *     <form method="post"> + inline style だけで構成する (page.ts の他 action と同じ)。
+ */
+
+import type { Env } from "../index";
+import { handleReleaseWaveListPage } from "./page";
+import {
+  getRepoReleaseStatuses,
+  type RepoReleaseStatus,
+} from "./repo-release-status";
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+/** release を促すべき repo か (未tag、または tag が main から離れている)。 */
+export function needsRelease(s: RepoReleaseStatus): boolean {
+  if (s.behind < 0) return false; // 取得失敗
+  if (s.tagless) return false; // tag を打たない方針の repo
+  if (!s.hasTag) return true; // 未tag = main しか無い
+  return s.behind > 0; // tag が main から離れている
+}
+
+const GREEN = "#188038";
+const RED = "#d93025";
+const AMBER = "#f29900";
+const GRAY = "#9aa0a6";
+const DARKGRAY = "#5f6368";
+
+/** 監視対象 repo の tag 状況テーブル + サマリを HTML で返す。 */
+export function renderRepoReleaseStatusSection(
+  statuses: RepoReleaseStatus[],
+): string {
+  const counts = { untagged: 0, behind: 0, uptodate: 0, tagless: 0, error: 0 };
+  for (const s of statuses) {
+    if (s.behind < 0) counts.error++;
+    else if (s.tagless) counts.tagless++;
+    else if (!s.hasTag) counts.untagged++;
+    else if (s.behind > 0) counts.behind++;
+    else counts.uptodate++;
+  }
+
+  const chip = (label: string, color: string): string =>
+    `<span class="badge" style="background:${color};margin-right:6px">${escapeHtml(label)}</span>`;
+  const summary = [
+    counts.untagged ? chip(`未tag ${counts.untagged}`, RED) : "",
+    counts.behind ? chip(`要リリース ${counts.behind}`, AMBER) : "",
+    counts.uptodate ? chip(`最新 ${counts.uptodate}`, GREEN) : "",
+    counts.tagless ? chip(`tagless ${counts.tagless}`, GRAY) : "",
+    counts.error ? chip(`error ${counts.error}`, DARKGRAY) : "",
+  ].join("");
+
+  const rows = statuses
+    .map((s) => {
+      // tag badge: tag あり=緑(タグ名) / 未tag=赤 / tagless=灰。
+      const tagBadge = s.tagless
+        ? `<span class="badge" style="background:${GRAY}">tagless</span>`
+        : s.hasTag
+          ? `<span class="badge" style="background:${GREEN}">${escapeHtml(s.latestTag ?? "")}</span>`
+          : `<span class="badge" style="background:${RED}">未tag</span>`;
+
+      // 状況セル + 行頭の左帯色で一目で分かるように。
+      let statusCell: string;
+      let border: string;
+      if (s.behind < 0) {
+        statusCell = `<span class="err">取得失敗</span>`;
+        border = GRAY;
+      } else if (s.tagless) {
+        statusCell = `<span class="meta">tag を打たない repo (merge into default = release)</span>`;
+        border = GRAY;
+      } else if (!s.hasTag) {
+        statusCell = `<span class="err">未リリース (tag 無し / main のみ)</span>`;
+        border = RED;
+      } else if (s.behind > 0) {
+        statusCell = `<span style="color:#b06000">${s.behind} commits 未リリース</span>`;
+        border = AMBER;
+      } else {
+        statusCell = `<span class="ok">最新</span>`;
+        border = GREEN;
+      }
+
+      const action = needsRelease(s)
+        ? `<form method="post" action="/api/release-wave/tag-release" style="margin:0">
+             <input type="hidden" name="repo" value="${escapeHtml(s.repo)}">
+             <button type="submit" title="tag-release.yml workflow を main で dispatch する">Tag Release</button>
+           </form>`
+        : `<span class="meta">—</span>`;
+
+      return `
+        <tr>
+          <td style="border-left:4px solid ${border};padding-left:8px">${escapeHtml(s.repo)}</td>
+          <td>${tagBadge}</td>
+          <td>${statusCell}</td>
+          <td class="actions">${action}</td>
+        </tr>`;
+    })
+    .join("");
+
+  const tableOrEmpty =
+    statuses.length === 0
+      ? `<p class="meta">監視対象 repo がありません。</p>`
+      : `<table>
+          <thead>
+            <tr><th>Repo</th><th>Latest Tag</th><th>状況</th><th>Action</th></tr>
+          </thead>
+          <tbody>${rows}</tbody>
+        </table>`;
+
+  return `
+    <div class="section">
+      <h2>Repo リリース状況</h2>
+      <p class="meta">監視対象 repo の tag 有無と main HEAD からの乖離。
+        <span class="badge" style="background:${GREEN}">緑 = tag あり</span>
+        <span class="badge" style="background:${RED}">赤 = 未tag</span>
+        の repo を直接 Tag Release できる (tag 採番は各 repo の tag-release.yml)。</p>
+      <div style="margin:8px 0">${summary}</div>
+      ${tableOrEmpty}
+    </div>`;
+}
+
+/** レンダリング済み一覧 HTML に section を注入する (h1 直後、無ければ </body> 直前)。 */
+export function injectRepoStatusSection(html: string, section: string): string {
+  const marker = "<h1>Release Waves</h1>";
+  const i = html.indexOf(marker);
+  if (i === -1) {
+    return html.replace("</body>", `${section}\n</body>`);
+  }
+  const at = i + marker.length;
+  return html.slice(0, at) + "\n    " + section + html.slice(at);
+}
+
+/**
+ * GET /release-wave: 既存の一覧ページ + Repo リリース状況 section。
+ *
+ * CI_STATUS 未 bind (一部 unit test) や release-status 取得失敗時は、元の一覧を
+ * そのまま返す (section だけ落として degrade)。
+ */
+export async function handleReleaseWaveListPageWithRepoStatus(
+  env: Env,
+): Promise<Response> {
+  const res = await handleReleaseWaveListPage(env);
+  if (!env.CI_STATUS) return res;
+
+  let statuses: RepoReleaseStatus[];
+  try {
+    statuses = await getRepoReleaseStatuses(env);
+  } catch {
+    return res;
+  }
+
+  const section = renderRepoReleaseStatusSection(statuses);
+  const html = await res.text();
+  const injected = injectRepoStatusSection(html, section);
+  return new Response(injected, { status: res.status, headers: res.headers });
+}

--- a/src/release-wave/tag-release-action.ts
+++ b/src/release-wave/tag-release-action.ts
@@ -1,0 +1,62 @@
+/**
+ * Release Wave ページの「Tag Release」ボタン (form-POST) を受ける handler。
+ *
+ * /release-wave ページは strict CSP (`default-src 'none'`, script 無効) なので、
+ * /releases ページのような JS fetch は使えない。代わりに素の <form method="post">
+ * から叩き、Post/Redirect/Get で 303 redirect して一覧に戻す。
+ *
+ * tag 採番は各 repo の tag-release.yml workflow 側で行う (dispatchTagRelease は
+ * dispatch するだけ)。
+ */
+
+import type { Env } from "../index";
+import { dispatchTagRelease } from "../tag-release";
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+/** POST /api/release-wave/tag-release  (form field `repo`)。 */
+export async function handleReleaseWaveTagRelease(
+  req: Request,
+  env: Env,
+): Promise<Response> {
+  let repo: string | null = null;
+  const ct = req.headers.get("content-type") ?? "";
+  if (ct.includes("application/x-www-form-urlencoded")) {
+    const body = await req.text();
+    repo = new URLSearchParams(body).get("repo");
+  } else {
+    // JSON でも一応受ける (curl / test 用)。
+    try {
+      const j = await req.json<{ repo?: string }>();
+      repo = j.repo ?? null;
+    } catch {
+      repo = null;
+    }
+  }
+
+  const result = await dispatchTagRelease(env, repo ?? "");
+  if (!result.ok) {
+    const html = `<!doctype html><html lang="ja"><head><meta charset="utf-8">
+<title>Tag release failed</title></head><body>
+<p>tag-release failed: ${escapeHtml(result.error ?? "unknown error")}</p>
+<p><a href="/release-wave">&larr; Release Wave に戻る</a></p>
+</body></html>`;
+    return new Response(html, {
+      status: result.status,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  }
+
+  // PRG: reload で再 dispatch されないよう 303 で一覧へ戻す。
+  return new Response(null, {
+    status: 303,
+    headers: { Location: "/release-wave" },
+  });
+}

--- a/src/tag-release.ts
+++ b/src/tag-release.ts
@@ -1,25 +1,38 @@
 import type { Env } from "./index";
 import { tokenForOrg } from "./github-api";
 
-export async function handleTagRelease(
-  request: Request,
-  env: Env,
-): Promise<Response> {
-  const { repo } = await request.json<{ repo: string }>();
+export interface TagReleaseResult {
+  ok: boolean;
+  /** ok=false のとき HTTP status のヒント (400 / 403 / 502)。 */
+  status: number;
+  error?: string;
+}
 
+/**
+ * repo の `tag-release.yml` workflow を main 上で dispatch する。
+ *
+ * tag 採番 + GitHub Release 作成は各 repo の workflow 側に任せる
+ * (semver bump ロジックを ci-dashboard に持たない設計)。JSON API (/releases)
+ * と form-POST (/release-wave) の両経路から共有するため、純粋に dispatch の
+ * 成否だけを返す薄い関数として切り出す。
+ */
+export async function dispatchTagRelease(
+  env: Env,
+  repo: string,
+): Promise<TagReleaseResult> {
   if (!repo) {
-    return Response.json({ error: "Missing repo" }, { status: 400 });
+    return { ok: false, status: 400, error: "Missing repo" };
   }
   const [owner] = repo.split("/", 1);
   if (!owner) {
-    return Response.json({ error: "Bad repo" }, { status: 400 });
+    return { ok: false, status: 400, error: "Bad repo" };
   }
   let token: string;
   try {
     token = await tokenForOrg(env, owner);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    return Response.json({ error: msg }, { status: 403 });
+    return { ok: false, status: 403, error: msg };
   }
 
   const res = await fetch(
@@ -37,11 +50,21 @@ export async function handleTagRelease(
 
   if (!res.ok) {
     const text = await res.text();
-    return Response.json(
-      { error: `GitHub API ${res.status}: ${text}` },
-      { status: 502 },
-    );
+    return { ok: false, status: 502, error: `GitHub API ${res.status}: ${text}` };
   }
 
+  return { ok: true, status: 200 };
+}
+
+/** JSON API: POST /api/tag-release (/releases ページの JS fetch から)。 */
+export async function handleTagRelease(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  const { repo } = await request.json<{ repo: string }>();
+  const result = await dispatchTagRelease(env, repo);
+  if (!result.ok) {
+    return Response.json({ error: result.error }, { status: result.status });
+  }
   return Response.json({ ok: true, repo });
 }

--- a/test/release-wave/repo-status-section.test.ts
+++ b/test/release-wave/repo-status-section.test.ts
@@ -59,7 +59,9 @@ describe("renderRepoReleaseStatusSection", () => {
     ]);
     expect(html).toContain("v2.1.0");
     expect(html).toContain("最新");
-    expect(html).not.toContain("Tag Release");
+    // legend には "直接 Tag Release できる" の文言があるので、ボタンの有無は
+    // form の action (= 実際の発火経路) で判定する。
+    expect(html).not.toContain('action="/api/release-wave/tag-release"');
   });
 
   it("shows behind repo as 要リリース summary + button", () => {
@@ -76,7 +78,7 @@ describe("renderRepoReleaseStatusSection", () => {
       status({ repo: "ippoan/ci-dashboard", tagless: true }),
     ]);
     expect(html).toContain("tagless");
-    expect(html).not.toContain("Tag Release");
+    expect(html).not.toContain('action="/api/release-wave/tag-release"');
   });
 
   it("shows errored repo as 取得失敗 with no button", () => {
@@ -85,7 +87,7 @@ describe("renderRepoReleaseStatusSection", () => {
     ]);
     expect(html).toContain("取得失敗");
     expect(html).toContain("error 1");
-    expect(html).not.toContain("Tag Release");
+    expect(html).not.toContain('action="/api/release-wave/tag-release"');
   });
 
   it("escapes repo names", () => {

--- a/test/release-wave/repo-status-section.test.ts
+++ b/test/release-wave/repo-status-section.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import {
+  needsRelease,
+  renderRepoReleaseStatusSection,
+  injectRepoStatusSection,
+  handleReleaseWaveListPageWithRepoStatus,
+} from "../../src/release-wave/repo-status-section";
+import type { RepoReleaseStatus } from "../../src/release-wave/repo-release-status";
+import type { Env } from "../../src/index";
+
+function status(p: Partial<RepoReleaseStatus>): RepoReleaseStatus {
+  return {
+    repo: "ippoan/x",
+    latestTag: null,
+    behind: 0,
+    hasTag: false,
+    tagless: false,
+    ...p,
+  };
+}
+
+describe("needsRelease", () => {
+  it("untagged (main only) repo needs release", () => {
+    expect(needsRelease(status({ hasTag: false }))).toBe(true);
+  });
+  it("tagged repo behind main needs release", () => {
+    expect(
+      needsRelease(status({ hasTag: true, latestTag: "v1.0.0", behind: 3 })),
+    ).toBe(true);
+  });
+  it("tagged + up to date does not", () => {
+    expect(
+      needsRelease(status({ hasTag: true, latestTag: "v1.0.0", behind: 0 })),
+    ).toBe(false);
+  });
+  it("tagless repo never needs release", () => {
+    expect(needsRelease(status({ hasTag: false, tagless: true }))).toBe(false);
+  });
+  it("errored repo (behind<0) does not", () => {
+    expect(needsRelease(status({ behind: -1 }))).toBe(false);
+  });
+});
+
+describe("renderRepoReleaseStatusSection", () => {
+  it("shows untagged repo as 未tag with a Tag Release button", () => {
+    const html = renderRepoReleaseStatusSection([
+      status({ repo: "ippoan/foo", hasTag: false }),
+    ]);
+    expect(html).toContain("未tag");
+    expect(html).toContain("Tag Release");
+    expect(html).toContain('name="repo" value="ippoan/foo"');
+    expect(html).toContain('action="/api/release-wave/tag-release"');
+    expect(html).toContain("未tag 1");
+  });
+
+  it("shows tagged + up-to-date repo with the tag and no button", () => {
+    const html = renderRepoReleaseStatusSection([
+      status({ repo: "ippoan/bar", hasTag: true, latestTag: "v2.1.0", behind: 0 }),
+    ]);
+    expect(html).toContain("v2.1.0");
+    expect(html).toContain("最新");
+    expect(html).not.toContain("Tag Release");
+  });
+
+  it("shows behind repo as 要リリース summary + button", () => {
+    const html = renderRepoReleaseStatusSection([
+      status({ repo: "ippoan/baz", hasTag: true, latestTag: "v1.0.0", behind: 5 }),
+    ]);
+    expect(html).toContain("5 commits 未リリース");
+    expect(html).toContain("要リリース 1");
+    expect(html).toContain("Tag Release");
+  });
+
+  it("marks tagless repos and does not offer a button", () => {
+    const html = renderRepoReleaseStatusSection([
+      status({ repo: "ippoan/ci-dashboard", tagless: true }),
+    ]);
+    expect(html).toContain("tagless");
+    expect(html).not.toContain("Tag Release");
+  });
+
+  it("shows errored repo as 取得失敗 with no button", () => {
+    const html = renderRepoReleaseStatusSection([
+      status({ repo: "ippoan/err", behind: -1 }),
+    ]);
+    expect(html).toContain("取得失敗");
+    expect(html).toContain("error 1");
+    expect(html).not.toContain("Tag Release");
+  });
+
+  it("escapes repo names", () => {
+    const html = renderRepoReleaseStatusSection([
+      status({ repo: 'a/<b>"&', hasTag: false }),
+    ]);
+    expect(html).not.toContain("<b>");
+    expect(html).toContain("&lt;b&gt;");
+  });
+
+  it("handles empty repo list", () => {
+    const html = renderRepoReleaseStatusSection([]);
+    expect(html).toContain("監視対象 repo がありません");
+  });
+});
+
+describe("injectRepoStatusSection", () => {
+  it("inserts the section right after the h1", () => {
+    const out = injectRepoStatusSection(
+      "<body><h1>Release Waves</h1><table></table></body>",
+      "<div>SECTION</div>",
+    );
+    expect(out).toContain("<h1>Release Waves</h1>\n    <div>SECTION</div>");
+  });
+
+  it("falls back to before </body> when the h1 marker is missing", () => {
+    const out = injectRepoStatusSection("<body>hi</body>", "<div>SECTION</div>");
+    expect(out).toContain("<div>SECTION</div>\n</body>");
+  });
+});
+
+describe("handleReleaseWaveListPageWithRepoStatus", () => {
+  function baseEnv(): Env {
+    return {
+      RELEASE_WAVE_HUB: {
+        idFromName: () => ({}),
+        get: () => ({ list: async () => [] }),
+      },
+      CI_HUB: {
+        idFromName: () => ({}),
+        get: () => ({
+          // empty Hub status list — no repos discovered from this source
+          fetch: async () =>
+            new Response("[]", {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }),
+        }),
+      },
+      COMPAT_KV: undefined,
+    } as unknown as Env;
+  }
+
+  /** in-memory KV (allowlist / token lookups miss → discovery yields []). */
+  function memKv(): KVNamespace {
+    const store = new Map<string, string>();
+    return {
+      async get(key: string, type?: string) {
+        const raw = store.get(key);
+        if (raw === undefined) return null;
+        return type === "json" ? JSON.parse(raw) : raw;
+      },
+      async put(key: string, value: string) {
+        store.set(key, value);
+      },
+      async delete(key: string) {
+        store.delete(key);
+      },
+      async list({ prefix = "" }: { prefix?: string } = {}) {
+        const keys = [...store.keys()]
+          .filter((k) => k.startsWith(prefix))
+          .map((name) => ({ name }));
+        return { keys, list_complete: true, cacheStatus: null };
+      },
+    } as unknown as KVNamespace;
+  }
+
+  it("passes the page through unchanged when CI_STATUS is unbound", async () => {
+    const res = await handleReleaseWaveListPageWithRepoStatus(baseEnv());
+    const html = await res.text();
+    expect(res.status).toBe(200);
+    expect(html).toContain("Release Waves");
+    expect(html).not.toContain("Repo リリース状況");
+  });
+
+  it("injects the repo status section when CI_STATUS is bound", async () => {
+    const env = { ...baseEnv(), CI_STATUS: memKv() } as unknown as Env;
+    const res = await handleReleaseWaveListPageWithRepoStatus(env);
+    const html = await res.text();
+    expect(res.status).toBe(200);
+    expect(html).toContain("Repo リリース状況");
+    // no repos discoverable in the test env → empty-list copy
+    expect(html).toContain("監視対象 repo がありません");
+    // CSP header from the original page is preserved through injection.
+    expect(res.headers.get("Content-Security-Policy")).toContain(
+      "default-src 'none'",
+    );
+  });
+});


### PR DESCRIPTION
## 概要

`/release-wave` ページで、**未tag (= main しか無い)** repo や **tag が default branch から離れている** repo を一目で見分けられるようにし、その場から直接 Tag Release を発火できるようにした。

## 変更点

### 新規: Repo リリース状況セクション
ページ上部に「Repo リリース状況」セクションを追加 (`src/release-wave/repo-status-section.ts`)。

- **tag あり / なしを明示**: 最新 tag を緑 badge、未tag を赤 badge で表示。行頭の左帯色でも状態が分かる (緑 = 最新 / 黄 = 要リリース / 赤 = 未tag / 灰 = tagless・取得失敗)。
- 上部サマリに「未tag N / 要リリース N / 最新 N / tagless N / error N」を表示。
- **要リリースの repo に `Tag Release` ボタン**を出す (未tag、または tag が default branch から離れている repo)。
- `TAGLESS_REPOS` 指定 repo は `tagless` 表示にしてボタンを出さない (merge into default branch が release event 扱いのため)。

### repo 状況の算出 (`src/release-wave/repo-release-status.ts`)
監視対象 repo を `/releases` と同じ 3 ソース (Hub status / direct-push allowlist / `TAGLESS_REPOS`) から集め、各 repo の `latestTag` / `hasTag` / `behind` (最新 tag → default branch HEAD の commit 数) / `tagless` を算出。tag / compare / repo-meta の GitHub 呼び出しは release-cache の KV キャッシュ層を共用するので二重 fetch にならない。archived repo は除外。

### Tag Release 発火
- `src/tag-release.ts`: dispatch ロジックを `dispatchTagRelease()` に切り出し、既存の JSON API (`POST /api/tag-release`) と新 form-POST 経路で共有。tag 採番 + GitHub Release 作成は各 repo の `tag-release.yml` workflow に委譲 (`workflow_dispatch` on `main`)。
- `src/release-wave/tag-release-action.ts`: `/release-wave` は strict CSP (JS 無効) のため、素の `<form method="post">` を受ける handler。dispatch 後は Post/Redirect/Get で 303 → `/release-wave` に戻す。
- `src/index.ts`: `GET /release-wave` を repo 状況付き wrapper (`handleReleaseWaveListPageWithRepoStatus`) に差し替え、`POST /api/release-wave/tag-release` route を追加。

### 設計メモ
既存の `page.ts` (CSP header と共通 style を所有) は変更せず、レンダリング済み HTML に section を string 注入する wrapper 構成にした。CI_STATUS 未 bind / 取得失敗時は section を落として元の一覧をそのまま返す (graceful degrade)。

## テスト
- `test/release-wave/repo-status-section.test.ts` を追加 (pure render / needsRelease / inject / wrapper handler)。
- `npm run typecheck` ✅
- `npm test` ✅ (全 suite green)

Refs #137

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACYyQmmaf7LZH7XJYPEEBo)_