### PR TITLE
feat(release-wave): version traffic split を Compatibility グラフ下に表示

### DIFF
--- a/docs/release-wave.md
+++ b/docs/release-wave.md
@@ -278,7 +278,38 @@ caller repo (e.g. `rust-alc-api`) の migration deploy workflow に以下 step �
 - **Compatibility グラフ内 repo の Tag Release**: Compatibility (all consumers)
   グラフの直下に、グラフに出ている repo (backend + 既 deploy frontend) の
   `Tag Release: <repo>` ボタンを並べる。グラフを見ながらその場でリリースを発火
-  できる (tagless repo は除外)。発火経路は上記 Tag Release と同じ。
+  できる (tagless repo は除外)。発火経路は上記 Tag Release と同じ。「最新」
+  (tag あり & main と差分なし) の repo はボタンを `disabled` (inactive) にする。
+
+## Traffic (version split) — Compatibility グラフ下 (Refs #137)
+
+Compatibility グラフの直下に「Traffic (version split)」テーブルを出す。各 repo の
+worker version の traffic 配分 (どの version に何 % traffic が乗っているか) を
+percentage 降順で並べ、**「100% がどの version / 0% (no-traffic) がどの version」**
+を一目で確認できる (緑 = 100% / 灰 = 0% / 黄 = その他)。version id は先頭 12 文字に
+短縮表示し、full id と % は hover (title) で見える。
+
+データソースは frontend CI からの webhook 報告:
+
+### POST /webhooks/release-wave/traffic-report
+
+frontend CI が deploy 時に `wrangler deployments list` 相当の version 配分を報告し、
+`traffic::<repo>` (COMPAT_KV) に upsert する。shared secret
+(`RELEASE_WAVE_WEBHOOK_SECRET`) 認証。
+
+```jsonc
+// body
+{
+  "repo": "ippoan/auth-worker",
+  "versions": [
+    { "version_id": "530b908c-5385-451c-b163-747caaedafd3", "percentage": 100 },
+    { "version_id": "1a2b3c4d-...",                          "percentage": 0 }
+  ]
+}
+```
+
+報告が無い repo は traffic 行が出ないだけ (graceful)。報告を流すには各 frontend の
+CI (ci-workflows の frontend-ci 等) に traffic-report step を足す必要がある。
 
 repo 一覧の出所は `/releases` と同じ 3 ソース (Hub status / direct-push
 allowlist / `TAGLESS_REPOS`)。tag / compare / repo-meta の GitHub 呼び出しは

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import {
   handleBackendDeployReportWebhook,
   handleBackendCurrentImageWebhook,
   handlePendingReleaseWebhook,
+  handleTrafficReportWebhook,
 } from "./release-wave/webhook";
 import {
   handleCompatibility,
@@ -237,6 +238,11 @@ app.post("/webhooks/release-wave/backend-deploy-report", (c) =>
 // version_id / tag / preview_url を報告する (Refs #181 / #174)。
 app.post("/webhooks/release-wave/pending-release", (c) =>
   handlePendingReleaseWebhook(c.req.raw, c.env),
+);
+// frontend CI が deploy 時に worker の version traffic split (version_id →
+// percentage) を報告する。Compatibility グラフ下に 100%/0% version を出す用。
+app.post("/webhooks/release-wave/traffic-report", (c) =>
+  handleTrafficReportWebhook(c.req.raw, c.env),
 );
 // 認証付き read (CF Access が bypass する /webhooks/* 配下)。frontend CI が
 // 現 prod backend image を解決する用 — CF Access 下の /backend-current-image は

--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -24,6 +24,7 @@ import {
 } from "./repo-release-status";
 import { computeGlobalCompatibility } from "./compat";
 import { parseTaglessRepos } from "../tagless-repos";
+import { getTrafficForRepos, type TrafficRecord } from "./traffic";
 
 function escapeHtml(s: string): string {
   return s
@@ -211,6 +212,57 @@ export function renderCompatTagReleaseButtons(
     </div>`;
 }
 
+/** 短縮 version id 表示 (full は title に出す)。 */
+function shortId(id: string): string {
+  return id.length > 12 ? `${id.slice(0, 12)}…` : id;
+}
+
+/**
+ * Compatibility グラフに出ている repo の version traffic split を HTML で返す。
+ * frontend CI が報告した `traffic::<repo>` を読み、repo ごとに
+ * 「version_id → percentage」を percentage 降順で並べる。
+ *
+ * これで「100% がどの version / 0% (no-traffic) がどの version」が一目で分かる
+ * (要望: 0% の場合 100% はどの id か)。traffic 報告のある repo が 1 つも無ければ ""。
+ */
+export function renderTrafficVersionsBlock(
+  repos: Iterable<string>,
+  trafficByRepo: Map<string, TrafficRecord>,
+): string {
+  const list = [...new Set(repos)]
+    .filter((r) => trafficByRepo.has(r))
+    .sort();
+  if (list.length === 0) return "";
+
+  const rows = list
+    .map((repo) => {
+      const rec = trafficByRepo.get(repo)!;
+      const chips = rec.versions
+        .map((v) => {
+          // 100% = 緑 / 0% = 灰 / その他 (canary 等) = 黄。
+          const color = v.percentage >= 100 ? GREEN : v.percentage <= 0 ? GRAY : AMBER;
+          return `<span class="badge" style="background:${color};margin-right:6px"
+            title="${escapeHtml(repo)} version ${escapeHtml(v.version_id)} = ${v.percentage}%">${v.percentage}% ${escapeHtml(shortId(v.version_id))}</span>`;
+        })
+        .join("");
+      return `
+        <tr>
+          <td>${escapeHtml(repo)}</td>
+          <td>${chips}</td>
+        </tr>`;
+    })
+    .join("");
+
+  return `
+    <div style="margin-top:10px">
+      <strong class="meta">Traffic (version split)</strong>
+      <table style="margin-top:6px">
+        <thead><tr><th>Repo</th><th>Versions (100% / 0% …)</th></tr></thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>`;
+}
+
 /**
  * Compatibility グラフ直下 (= "Staged previews (active waves)" block の直前) に
  * Tag Release ボタン block を注入する。アンカー (グラフの overlay) が無い
@@ -268,7 +320,13 @@ export async function handleReleaseWaveListPageWithRepoStatus(
       // 「最新」repo のボタンを inactive にする。
       const statusByRepo = new Map(statuses.map((s) => [s.repo, s]));
       const buttons = renderCompatTagReleaseButtons(repos, tagless, statusByRepo);
-      html = injectCompatTagReleaseButtons(html, buttons);
+
+      // version traffic split (frontend CI が報告) をグラフ下に出す。
+      const trafficByRepo = await getTrafficForRepos(env.COMPAT_KV, repos);
+      const trafficBlock = renderTrafficVersionsBlock(repos, trafficByRepo);
+
+      // traffic を上、Tag Release ボタンを下にして 1 回で注入する。
+      html = injectCompatTagReleaseButtons(html, trafficBlock + buttons);
     } catch {
       // compat 取得失敗時はボタンだけ落とす
     }

--- a/src/release-wave/traffic.ts
+++ b/src/release-wave/traffic.ts
@@ -1,0 +1,88 @@
+/**
+ * Worker version の traffic split (gradual deployment) の KV 永続化。
+ *
+ * 各 frontend worker の「今どの version に何 % traffic が乗っているか」を
+ * frontend CI が deploy 時に報告し (`wrangler deployments list` 相当)、
+ * ci-dashboard が `traffic::<repo>` として COMPAT_KV に保存する。
+ * /release-wave の Compatibility グラフ下に「version split」として出す。
+ *
+ * 「100% がどの version id か / 0% (no-traffic) がどの version id か」を一目で
+ * 見られるようにするのが目的 (要望: 0% の場合 100% はどの id か)。
+ */
+
+const TRAFFIC_PREFIX = "traffic::";
+const SCHEMA_VERSION = 1 as const;
+
+/** version 1 件の traffic 配分。 */
+export interface TrafficVersion {
+  /** wrangler version id (UUID 等)。 */
+  version_id: string;
+  /** traffic 配分 % (0〜100)。 */
+  percentage: number;
+}
+
+/** `traffic::<repo>` value。repo ごとに最新の deployment 配分のみ保持 (upsert)。 */
+export interface TrafficRecord {
+  schema_version: typeof SCHEMA_VERSION;
+  /** "owner/name"。 */
+  repo: string;
+  /** version 配分 (percentage 降順)。100% / 0% の version が並ぶ。 */
+  versions: TrafficVersion[];
+  /** 報告を受けた UTC ISO。 */
+  reported_at: string;
+}
+
+function trafficKey(repo: string): string {
+  return `${TRAFFIC_PREFIX}${repo}`;
+}
+
+/** upsert: repo ごとに最新報告で上書きする。versions は percentage 降順で保存。 */
+export async function recordTraffic(
+  kv: KVNamespace,
+  input: {
+    repo: string;
+    versions: TrafficVersion[];
+    now: string;
+  },
+): Promise<TrafficRecord> {
+  const versions = [...input.versions].sort(
+    (a, b) => b.percentage - a.percentage,
+  );
+  const record: TrafficRecord = {
+    schema_version: SCHEMA_VERSION,
+    repo: input.repo,
+    versions,
+    reported_at: input.now,
+  };
+  await kv.put(trafficKey(input.repo), JSON.stringify(record));
+  return record;
+}
+
+/** 単一 repo の traffic を取得 (無ければ null)。 */
+export async function getTraffic(
+  kv: KVNamespace,
+  repo: string,
+): Promise<TrafficRecord | null> {
+  const v = await kv.get<TrafficRecord>(trafficKey(repo), "json");
+  if (!v || v.schema_version !== SCHEMA_VERSION) return null;
+  return v;
+}
+
+/**
+ * 指定 repo 群の traffic を repo→record の Map で返す (record 無しは含めない)。
+ * compat グラフに出る repo だけ引きたいので個別 get を並列で叩く。
+ */
+export async function getTrafficForRepos(
+  kv: KVNamespace,
+  repos: Iterable<string>,
+): Promise<Map<string, TrafficRecord>> {
+  const list = [...new Set(repos)];
+  const entries = await Promise.all(
+    list.map(async (repo) => [repo, await getTraffic(kv, repo)] as const),
+  );
+  const out = new Map<string, TrafficRecord>();
+  for (const [repo, rec] of entries) {
+    if (rec) out.set(repo, rec);
+  }
+  return out;
+}

--- a/src/release-wave/webhook.ts
+++ b/src/release-wave/webhook.ts
@@ -24,6 +24,7 @@ import type { ReleaseWaveHub, RpcResult } from "./do";
 import type { WaveState } from "./types";
 import { recordFrontendTest, recordBackendDeploy, getBackendCurrent } from "./compat";
 import { recordPendingRelease } from "./pending-release";
+import { recordTraffic } from "./traffic";
 
 // ----------------------------------------------------------------------------
 // Common helpers

--- a/src/release-wave/webhook.ts
+++ b/src/release-wave/webhook.ts
@@ -433,3 +433,54 @@ export async function handleBackendCurrentImageWebhook(
     deployed_at: record.deployed_at,
   });
 }
+
+// ----------------------------------------------------------------------------
+// /webhooks/release-wave/traffic-report  (Refs #137)
+// ----------------------------------------------------------------------------
+
+/**
+ * frontend CI が deploy 時に worker の version traffic split を報告する。
+ * `wrangler deployments list` 相当の「version_id → percentage」配列を受け取り、
+ * `traffic::<repo>` (COMPAT_KV) に upsert する。Compatibility グラフ下に
+ * 「100% がどの version / 0% (no-traffic) がどの version」を出すための入力。
+ *
+ * body:
+ *   {
+ *     "repo": "ippoan/auth-worker",
+ *     "versions": [
+ *       { "version_id": "530b908c-...", "percentage": 100 },
+ *       { "version_id": "1a2b3c4d-...", "percentage": 0 }
+ *     ]
+ *   }
+ */
+const trafficReportSchema = z.object({
+  repo: z.string().min(1),
+  versions: z
+    .array(
+      z.object({
+        version_id: z.string().min(1),
+        percentage: z.number().min(0).max(100),
+      }),
+    )
+    .min(1),
+});
+
+export async function handleTrafficReportWebhook(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  const v = await validateAndAuth(request, env, trafficReportSchema);
+  if (!v.ok) return v.response;
+  if (!env.COMPAT_KV) {
+    return jsonResponse(500, {
+      code: "KV_NOT_CONFIGURED",
+      error: "COMPAT_KV is not bound",
+    });
+  }
+  const record = await recordTraffic(env.COMPAT_KV, {
+    repo: v.data.repo,
+    versions: v.data.versions,
+    now: new Date().toISOString(),
+  });
+  return jsonResponse(200, { ok: true, record });
+}

--- a/test/release-wave/repo-status-section.test.ts
+++ b/test/release-wave/repo-status-section.test.ts
@@ -6,8 +6,10 @@ import {
   injectRepoStatusSection,
   renderCompatTagReleaseButtons,
   injectCompatTagReleaseButtons,
+  renderTrafficVersionsBlock,
   handleReleaseWaveListPageWithRepoStatus,
 } from "../../src/release-wave/repo-status-section";
+import type { TrafficRecord } from "../../src/release-wave/traffic";
 import type { RepoReleaseStatus } from "../../src/release-wave/repo-release-status";
 import type { Env } from "../../src/index";
 
@@ -246,6 +248,54 @@ describe("renderCompatTagReleaseButtons", () => {
   });
 });
 
+describe("renderTrafficVersionsBlock", () => {
+  function rec(repo: string, versions: TrafficRecord["versions"]): TrafficRecord {
+    return { schema_version: 1, repo, versions, reported_at: "t" };
+  }
+
+  it("shows 100% and 0% version ids for a repo", () => {
+    const map = new Map([
+      [
+        "ippoan/auth-worker",
+        rec("ippoan/auth-worker", [
+          { version_id: "530b908c-aaaa", percentage: 100 },
+          { version_id: "1a2b3c4d-bbbb", percentage: 0 },
+        ]),
+      ],
+    ]);
+    const html = renderTrafficVersionsBlock(["ippoan/auth-worker"], map);
+    expect(html).toContain("Traffic (version split)");
+    expect(html).toContain("ippoan/auth-worker");
+    expect(html).toContain("100% 530b908c-aaa"); // shortId truncates at 12 chars
+    expect(html).toContain("0% 1a2b3c4d-bbb");
+    // full id in title for 100% and 0%
+    expect(html).toContain("530b908c-aaaa = 100%");
+    expect(html).toContain("1a2b3c4d-bbbb = 0%");
+  });
+
+  it("only lists repos that have a traffic record", () => {
+    const map = new Map([
+      ["ippoan/a", rec("ippoan/a", [{ version_id: "v", percentage: 100 }])],
+    ]);
+    const html = renderTrafficVersionsBlock(["ippoan/a", "ippoan/b"], map);
+    expect(html).toContain("ippoan/a");
+    expect(html).not.toContain("ippoan/b");
+  });
+
+  it("returns empty string when no repo has traffic", () => {
+    expect(renderTrafficVersionsBlock(["ippoan/a"], new Map())).toBe("");
+  });
+
+  it("escapes repo names and version ids", () => {
+    const map = new Map([
+      ['a/<b>', rec('a/<b>', [{ version_id: '<v>', percentage: 100 }])],
+    ]);
+    const html = renderTrafficVersionsBlock(['a/<b>'], map);
+    expect(html).not.toContain("<b>");
+    expect(html).toContain("&lt;b&gt;");
+  });
+});
+
 describe("isUpToDate", () => {
   it("true only when tagged and behind === 0", () => {
     expect(isUpToDate(status({ hasTag: true, latestTag: "v1.0.0", behind: 0 }))).toBe(true);
@@ -398,5 +448,41 @@ describe("handleReleaseWaveListPageWithRepoStatus", () => {
     const html = await res.text();
     expect(html).toContain("Tag Release: ippoan/rust-alc-api");
     expect(html).toContain('name="repo" value="ippoan/rust-alc-api"');
+  });
+
+  it("shows the version traffic split under the compatibility graph", async () => {
+    const compatKv = memKv({
+      "backend::ippoan/rust-alc-api": {
+        schema_version: 1,
+        repo: "ippoan/rust-alc-api",
+        current_image: "sha-abc123",
+        deployed_at: "2026-05-29T00:00:00Z",
+        deployed_by: "ci",
+        wave_id: null,
+      },
+      "traffic::ippoan/rust-alc-api": {
+        schema_version: 1,
+        repo: "ippoan/rust-alc-api",
+        versions: [
+          { version_id: "full-100-id", percentage: 100 },
+          { version_id: "zero-000-id", percentage: 0 },
+        ],
+        reported_at: "2026-05-29T00:00:00Z",
+      },
+    });
+    const env = {
+      ...baseEnv(),
+      CI_STATUS: memKv(),
+      COMPAT_KV: compatKv,
+    } as unknown as Env;
+    const res = await handleReleaseWaveListPageWithRepoStatus(env);
+    const html = await res.text();
+    expect(html).toContain("Traffic (version split)");
+    expect(html).toContain("100% full-100-id");
+    expect(html).toContain("0% zero-000-id");
+    // グラフ overlay の Staged previews より前 (= グラフ直下) に出る。
+    expect(html.indexOf("Traffic (version split)")).toBeLessThan(
+      html.indexOf("Staged previews (active waves)"),
+    );
   });
 });

--- a/test/release-wave/traffic.test.ts
+++ b/test/release-wave/traffic.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import {
+  recordTraffic,
+  getTraffic,
+  getTrafficForRepos,
+  type TrafficRecord,
+} from "../../src/release-wave/traffic";
+
+function memKv(seed: Record<string, unknown> = {}): KVNamespace {
+  const store = new Map<string, string>(
+    Object.entries(seed).map(([k, v]) => [k, JSON.stringify(v)]),
+  );
+  return {
+    async get(key: string, type?: string) {
+      const raw = store.get(key);
+      if (raw === undefined) return null;
+      return type === "json" ? JSON.parse(raw) : raw;
+    },
+    async put(key: string, value: string) {
+      store.set(key, value);
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+    async list({ prefix = "" }: { prefix?: string } = {}) {
+      const keys = [...store.keys()]
+        .filter((k) => k.startsWith(prefix))
+        .map((name) => ({ name }));
+      return { keys, list_complete: true, cacheStatus: null };
+    },
+  } as unknown as KVNamespace;
+}
+
+describe("traffic record", () => {
+  it("recordTraffic sorts versions by percentage desc and round-trips", async () => {
+    const kv = memKv();
+    await recordTraffic(kv, {
+      repo: "ippoan/auth-worker",
+      versions: [
+        { version_id: "zero", percentage: 0 },
+        { version_id: "full", percentage: 100 },
+      ],
+      now: "2026-05-29T00:00:00Z",
+    });
+    const rec = await getTraffic(kv, "ippoan/auth-worker");
+    expect(rec).not.toBeNull();
+    expect(rec!.versions[0]).toEqual({ version_id: "full", percentage: 100 });
+    expect(rec!.versions[1]).toEqual({ version_id: "zero", percentage: 0 });
+    expect(rec!.reported_at).toBe("2026-05-29T00:00:00Z");
+  });
+
+  it("getTraffic returns null for a missing repo", async () => {
+    expect(await getTraffic(memKv(), "ippoan/none")).toBeNull();
+  });
+
+  it("getTraffic rejects a record with a mismatched schema_version", async () => {
+    const kv = memKv({
+      "traffic::ippoan/x": { schema_version: 99, repo: "ippoan/x", versions: [], reported_at: "t" },
+    });
+    expect(await getTraffic(kv, "ippoan/x")).toBeNull();
+  });
+
+  it("recordTraffic upserts (latest report wins)", async () => {
+    const kv = memKv();
+    await recordTraffic(kv, {
+      repo: "ippoan/x",
+      versions: [{ version_id: "a", percentage: 100 }],
+      now: "t1",
+    });
+    await recordTraffic(kv, {
+      repo: "ippoan/x",
+      versions: [{ version_id: "b", percentage: 100 }],
+      now: "t2",
+    });
+    const rec = await getTraffic(kv, "ippoan/x");
+    expect(rec!.versions).toEqual([{ version_id: "b", percentage: 100 }]);
+    expect(rec!.reported_at).toBe("t2");
+  });
+
+  it("getTrafficForRepos returns only repos that have a record", async () => {
+    const seedRec = (repo: string): TrafficRecord => ({
+      schema_version: 1,
+      repo,
+      versions: [{ version_id: "v", percentage: 100 }],
+      reported_at: "t",
+    });
+    const kv = memKv({
+      "traffic::ippoan/a": seedRec("ippoan/a"),
+      "traffic::ippoan/b": seedRec("ippoan/b"),
+    });
+    const map = await getTrafficForRepos(kv, ["ippoan/a", "ippoan/c"]);
+    expect(map.has("ippoan/a")).toBe(true);
+    expect(map.has("ippoan/c")).toBe(false);
+    expect(map.size).toBe(1);
+  });
+});

--- a/test/release-wave/webhook.test.ts
+++ b/test/release-wave/webhook.test.ts
@@ -4,8 +4,10 @@ import {
   handleStageReportWebhook,
   handleFlipReportWebhook,
   handlePendingReleaseWebhook,
+  handleTrafficReportWebhook,
 } from "../../src/release-wave/webhook";
 import { getPendingRelease } from "../../src/release-wave/pending-release";
+import { getTraffic } from "../../src/release-wave/traffic";
 import type { Env } from "../../src/index";
 import type { ReleaseWaveHub } from "../../src/release-wave/do";
 
@@ -633,6 +635,84 @@ describe("handlePendingReleaseWebhook", () => {
         url: PENDING_URL,
         secret: "wrong-secret",
         body: { repo: "ippoan/auth-worker", version_id: VALID_VID, tag: "v1.0.0" },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(401);
+  });
+});
+
+// ============================================================================
+// traffic-report webhook
+// ============================================================================
+
+const TRAFFIC_URL =
+  "https://ci-dashboard.ippoan.org/webhooks/release-wave/traffic-report";
+
+describe("handleTrafficReportWebhook", () => {
+  it("records traffic split sorted by percentage desc (ok=true)", async () => {
+    const kv = memKv();
+    const { env } = fakeEnv({ compatKv: kv });
+    const resp = await handleTrafficReportWebhook(
+      jsonRequest({
+        url: TRAFFIC_URL,
+        secret: "expected-secret",
+        body: {
+          repo: "ippoan/auth-worker",
+          versions: [
+            { version_id: "zero-id", percentage: 0 },
+            { version_id: "full-id", percentage: 100 },
+          ],
+        },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(200);
+    const rec = await getTraffic(kv, "ippoan/auth-worker");
+    expect(rec).not.toBeNull();
+    expect(rec!.versions[0]).toEqual({ version_id: "full-id", percentage: 100 });
+    expect(rec!.versions[1]).toEqual({ version_id: "zero-id", percentage: 0 });
+  });
+
+  it("rejects an empty versions array with 400", async () => {
+    const kv = memKv();
+    const { env } = fakeEnv({ compatKv: kv });
+    const resp = await handleTrafficReportWebhook(
+      jsonRequest({
+        url: TRAFFIC_URL,
+        secret: "expected-secret",
+        body: { repo: "ippoan/x", versions: [] },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(400);
+  });
+
+  it("rejects a percentage out of range with 400", async () => {
+    const kv = memKv();
+    const { env } = fakeEnv({ compatKv: kv });
+    const resp = await handleTrafficReportWebhook(
+      jsonRequest({
+        url: TRAFFIC_URL,
+        secret: "expected-secret",
+        body: { repo: "ippoan/x", versions: [{ version_id: "a", percentage: 150 }] },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(400);
+  });
+
+  it("rejects bad webhook secret with 401", async () => {
+    const kv = memKv();
+    const { env } = fakeEnv({ compatKv: kv });
+    const resp = await handleTrafficReportWebhook(
+      jsonRequest({
+        url: TRAFFIC_URL,
+        secret: "wrong-secret",
+        body: {
+          repo: "ippoan/auth-worker",
+          versions: [{ version_id: "a", percentage: 100 }],
+        },
       }),
       env,
     );


### PR DESCRIPTION
## 概要

要望「ここに traffic 出せる？ 0% の場合 100% はどの id か まで出したい」に対応。

Compatibility (all consumers) グラフの直下に **「Traffic (version split)」テーブル**を追加し、各 repo の worker version の traffic 配分（どの version に何 % traffic が乗っているか）を percentage 降順で表示します。**「100% がどの version / 0% (no-traffic) がどの version か」**が一目で分かります。

- 緑 = 100% / 灰 = 0% / 黄 = その他（canary 等）
- version id は先頭 12 文字に短縮、full id と % は hover (title) で表示

## 取得方法（選択: frontend CI が webhook で報告）

### `POST /webhooks/release-wave/traffic-report`（新規）
frontend CI が deploy 時に `wrangler deployments list` 相当の version 配分を shared secret 認証で報告 → `traffic::<repo>` (COMPAT_KV) に upsert。

```jsonc
{
  "repo": "ippoan/auth-worker",
  "versions": [
    { "version_id": "530b908c-...", "percentage": 100 },
    { "version_id": "1a2b3c4d-...", "percentage": 0 }
  ]
}
```

## 変更点
- `src/release-wave/traffic.ts`（新規）: `traffic::<repo>` の KV 永続化（versions は percentage 降順保存）。
- `src/release-wave/webhook.ts`: `handleTrafficReportWebhook`（zod validation: percentage 0–100、versions 1 件以上）。
- `src/index.ts`: route 追加。
- `src/release-wave/repo-status-section.ts`: `renderTrafficVersionsBlock` を追加し、グラフ overlay 直前に traffic block + Tag Release ボタンをまとめて注入（traffic を上）。
- test（traffic / webhook / section、計 +多数）+ docs（`release-wave.md` / `release-wave-compatibility-kv.md` に `traffic::` shape）。

## graceful degrade
報告が無い repo は traffic 行が出ないだけ。**実データを流すには各 frontend の CI に traffic-report step が必要**です（ci-workflows 側で別途。ご希望なら続けて対応します）。

## テスト
- `npm run typecheck` ✅
- `npm test`（traffic / webhook / repo-status-section）✅ 61 passed

Refs #137

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACYyQmmaf7LZH7XJYPEEBo)_