### PR TITLE
fix(release-wave): compat グラフの repo を Repo リリース状況にも含める

### DIFF
--- a/src/release-wave/repo-release-status.ts
+++ b/src/release-wave/repo-release-status.ts
@@ -32,7 +32,7 @@ export interface RepoReleaseStatus {
   tagless: boolean;
 }
 
-/** 監視対象 repo の集合と tagless set を /releases と同じ 3 ソースから組む。 */
+/** 監視対象 repo の集合と tagless set を 4 ソースから組む。 */
 async function discoverRepos(
   env: Env,
 ): Promise<{ repos: string[]; tagless: Set<string> }> {
@@ -63,6 +63,20 @@ async function discoverRepos(
   // (c) TAGLESS_REPOS wrangler var。
   const tagless = parseTaglessRepos(env.TAGLESS_REPOS);
   for (const r of tagless) watched.add(r);
+
+  // (d) Compatibility (all consumers) グラフに出る repo (backend + frontend)。
+  // compat グラフにしか出ない consumer frontend (nuxt-notify 等) を取りこぼさない。
+  if (env.COMPAT_KV) {
+    try {
+      const compat = await computeGlobalCompatibility(env.COMPAT_KV);
+      for (const b of compat.backends) {
+        watched.add(b.backend_repo);
+        for (const m of b.matrix) watched.add(m.frontend);
+      }
+    } catch {
+      // compat 取得失敗 → 他ソースに委ねる
+    }
+  }
 
   return { repos: [...watched].sort(), tagless };
 }

--- a/src/release-wave/repo-release-status.ts
+++ b/src/release-wave/repo-release-status.ts
@@ -8,10 +8,13 @@
  *                    (= まだ release されていない変更量)。-1 は取得失敗。
  *   - tagless      : TAGLESS_REPOS 指定の repo か (tag を打たない方針)
  *
- * repo 一覧の出所は /releases ページと同じ 3 ソース (Hub status / direct-push
- * allowlist / TAGLESS_REPOS)。tag / compare / repo-meta の GitHub 呼び出しは
- * release-cache の KV キャッシュ層を共用するので /releases と同じ rcache: entry を
- * 再利用する (二重 fetch にならない)。
+ * repo 一覧の出所は /releases と同じ 3 ソース (Hub status / direct-push
+ * allowlist / TAGLESS_REPOS) に加え、Compatibility (all consumers) グラフに出る
+ * repo (compat KV の backend + frontend) も含める。後者を足すのは、compat グラフ
+ * にしか出ない consumer frontend (例: nuxt-notify。ci-dashboard 宛の CI webhook を
+ * 出さず allowlist/tagless でもない) を取りこぼさないため。tag / compare /
+ * repo-meta の GitHub 呼び出しは release-cache の KV キャッシュ層を共用するので
+ * /releases と同じ rcache: entry を再利用する (二重 fetch にならない)。
  */
 
 import type { Env } from "../index";
@@ -20,6 +23,7 @@ import { cachedTags, cachedCompare, cachedRepoMeta } from "../release-cache";
 import { loadDirectPushAllowlist } from "../direct-push-allowlist";
 import { parseTaglessRepos } from "../tagless-repos";
 import { sortSemverDesc } from "../release-helpers";
+import { computeGlobalCompatibility } from "./compat";
 
 export interface RepoReleaseStatus {
   repo: string;

--- a/test/release-wave/repo-status-section.test.ts
+++ b/test/release-wave/repo-status-section.test.ts
@@ -367,8 +367,10 @@ describe("handleReleaseWaveListPageWithRepoStatus", () => {
     // Compatibility の下、Pending releases の上に置かれる。
     expect(compatIdx).toBeLessThan(repoIdx);
     expect(repoIdx).toBeLessThan(pendingIdx);
-    // discovery では repo が見つからないので空一覧コピー。
-    expect(html).toContain("リリース対象の repo はありません");
+    // compat グラフの repo (rust-alc-api) は discovery の (d) ソースで拾われ、
+    // 「Repo リリース状況」テーブルにも出る (= 空一覧ではない)。
+    expect(html).toContain("ippoan/rust-alc-api");
+    expect(html).not.toContain("リリース対象の repo はありません");
 
     // CSP header は injection 後も維持される。
     expect(res.headers.get("Content-Security-Policy")).toContain(


### PR DESCRIPTION
## 原因

`nuxt-notify` が「Repo リリース状況」テーブルに出てこないのは、**テーブルとグラフのボタンで repo を集めるソースが別**だったため。

- 「Repo リリース状況」テーブル (`discoverRepos`) のソース = Hub status / direct-push allowlist / `TAGLESS_REPOS` の 3 つだけ
- Compatibility グラフのボタン = `computeGlobalCompatibility`（compat KV）

`nuxt-notify` は compat グラフの **frontend (consumer)** としてのみ現れ（ci-dashboard 宛の CI webhook を出さず allowlist/tagless でもない）、テーブル側の 3 ソースに入らないため取りこぼされていた。

## 修正

`discoverRepos` に **4 つ目のソース (d): Compatibility (all consumers) グラフの repo（backend + frontend）** を追加。compat グラフに出る repo はテーブルにも出るようにした。

- `COMPAT_KV` があれば `computeGlobalCompatibility` の `backend_repo` + `matrix[].frontend` を `watched` に追加。
- `COMPAT_KV` 未 bind / 取得失敗時は従来どおり 3 ソースで degrade。
- repo は `Set` 管理なので重複しない。tag/compare/repo-meta は release-cache の KV キャッシュ共用で二重 fetch なし。

これで `nuxt-notify` もテーブルに出る（tag 状況に応じて未tag/最新/要リリース表示 + 適切な Tag Release ボタン）。

## テスト
- 既存 wrapper テストを更新（compat に seed した `rust-alc-api` がテーブルにも出ることを検証）。
- `npm run typecheck` ✅
- `npm test` (repo-status-section) ✅ 33 passed

Refs #137

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACYyQmmaf7LZH7XJYPEEBo)_