### PR TITLE
feat(release-wave): 最新 repo の compat Tag Release ボタンを inactive 化

### DIFF
--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -162,27 +162,47 @@ export function injectRepoStatusSection(html: string, section: string): string {
   return html.replace("</body>", `${section}\n</body>`);
 }
 
+/** 最新か (tag あり & main と差分なし)。最新なら release 不要なのでボタンを無効化。 */
+export function isUpToDate(s: RepoReleaseStatus): boolean {
+  return s.hasTag && s.behind === 0;
+}
+
 /**
  * Compatibility (all consumers) グラフに出ている repo (backend + frontend) の
  * Tag Release ボタン群を HTML で返す。tagless repo は除外。1 つも無ければ ""。
  *
  * グラフ内の repo をその場でリリースしたい、という要望 (ここにボタン欲しい) に
  * 応えるための block。グラフ直下に注入する (injectCompatTagReleaseButtons)。
+ *
+ * `statusByRepo` に該当があり「最新」(tag あり & main と差分なし) の repo は
+ * ボタンを `disabled` (inactive) にする (= release 不要)。status 不明の repo は
+ * active のまま。
  */
 export function renderCompatTagReleaseButtons(
   repos: Iterable<string>,
   tagless: Set<string>,
+  statusByRepo?: Map<string, RepoReleaseStatus>,
 ): string {
   const list = [...new Set(repos)].filter((r) => !tagless.has(r)).sort();
   if (list.length === 0) return "";
   const buttons = list
-    .map(
-      (r) => `
+    .map((r) => {
+      const st = statusByRepo?.get(r);
+      const upToDate = st ? isUpToDate(st) : false;
+      if (upToDate) {
+        const tag = st?.latestTag ? ` (${escapeHtml(st.latestTag)})` : "";
+        // 最新 = release 不要。submit させない素の disabled button。
+        return `
+        <span style="margin:0 6px 6px 0;display:inline-block">
+          <button type="button" disabled title="${escapeHtml(r)} は最新${tag} のため release 不要">Tag Release: ${escapeHtml(r)}</button>
+        </span>`;
+      }
+      return `
         <form method="post" action="/api/release-wave/tag-release" style="margin:0 6px 6px 0;display:inline-block">
           <input type="hidden" name="repo" value="${escapeHtml(r)}">
           <button type="submit" title="${escapeHtml(r)} の tag-release.yml workflow を main で dispatch する">Tag Release: ${escapeHtml(r)}</button>
-        </form>`,
-    )
+        </form>`;
+    })
     .join("");
   return `
     <div class="actions" style="margin-top:10px">
@@ -244,7 +264,10 @@ export async function handleReleaseWaveListPageWithRepoStatus(
         for (const m of b.matrix) repos.add(m.frontend);
       }
       const tagless = parseTaglessRepos(env.TAGLESS_REPOS);
-      const buttons = renderCompatTagReleaseButtons(repos, tagless);
+      // Repo リリース状況で算出済みの status を repo→status で引けるようにし、
+      // 「最新」repo のボタンを inactive にする。
+      const statusByRepo = new Map(statuses.map((s) => [s.repo, s]));
+      const buttons = renderCompatTagReleaseButtons(repos, tagless, statusByRepo);
       html = injectCompatTagReleaseButtons(html, buttons);
     } catch {
       // compat 取得失敗時はボタンだけ落とす

--- a/test/release-wave/repo-status-section.test.ts
+++ b/test/release-wave/repo-status-section.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   needsRelease,
+  isUpToDate,
   renderRepoReleaseStatusSection,
   injectRepoStatusSection,
   renderCompatTagReleaseButtons,
@@ -179,6 +180,78 @@ describe("renderCompatTagReleaseButtons", () => {
     const html = renderCompatTagReleaseButtons(['a/<b>"&'], new Set());
     expect(html).not.toContain("<b>");
     expect(html).toContain("&lt;b&gt;");
+  });
+
+  it("disables (inactive) the button for an up-to-date repo", () => {
+    const statusByRepo = new Map([
+      [
+        "ippoan/rust-alc-api",
+        status({ repo: "ippoan/rust-alc-api", hasTag: true, latestTag: "v0.0.75", behind: 0 }),
+      ],
+    ]);
+    const html = renderCompatTagReleaseButtons(
+      ["ippoan/rust-alc-api"],
+      new Set(),
+      statusByRepo,
+    );
+    expect(html).toContain("Tag Release: ippoan/rust-alc-api");
+    expect(html).toContain("disabled");
+    // 最新なので submit form は作らない
+    expect(html).not.toContain('action="/api/release-wave/tag-release"');
+    expect(html).toContain("最新 (v0.0.75)");
+  });
+
+  it("keeps the button active for a behind repo", () => {
+    const statusByRepo = new Map([
+      [
+        "ippoan/auth-worker",
+        status({ repo: "ippoan/auth-worker", hasTag: true, latestTag: "v0.5.0", behind: 8 }),
+      ],
+    ]);
+    const html = renderCompatTagReleaseButtons(
+      ["ippoan/auth-worker"],
+      new Set(),
+      statusByRepo,
+    );
+    expect(html).not.toContain("disabled");
+    expect(html).toContain('action="/api/release-wave/tag-release"');
+    expect(html).toContain('name="repo" value="ippoan/auth-worker"');
+  });
+
+  it("keeps the button active for an untagged repo", () => {
+    const statusByRepo = new Map([
+      ["ippoan/new", status({ repo: "ippoan/new", hasTag: false })],
+    ]);
+    const html = renderCompatTagReleaseButtons(["ippoan/new"], new Set(), statusByRepo);
+    expect(html).not.toContain("disabled");
+    expect(html).toContain('action="/api/release-wave/tag-release"');
+  });
+
+  it("keeps the button active when status is unknown (repo not in map)", () => {
+    const html = renderCompatTagReleaseButtons(
+      ["ippoan/unknown"],
+      new Set(),
+      new Map(),
+    );
+    expect(html).not.toContain("disabled");
+    expect(html).toContain('action="/api/release-wave/tag-release"');
+  });
+
+  it("does not disable an errored repo (behind < 0)", () => {
+    const statusByRepo = new Map([
+      ["ippoan/err", status({ repo: "ippoan/err", hasTag: false, behind: -1 })],
+    ]);
+    const html = renderCompatTagReleaseButtons(["ippoan/err"], new Set(), statusByRepo);
+    expect(html).not.toContain("disabled");
+  });
+});
+
+describe("isUpToDate", () => {
+  it("true only when tagged and behind === 0", () => {
+    expect(isUpToDate(status({ hasTag: true, latestTag: "v1.0.0", behind: 0 }))).toBe(true);
+    expect(isUpToDate(status({ hasTag: true, latestTag: "v1.0.0", behind: 2 }))).toBe(false);
+    expect(isUpToDate(status({ hasTag: false, behind: 0 }))).toBe(false);
+    expect(isUpToDate(status({ hasTag: false, behind: -1 }))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## 概要

Compatibility (all consumers) グラフ下の `Tag Release: <repo>` ボタンで、repo が **「最新」(tag あり & main と差分なし)** の場合はボタンを **inactive (disabled)** にする。スクショの `rust-alc-api` (v0.0.75 / 最新) のように、release 不要な repo を誤って押せないようにする。

## 変更点

- `isUpToDate(s)` helper を追加（`hasTag && behind === 0`）。
- `renderCompatTagReleaseButtons` に `statusByRepo` 引数を追加。
  - 最新の repo → submit form ではなく `disabled` button（`title="… は最新 (vX.Y.Z) のため release 不要"`）。
  - 未tag / behind / 取得失敗 / status 不明（グラフにあるが discovery に出てこない repo）→ 従来どおり active。
- wrapper (`handleReleaseWaveListPageWithRepoStatus`) で「Repo リリース状況」算出済みの `statuses` を `repo→status` の Map にして渡す（追加の GitHub 呼び出しなし）。

## テスト
- 最新 → disabled / behind・未tag・status 不明・取得失敗 → active、`isUpToDate` の真偽を検証。
- `npm run typecheck` ✅
- `npm test` (repo-status-section) ✅ 33 passed

Refs #137

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACYyQmmaf7LZH7XJYPEEBo)_