### PR TITLE
feat(release-wave): Repo リリース状況を Compatibility の下に移動し tagless を除外

### DIFF
--- a/docs/release-wave.md
+++ b/docs/release-wave.md
@@ -275,6 +275,10 @@ caller repo (e.g. `rust-alc-api`) の migration deploy workflow に以下 step �
   `<form method="post">` + Post/Redirect/Get (303 → `/release-wave`) で動く。
 - `TAGLESS_REPOS` 指定 repo は **一覧から除外する** (merge into default branch が
   release event 扱いで、そもそもリリース対象ではないため)。
+- **Compatibility グラフ内 repo の Tag Release**: Compatibility (all consumers)
+  グラフの直下に、グラフに出ている repo (backend + 既 deploy frontend) の
+  `Tag Release: <repo>` ボタンを並べる。グラフを見ながらその場でリリースを発火
+  できる (tagless repo は除外)。発火経路は上記 Tag Release と同じ。
 
 repo 一覧の出所は `/releases` と同じ 3 ソース (Hub status / direct-push
 allowlist / `TAGLESS_REPOS`)。tag / compare / repo-meta の GitHub 呼び出しは

--- a/docs/release-wave.md
+++ b/docs/release-wave.md
@@ -260,21 +260,21 @@ caller repo (e.g. `rust-alc-api`) の migration deploy workflow に以下 step �
 
 ## Repo リリース状況 / 直接 Tag Release (Refs #137)
 
-`/release-wave` ページ上部の「Repo リリース状況」セクションで、監視対象 repo の
-tag 状況を一覧する。
+`/release-wave` ページの **Compatibility (all consumers) セクションの下**に
+「Repo リリース状況」セクションがあり、監視対象 repo の tag 状況を一覧する。
 
 - **tag あり / なしを明示**: 最新 tag を緑 badge、未tag (= main しか無い repo) を
   赤 badge で表示。行頭の左帯色でも状態が分かる (緑 = 最新 / 黄 = 要リリース /
-  赤 = 未tag / 灰 = tagless・取得失敗)。
-- 上部サマリに「未tag N / 要リリース N / 最新 N / tagless N」を表示。
+  赤 = 未tag / 灰 = 取得失敗)。
+- 上部サマリに「未tag N / 要リリース N / 最新 N」を表示。
 - **直接 Tag Release**: 未tag、または tag が default branch から離れている
   (commits 未リリース) repo には `Tag Release` ボタンが出る。押すと
   `POST /api/release-wave/tag-release` 経由で各 repo の `tag-release.yml`
   workflow を `main` で `workflow_dispatch` する (tag 採番 + GitHub Release 作成は
   workflow 側に委譲)。`/release-wave` は strict CSP (JS 無効) のため、素の
   `<form method="post">` + Post/Redirect/Get (303 → `/release-wave`) で動く。
-- `TAGLESS_REPOS` 指定 repo は `tagless` 表示でボタンを出さない
-  (merge into default branch が release event 扱いのため)。
+- `TAGLESS_REPOS` 指定 repo は **一覧から除外する** (merge into default branch が
+  release event 扱いで、そもそもリリース対象ではないため)。
 
 repo 一覧の出所は `/releases` と同じ 3 ソース (Hub status / direct-push
 allowlist / `TAGLESS_REPOS`)。tag / compare / repo-meta の GitHub 呼び出しは

--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -22,6 +22,8 @@ import {
   getRepoReleaseStatuses,
   type RepoReleaseStatus,
 } from "./repo-release-status";
+import { computeGlobalCompatibility } from "./compat";
+import { parseTaglessRepos } from "../tagless-repos";
 
 function escapeHtml(s: string): string {
   return s
@@ -161,10 +163,59 @@ export function injectRepoStatusSection(html: string, section: string): string {
 }
 
 /**
- * GET /release-wave: 既存の一覧ページ + Repo リリース状況 section。
+ * Compatibility (all consumers) グラフに出ている repo (backend + frontend) の
+ * Tag Release ボタン群を HTML で返す。tagless repo は除外。1 つも無ければ ""。
+ *
+ * グラフ内の repo をその場でリリースしたい、という要望 (ここにボタン欲しい) に
+ * 応えるための block。グラフ直下に注入する (injectCompatTagReleaseButtons)。
+ */
+export function renderCompatTagReleaseButtons(
+  repos: Iterable<string>,
+  tagless: Set<string>,
+): string {
+  const list = [...new Set(repos)].filter((r) => !tagless.has(r)).sort();
+  if (list.length === 0) return "";
+  const buttons = list
+    .map(
+      (r) => `
+        <form method="post" action="/api/release-wave/tag-release" style="margin:0 6px 6px 0;display:inline-block">
+          <input type="hidden" name="repo" value="${escapeHtml(r)}">
+          <button type="submit" title="${escapeHtml(r)} の tag-release.yml workflow を main で dispatch する">Tag Release: ${escapeHtml(r)}</button>
+        </form>`,
+    )
+    .join("");
+  return `
+    <div class="actions" style="margin-top:10px">
+      <strong class="meta">Tag Release (compatibility graph の repo)</strong>
+      <div style="margin-top:6px">${buttons}</div>
+    </div>`;
+}
+
+/**
+ * Compatibility グラフ直下 (= "Staged previews (active waves)" block の直前) に
+ * Tag Release ボタン block を注入する。アンカー (グラフの overlay) が無い
+ * (compat 未記録) 場合や block 空のときは html をそのまま返す。
+ */
+export function injectCompatTagReleaseButtons(
+  html: string,
+  block: string,
+): string {
+  if (!block) return html;
+  const marker = "Staged previews (active waves)";
+  const m = html.indexOf(marker);
+  if (m === -1) return html;
+  const divStart = html.lastIndexOf('<div style="margin-top:10px">', m);
+  if (divStart === -1) return html;
+  return html.slice(0, divStart) + block + "\n      " + html.slice(divStart);
+}
+
+/**
+ * GET /release-wave: 既存の一覧ページ + Repo リリース状況 section
+ * + Compatibility グラフ内 repo の Tag Release ボタン。
  *
  * CI_STATUS 未 bind (一部 unit test) や release-status 取得失敗時は、元の一覧を
- * そのまま返す (section だけ落として degrade)。
+ * そのまま返す (section だけ落として degrade)。COMPAT_KV 未 bind / 取得失敗時は
+ * compat ボタンだけ落とす。
  */
 export async function handleReleaseWaveListPageWithRepoStatus(
   env: Env,
@@ -180,7 +231,25 @@ export async function handleReleaseWaveListPageWithRepoStatus(
   }
 
   const section = renderRepoReleaseStatusSection(statuses);
-  const html = await res.text();
-  const injected = injectRepoStatusSection(html, section);
-  return new Response(injected, { status: res.status, headers: res.headers });
+  let html = await res.text();
+  html = injectRepoStatusSection(html, section);
+
+  // Compatibility (all consumers) グラフ内 repo に Tag Release ボタンを足す。
+  if (env.COMPAT_KV) {
+    try {
+      const compat = await computeGlobalCompatibility(env.COMPAT_KV);
+      const repos = new Set<string>();
+      for (const b of compat.backends) {
+        repos.add(b.backend_repo);
+        for (const m of b.matrix) repos.add(m.frontend);
+      }
+      const tagless = parseTaglessRepos(env.TAGLESS_REPOS);
+      const buttons = renderCompatTagReleaseButtons(repos, tagless);
+      html = injectCompatTagReleaseButtons(html, buttons);
+    } catch {
+      // compat 取得失敗時はボタンだけ落とす
+    }
+  }
+
+  return new Response(html, { status: res.status, headers: res.headers });
 }

--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -5,8 +5,11 @@
  * 未tag (main しか無い) repo や tag が離れた repo を直接 Tag Release できる
  * ボタンを出す (tag 採番は各 repo の tag-release.yml workflow 側)。
  *
- * page.ts の template を直接いじらず、レンダリング済み HTML に section を string
- * 注入する構成にしている。これは:
+ * tagless repo (TAGLESS_REPOS) は「リリース対象」ではないので一覧から除外する。
+ *
+ * 配置: page.ts の template を直接いじらず、レンダリング済み HTML の
+ * Compatibility section 直後 (= Pending releases section の直前) に string 注入
+ * する。これは:
  *   - page.ts が CSP header と COMMON_STYLES (badge / actions 等) を所有しており、
  *     同じページに足せば追加 CSS / header 変更が不要なため。
  *   - section は strict CSP (`default-src 'none'`, JS 無効) でも動くよう、素の
@@ -43,14 +46,16 @@ const AMBER = "#f29900";
 const GRAY = "#9aa0a6";
 const DARKGRAY = "#5f6368";
 
-/** 監視対象 repo の tag 状況テーブル + サマリを HTML で返す。 */
+/** 監視対象 repo の tag 状況テーブル + サマリを HTML で返す (tagless は除外)。 */
 export function renderRepoReleaseStatusSection(
   statuses: RepoReleaseStatus[],
 ): string {
-  const counts = { untagged: 0, behind: 0, uptodate: 0, tagless: 0, error: 0 };
-  for (const s of statuses) {
+  // tagless repo はリリース対象ではないので一覧から除外する。
+  const visible = statuses.filter((s) => !s.tagless);
+
+  const counts = { untagged: 0, behind: 0, uptodate: 0, error: 0 };
+  for (const s of visible) {
     if (s.behind < 0) counts.error++;
-    else if (s.tagless) counts.tagless++;
     else if (!s.hasTag) counts.untagged++;
     else if (s.behind > 0) counts.behind++;
     else counts.uptodate++;
@@ -62,27 +67,21 @@ export function renderRepoReleaseStatusSection(
     counts.untagged ? chip(`未tag ${counts.untagged}`, RED) : "",
     counts.behind ? chip(`要リリース ${counts.behind}`, AMBER) : "",
     counts.uptodate ? chip(`最新 ${counts.uptodate}`, GREEN) : "",
-    counts.tagless ? chip(`tagless ${counts.tagless}`, GRAY) : "",
     counts.error ? chip(`error ${counts.error}`, DARKGRAY) : "",
   ].join("");
 
-  const rows = statuses
+  const rows = visible
     .map((s) => {
-      // tag badge: tag あり=緑(タグ名) / 未tag=赤 / tagless=灰。
-      const tagBadge = s.tagless
-        ? `<span class="badge" style="background:${GRAY}">tagless</span>`
-        : s.hasTag
-          ? `<span class="badge" style="background:${GREEN}">${escapeHtml(s.latestTag ?? "")}</span>`
-          : `<span class="badge" style="background:${RED}">未tag</span>`;
+      // tag badge: tag あり=緑(タグ名) / 未tag=赤。
+      const tagBadge = s.hasTag
+        ? `<span class="badge" style="background:${GREEN}">${escapeHtml(s.latestTag ?? "")}</span>`
+        : `<span class="badge" style="background:${RED}">未tag</span>`;
 
       // 状況セル + 行頭の左帯色で一目で分かるように。
       let statusCell: string;
       let border: string;
       if (s.behind < 0) {
         statusCell = `<span class="err">取得失敗</span>`;
-        border = GRAY;
-      } else if (s.tagless) {
-        statusCell = `<span class="meta">tag を打たない repo (merge into default = release)</span>`;
         border = GRAY;
       } else if (!s.hasTag) {
         statusCell = `<span class="err">未リリース (tag 無し / main のみ)</span>`;
@@ -113,8 +112,8 @@ export function renderRepoReleaseStatusSection(
     .join("");
 
   const tableOrEmpty =
-    statuses.length === 0
-      ? `<p class="meta">監視対象 repo がありません。</p>`
+    visible.length === 0
+      ? `<p class="meta">リリース対象の repo はありません。</p>`
       : `<table>
           <thead>
             <tr><th>Repo</th><th>Latest Tag</th><th>状況</th><th>Action</th></tr>
@@ -125,7 +124,7 @@ export function renderRepoReleaseStatusSection(
   return `
     <div class="section">
       <h2>Repo リリース状況</h2>
-      <p class="meta">監視対象 repo の tag 有無と main HEAD からの乖離。
+      <p class="meta">監視対象 repo の tag 有無と main HEAD からの乖離 (tagless repo は除外)。
         <span class="badge" style="background:${GREEN}">緑 = tag あり</span>
         <span class="badge" style="background:${RED}">赤 = 未tag</span>
         の repo を直接 Tag Release できる (tag 採番は各 repo の tag-release.yml)。</p>
@@ -134,15 +133,31 @@ export function renderRepoReleaseStatusSection(
     </div>`;
 }
 
-/** レンダリング済み一覧 HTML に section を注入する (h1 直後、無ければ </body> 直前)。 */
+/**
+ * レンダリング済み一覧 HTML に section を注入する。
+ *
+ * 配置優先順:
+ *   1. Compatibility section の直後 (= Pending releases section の <div> 直前)
+ *   2. h1 (`Release Waves`) 直後
+ *   3. </body> 直前
+ */
 export function injectRepoStatusSection(html: string, section: string): string {
-  const marker = "<h1>Release Waves</h1>";
-  const i = html.indexOf(marker);
-  if (i === -1) {
-    return html.replace("</body>", `${section}\n</body>`);
+  // Pending releases section を起点に、その section の開始 <div> 直前へ入れる。
+  // = Compatibility (all consumers) section の直後。
+  const pending = html.indexOf("<h2>Pending releases");
+  if (pending !== -1) {
+    const divStart = html.lastIndexOf('<div class="section">', pending);
+    if (divStart !== -1) {
+      return html.slice(0, divStart) + section + "\n    " + html.slice(divStart);
+    }
   }
-  const at = i + marker.length;
-  return html.slice(0, at) + "\n    " + section + html.slice(at);
+  const h1Marker = "<h1>Release Waves</h1>";
+  const h1 = html.indexOf(h1Marker);
+  if (h1 !== -1) {
+    const at = h1 + h1Marker.length;
+    return html.slice(0, at) + "\n    " + section + html.slice(at);
+  }
+  return html.replace("</body>", `${section}\n</body>`);
 }
 
 /**

--- a/test/release-wave/repo-status-section.test.ts
+++ b/test/release-wave/repo-status-section.test.ts
@@ -3,6 +3,8 @@ import {
   needsRelease,
   renderRepoReleaseStatusSection,
   injectRepoStatusSection,
+  renderCompatTagReleaseButtons,
+  injectCompatTagReleaseButtons,
   handleReleaseWaveListPageWithRepoStatus,
 } from "../../src/release-wave/repo-status-section";
 import type { RepoReleaseStatus } from "../../src/release-wave/repo-release-status";
@@ -137,6 +139,70 @@ describe("injectRepoStatusSection", () => {
   it("falls back to before </body> when no markers are present", () => {
     const out = injectRepoStatusSection("<body>hi</body>", "<div>SECTION</div>");
     expect(out).toContain("<div>SECTION</div>\n</body>");
+  });
+});
+
+describe("renderCompatTagReleaseButtons", () => {
+  it("renders one Tag Release button per repo, excluding tagless", () => {
+    const html = renderCompatTagReleaseButtons(
+      ["ippoan/rust-alc-api", "ippoan/auth-worker", "ippoan/ci-dashboard"],
+      new Set(["ippoan/ci-dashboard"]),
+    );
+    expect(html).toContain("Tag Release: ippoan/rust-alc-api");
+    expect(html).toContain("Tag Release: ippoan/auth-worker");
+    expect(html).not.toContain("ippoan/ci-dashboard");
+    expect(html).toContain('action="/api/release-wave/tag-release"');
+    expect(html).toContain('name="repo" value="ippoan/auth-worker"');
+  });
+
+  it("dedupes repos", () => {
+    const html = renderCompatTagReleaseButtons(
+      ["ippoan/a", "ippoan/a", "ippoan/b"],
+      new Set(),
+    );
+    expect(html.match(/Tag Release: ippoan\/a/g)?.length).toBe(1);
+  });
+
+  it("returns empty string when every repo is tagless", () => {
+    const html = renderCompatTagReleaseButtons(
+      ["ippoan/ci-dashboard"],
+      new Set(["ippoan/ci-dashboard"]),
+    );
+    expect(html).toBe("");
+  });
+
+  it("returns empty string for an empty repo set", () => {
+    expect(renderCompatTagReleaseButtons([], new Set())).toBe("");
+  });
+
+  it("escapes repo names", () => {
+    const html = renderCompatTagReleaseButtons(['a/<b>"&'], new Set());
+    expect(html).not.toContain("<b>");
+    expect(html).toContain("&lt;b&gt;");
+  });
+});
+
+describe("injectCompatTagReleaseButtons", () => {
+  const overlay =
+    'graph</svg></div>\n    <div style="margin-top:10px">\n      <strong class="meta">Staged previews (active waves)</strong></div>';
+
+  it("inserts the buttons right before the Staged previews block", () => {
+    const out = injectCompatTagReleaseButtons(overlay, "<!--BTN-->");
+    expect(out).toContain("<!--BTN-->");
+    expect(out.indexOf("<!--BTN-->")).toBeLessThan(
+      out.indexOf("Staged previews (active waves)"),
+    );
+    // graph (= svg) は ボタンより前
+    expect(out.indexOf("</svg>")).toBeLessThan(out.indexOf("<!--BTN-->"));
+  });
+
+  it("returns html unchanged when the block is empty", () => {
+    expect(injectCompatTagReleaseButtons(overlay, "")).toBe(overlay);
+  });
+
+  it("returns html unchanged when the overlay anchor is missing", () => {
+    const html = "<div>no compat overlay here</div>";
+    expect(injectCompatTagReleaseButtons(html, "<!--BTN-->")).toBe(html);
   });
 });
 

--- a/test/release-wave/repo-status-section.test.ts
+++ b/test/release-wave/repo-status-section.test.ts
@@ -229,8 +229,10 @@ describe("handleReleaseWaveListPageWithRepoStatus", () => {
   }
 
   /** in-memory KV (allowlist / token lookups miss → discovery yields []). */
-  function memKv(): KVNamespace {
-    const store = new Map<string, string>();
+  function memKv(seed: Record<string, unknown> = {}): KVNamespace {
+    const store = new Map<string, string>(
+      Object.entries(seed).map(([k, v]) => [k, JSON.stringify(v)]),
+    );
     return {
       async get(key: string, type?: string) {
         const raw = store.get(key);

--- a/test/release-wave/repo-status-section.test.ts
+++ b/test/release-wave/repo-status-section.test.ts
@@ -262,17 +262,66 @@ describe("handleReleaseWaveListPageWithRepoStatus", () => {
     expect(html).not.toContain("Repo リリース状況");
   });
 
-  it("injects the repo status section when CI_STATUS is bound", async () => {
-    const env = { ...baseEnv(), CI_STATUS: memKv() } as unknown as Env;
+  it("injects the repo status section between Compatibility and Pending releases", async () => {
+    // backend:: record を 1 件入れて Compatibility (all consumers) section を
+    // 実際にレンダリングさせる (record が無いと俯瞰グラフ section の verdict 付き
+    // 見出しは出ない)。
+    const compatKv = memKv({
+      "backend::ippoan/rust-alc-api": {
+        schema_version: 1,
+        repo: "ippoan/rust-alc-api",
+        current_image: "sha-abc123",
+        deployed_at: "2026-05-29T00:00:00Z",
+        deployed_by: "ci",
+        wave_id: null,
+      },
+    });
+    const env = {
+      ...baseEnv(),
+      CI_STATUS: memKv(),
+      COMPAT_KV: compatKv,
+    } as unknown as Env;
     const res = await handleReleaseWaveListPageWithRepoStatus(env);
     const html = await res.text();
     expect(res.status).toBe(200);
-    expect(html).toContain("Repo リリース状況");
-    // no repos discoverable in the test env → empty-list copy
-    expect(html).toContain("監視対象 repo がありません");
-    // CSP header from the original page is preserved through injection.
+
+    const compatIdx = html.indexOf("Compatibility (all consumers)");
+    const repoIdx = html.indexOf("Repo リリース状況");
+    const pendingIdx = html.indexOf("Pending releases");
+    expect(compatIdx).toBeGreaterThanOrEqual(0);
+    expect(repoIdx).toBeGreaterThanOrEqual(0);
+    expect(pendingIdx).toBeGreaterThanOrEqual(0);
+    // Compatibility の下、Pending releases の上に置かれる。
+    expect(compatIdx).toBeLessThan(repoIdx);
+    expect(repoIdx).toBeLessThan(pendingIdx);
+    // discovery では repo が見つからないので空一覧コピー。
+    expect(html).toContain("リリース対象の repo はありません");
+
+    // CSP header は injection 後も維持される。
     expect(res.headers.get("Content-Security-Policy")).toContain(
       "default-src 'none'",
     );
+  });
+
+  it("adds a Tag Release button for repos in the compatibility graph", async () => {
+    const compatKv = memKv({
+      "backend::ippoan/rust-alc-api": {
+        schema_version: 1,
+        repo: "ippoan/rust-alc-api",
+        current_image: "sha-abc123",
+        deployed_at: "2026-05-29T00:00:00Z",
+        deployed_by: "ci",
+        wave_id: null,
+      },
+    });
+    const env = {
+      ...baseEnv(),
+      CI_STATUS: memKv(),
+      COMPAT_KV: compatKv,
+    } as unknown as Env;
+    const res = await handleReleaseWaveListPageWithRepoStatus(env);
+    const html = await res.text();
+    expect(html).toContain("Tag Release: ippoan/rust-alc-api");
+    expect(html).toContain('name="repo" value="ippoan/rust-alc-api"');
   });
 });

--- a/test/release-wave/repo-status-section.test.ts
+++ b/test/release-wave/repo-status-section.test.ts
@@ -73,12 +73,24 @@ describe("renderRepoReleaseStatusSection", () => {
     expect(html).toContain("Tag Release");
   });
 
-  it("marks tagless repos and does not offer a button", () => {
+  it("filters out tagless repos entirely", () => {
     const html = renderRepoReleaseStatusSection([
       status({ repo: "ippoan/ci-dashboard", tagless: true }),
     ]);
-    expect(html).toContain("tagless");
+    expect(html).not.toContain("ippoan/ci-dashboard");
     expect(html).not.toContain('action="/api/release-wave/tag-release"');
+    // 全部 tagless なら一覧は空扱い
+    expect(html).toContain("リリース対象の repo はありません");
+  });
+
+  it("keeps non-tagless repos while dropping tagless ones in a mixed list", () => {
+    const html = renderRepoReleaseStatusSection([
+      status({ repo: "ippoan/keep", hasTag: false }),
+      status({ repo: "ippoan/drop", tagless: true }),
+    ]);
+    expect(html).toContain("ippoan/keep");
+    expect(html).not.toContain("ippoan/drop");
+    expect(html).toContain("未tag 1");
   });
 
   it("shows errored repo as 取得失敗 with no button", () => {
@@ -100,12 +112,21 @@ describe("renderRepoReleaseStatusSection", () => {
 
   it("handles empty repo list", () => {
     const html = renderRepoReleaseStatusSection([]);
-    expect(html).toContain("監視対象 repo がありません");
+    expect(html).toContain("リリース対象の repo はありません");
   });
 });
 
 describe("injectRepoStatusSection", () => {
-  it("inserts the section right after the h1", () => {
+  it("inserts the section below Compatibility (just before the Pending releases section)", () => {
+    const html =
+      '<div class="section"><h2>Compatibility (all consumers)</h2></div>' +
+      '<div class="section">\n      <h2>Pending releases (no-traffic)</h2></div>';
+    const out = injectRepoStatusSection(html, "<!--RS-->");
+    expect(out.indexOf("Compatibility")).toBeLessThan(out.indexOf("<!--RS-->"));
+    expect(out.indexOf("<!--RS-->")).toBeLessThan(out.indexOf("Pending releases"));
+  });
+
+  it("falls back to after the h1 when the Pending section is missing", () => {
     const out = injectRepoStatusSection(
       "<body><h1>Release Waves</h1><table></table></body>",
       "<div>SECTION</div>",
@@ -113,7 +134,7 @@ describe("injectRepoStatusSection", () => {
     expect(out).toContain("<h1>Release Waves</h1>\n    <div>SECTION</div>");
   });
 
-  it("falls back to before </body> when the h1 marker is missing", () => {
+  it("falls back to before </body> when no markers are present", () => {
     const out = injectRepoStatusSection("<body>hi</body>", "<div>SECTION</div>");
     expect(out).toContain("<div>SECTION</div>\n</body>");
   });


### PR DESCRIPTION
## 概要

`/release-wave` の「Repo リリース状況」セクションについて、要望どおり 3 点を変更した。

## 変更点

### 1. 配置を Compatibility の下に移動
「Repo リリース状況」section を h1 直後ではなく、**Compatibility (all consumers) セクションの直後**（Pending releases の手前）に表示するようにした。`injectRepoStatusSection` を Pending releases section の `<div class="section">` 起点で挿入する方式に変更（マーカーが無い場合は h1 直後 → `</body>` 直前に fallback）。

### 2. tagless repo を一覧から除外
`TAGLESS_REPOS` 指定の repo はそもそもリリース対象ではない（merge into default branch が release event 扱い）ため、テーブルから `filter` で除外。サマリの `tagless` チップ・tag badge / 状況セルの tagless 分岐も削除。全件 tagless / 空のときのコピーを「リリース対象の repo はありません」に変更。

### 3. tagless に 3 repo 追加
`wrangler.jsonc` の `TAGLESS_REPOS` に以下を追加:
- `yhonda-ohishi/claude-hooks`
- `yhonda-ohishi/claude-skills`
- `ippoan/ci-workflows`

## テスト
- `test/release-wave/repo-status-section.test.ts` を新仕様に追従（tagless 除外 / 配置 / mixed list）。
- `npm run typecheck` ✅
- `npm test` (該当 + page) ✅ 52 passed

Refs #137

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACYyQmmaf7LZH7XJYPEEBo)_