### PR TITLE
feat(release-wave): traffic split に 0% version と deploy/upload 日時を追加

### DIFF
--- a/docs/release-wave.md
+++ b/docs/release-wave.md
@@ -284,32 +284,42 @@ caller repo (e.g. `rust-alc-api`) の migration deploy workflow に以下 step �
 ## Traffic (version split) — Compatibility グラフ下 (Refs #137)
 
 Compatibility グラフの直下に「Traffic (version split)」テーブルを出す。各 repo の
-worker version の traffic 配分 (どの version に何 % traffic が乗っているか) を
-percentage 降順で並べ、**「100% がどの version / 0% (no-traffic) がどの version」**
-を一目で確認できる (緑 = 100% / 灰 = 0% / 黄 = その他)。version id は先頭 12 文字に
-短縮表示し、full id と % は hover (title) で見える。
+worker version を **1 行ずつ** `percentage / version_id / deploy(100%)・upload(0%)
+日時` で並べ、**「どの version が 100% (active) / 0% (promote 待ち) で、それぞれ
+いつ deploy/upload されたか」**を一目で確認できる (緑 = 100% / 灰 = 0% / 黄 = その他)。
+version id は先頭 12 文字短縮 (full は hover)、日時は UTC `MM-DD HH:mm`。
+並び順は percentage 降順 → 同率は created_on 降順 (新しい version が上)。
+
+加えて Compatibility グラフの **frontend ノード hover (title)** にも、その repo の
+全 version の `% version_id` を列挙する (要望: グラフにも traffic)。
 
 データソースは frontend CI からの webhook 報告:
 
 ### POST /webhooks/release-wave/traffic-report
 
-frontend CI が deploy 時に `wrangler deployments list` 相当の version 配分を報告し、
-`traffic::<repo>` (COMPAT_KV) に upsert する。shared secret
+frontend CI が deploy 時に **`wrangler deployments list`** (version_id → percentage)
+と **`wrangler versions list`** (version の created_on) をマージして報告し、
+`traffic::<repo>` (COMPAT_KV, schema v2) に upsert する。shared secret
 (`RELEASE_WAVE_WEBHOOK_SECRET`) 認証。
 
+deployments list は active deployment (通常 100% の 1 件) しか返さないため、
+versions list の全 version に percentage を join (無ければ 0%) + created_on を付ける。
+これで **0% (no-traffic / promote 待ち) の version も日時付きで** 報告できる。
+
 ```jsonc
-// body
+// body (created_on は任意)
 {
   "repo": "ippoan/auth-worker",
   "versions": [
-    { "version_id": "530b908c-5385-451c-b163-747caaedafd3", "percentage": 100 },
-    { "version_id": "1a2b3c4d-...",                          "percentage": 0 }
+    { "version_id": "6403c1dc-...", "percentage": 100, "created_on": "2026-05-28T11:37:33Z" },
+    { "version_id": "ac6841e4-...", "percentage": 0,   "created_on": "2026-05-29T07:02:27Z" }
   ]
 }
 ```
 
-報告が無い repo は traffic 行が出ないだけ (graceful)。報告を流すには各 frontend の
-CI (ci-workflows の frontend-ci 等) に traffic-report step を足す必要がある。
+報告が無い repo は traffic 行が出ないだけ (graceful)。schema v1 (created_on 無し)
+record も後方互換で読める (日時は `—` 表示)。報告を流すには各 frontend の CI
+(ci-workflows の frontend-ci) に traffic-report step が必要。
 
 repo 一覧の出所は `/releases` と同じ 3 ソース (Hub status / direct-push
 allowlist / `TAGLESS_REPOS`)。tag / compare / repo-meta の GitHub 呼び出しは

--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -25,6 +25,7 @@ import {
   listPendingReleases,
   type PendingReleaseRecord,
 } from "./pending-release";
+import { getTrafficForRepos, type TrafficRecord } from "./traffic";
 
 // ----------------------------------------------------------------------------
 // Small HTML helpers
@@ -167,9 +168,25 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
       globalCompat = null;
     }
   }
+  // compat グラフに出る repo (backend + frontend) の version traffic を引く。
+  // グラフの frontend ノード hover に「現 active version の % / id」を出す用。
+  let trafficByRepo: Map<string, TrafficRecord> = new Map();
+  if (env.COMPAT_KV && globalCompat) {
+    const repos = new Set<string>();
+    for (const b of globalCompat.backends) {
+      repos.add(b.backend_repo);
+      for (const m of b.matrix) repos.add(m.frontend);
+    }
+    try {
+      trafficByRepo = await getTrafficForRepos(env.COMPAT_KV, repos);
+    } catch {
+      trafficByRepo = new Map();
+    }
+  }
   const compatSection = renderGlobalCompatibilitySection(
     globalCompat,
     buildActiveWaveInfo(waves),
+    trafficByRepo,
   );
 
   // 単独 v* リリースで upload された no-traffic version の一覧 (Refs #181)。
@@ -590,6 +607,7 @@ function buildActiveWaveInfo(waves: WaveState[]): ActiveWaveInfo {
 function renderGlobalCompatibilitySection(
   compat: WaveCompatibility | null,
   active?: ActiveWaveInfo,
+  trafficByRepo?: Map<string, TrafficRecord>,
 ): string {
   if (!compat || compat.backends.length === 0) {
     return `
@@ -607,7 +625,7 @@ function renderGlobalCompatibilitySection(
     : compat.verified
     ? `<span class="ok"><strong>all consumers tested</strong></span>`
     : `<span class="err"><strong>some consumers untested</strong></span>`;
-  const svg = renderCompatibilitySvg(compat, active);
+  const svg = renderCompatibilitySvg(compat, active, trafficByRepo);
   const body = svg
     ? svg
     : `<p class="meta">backend record はあるが、まだどの frontend も test 履歴を
@@ -827,6 +845,7 @@ function truncLabel(s: string, max = 30): string {
 function renderCompatibilitySvg(
   compat: WaveCompatibility,
   active?: ActiveWaveInfo,
+  trafficByRepo?: Map<string, TrafficRecord>,
 ): string {
   type Edge = {
     backend: string;
@@ -989,13 +1008,23 @@ function renderCompatibilitySvg(
       const previewNote = active?.preview.has(repo)
         ? `\npreview: ${active.preview.get(repo)!.url}`
         : "";
+      // traffic (version split) を hover (title) に出す。active(100%) / 0% の
+      // version id と % を、報告があれば列挙する (要望: ノードにも traffic)。
+      const traffic = trafficByRepo?.get(repo);
+      const trafficNote =
+        traffic && traffic.versions.length > 0
+          ? "\ntraffic:\n" +
+            traffic.versions
+              .map((v) => `  ${v.percentage}% ${v.version_id}`)
+              .join("\n")
+          : "";
       return node(
         rightX,
         fY(repo),
         repo,
         line2,
         border,
-        `${repo}\nprod version: ${ver}\ntested vs image: ${testedImg ?? "—"}\n${verdictTxt}${previewNote}`,
+        `${repo}\nprod version: ${ver}\ntested vs image: ${testedImg ?? "—"}\n${verdictTxt}${previewNote}${trafficNote}`,
         href,
       );
     })

--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -217,13 +217,23 @@ function shortId(id: string): string {
   return id.length > 12 ? `${id.slice(0, 12)}…` : id;
 }
 
+/** ISO 日時を "MM-DD HH:mm" (UTC) に短縮。null は "—"。 */
+function shortWhen(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${p(d.getUTCMonth() + 1)}-${p(d.getUTCDate())} ${p(d.getUTCHours())}:${p(d.getUTCMinutes())}`;
+}
+
 /**
  * Compatibility グラフに出ている repo の version traffic split を HTML で返す。
- * frontend CI が報告した `traffic::<repo>` を読み、repo ごとに
- * 「version_id → percentage」を percentage 降順で並べる。
+ * frontend CI が報告した `traffic::<repo>` を読み、repo ごとに各 version を
+ * 「percentage / version_id / deploy(100%)・upload(0%) 日時」で 1 行ずつ並べる。
  *
- * これで「100% がどの version / 0% (no-traffic) がどの version」が一目で分かる
- * (要望: 0% の場合 100% はどの id か)。traffic 報告のある repo が 1 つも無ければ ""。
+ * これで「100% (active) がどの version / 0% (promote 待ち) がどの version で、
+ * それぞれいつ deploy/upload されたか」が一目で分かる。
+ * traffic 報告のある repo が 1 つも無ければ ""。
  */
 export function renderTrafficVersionsBlock(
   repos: Iterable<string>,
@@ -234,22 +244,28 @@ export function renderTrafficVersionsBlock(
     .sort();
   if (list.length === 0) return "";
 
+  // 各 repo の各 version を 1 行ずつ (repo 名は最初の version 行にだけ出す)。
   const rows = list
     .map((repo) => {
       const rec = trafficByRepo.get(repo)!;
-      const chips = rec.versions
-        .map((v) => {
+      return rec.versions
+        .map((v, i) => {
           // 100% = 緑 / 0% = 灰 / その他 (canary 等) = 黄。
-          const color = v.percentage >= 100 ? GREEN : v.percentage <= 0 ? GRAY : AMBER;
-          return `<span class="badge" style="background:${color};margin-right:6px"
-            title="${escapeHtml(repo)} version ${escapeHtml(v.version_id)} = ${v.percentage}%">${v.percentage}% ${escapeHtml(shortId(v.version_id))}</span>`;
+          const color =
+            v.percentage >= 100 ? GREEN : v.percentage <= 0 ? GRAY : AMBER;
+          const pctBadge = `<span class="badge" style="background:${color}">${v.percentage}%</span>`;
+          const vid = `<code title="${escapeHtml(v.version_id)}">${escapeHtml(shortId(v.version_id))}</code>`;
+          const when = `<span class="meta" title="${escapeHtml(v.created_on ?? "")}">${escapeHtml(shortWhen(v.created_on))}</span>`;
+          const repoCell = i === 0 ? escapeHtml(repo) : "";
+          return `
+            <tr>
+              <td>${repoCell}</td>
+              <td>${pctBadge}</td>
+              <td>${vid}</td>
+              <td>${when}</td>
+            </tr>`;
         })
         .join("");
-      return `
-        <tr>
-          <td>${escapeHtml(repo)}</td>
-          <td>${chips}</td>
-        </tr>`;
     })
     .join("");
 
@@ -257,7 +273,7 @@ export function renderTrafficVersionsBlock(
     <div style="margin-top:10px">
       <strong class="meta">Traffic (version split)</strong>
       <table style="margin-top:6px">
-        <thead><tr><th>Repo</th><th>Versions (100% / 0% …)</th></tr></thead>
+        <thead><tr><th>Repo</th><th>%</th><th>Version</th><th>Deployed / Uploaded (UTC)</th></tr></thead>
         <tbody>${rows}</tbody>
       </table>
     </div>`;

--- a/src/release-wave/traffic.ts
+++ b/src/release-wave/traffic.ts
@@ -11,7 +11,9 @@
  */
 
 const TRAFFIC_PREFIX = "traffic::";
-const SCHEMA_VERSION = 1 as const;
+// v2: TrafficVersion に created_on を追加 (deploy/upload 日時)。v1 record は
+// created_on 無しとして読めるよう、reader は両方許容する (後方互換)。
+const SCHEMA_VERSION = 2 as const;
 
 /** version 1 件の traffic 配分。 */
 export interface TrafficVersion {
@@ -19,14 +21,23 @@ export interface TrafficVersion {
   version_id: string;
   /** traffic 配分 % (0〜100)。 */
   percentage: number;
+  /**
+   * version の deploy(100%) / upload(0%) 日時 (UTC ISO)。
+   * `wrangler versions list` の metadata.created_on 由来。
+   * 取得できなかった / v1 record では null。
+   */
+  created_on?: string | null;
 }
 
 /** `traffic::<repo>` value。repo ごとに最新の deployment 配分のみ保持 (upsert)。 */
 export interface TrafficRecord {
-  schema_version: typeof SCHEMA_VERSION;
+  schema_version: number;
   /** "owner/name"。 */
   repo: string;
-  /** version 配分 (percentage 降順)。100% / 0% の version が並ぶ。 */
+  /**
+   * version 配分。percentage 降順 → 同率は created_on 降順 (新しい順) で並ぶ。
+   * 100% (active) と 0% (no-traffic / promote 待ち) が混在する。
+   */
   versions: TrafficVersion[];
   /** 報告を受けた UTC ISO。 */
   reported_at: string;
@@ -36,7 +47,11 @@ function trafficKey(repo: string): string {
   return `${TRAFFIC_PREFIX}${repo}`;
 }
 
-/** upsert: repo ごとに最新報告で上書きする。versions は percentage 降順で保存。 */
+/**
+ * upsert: repo ごとに最新報告で上書きする。
+ * versions は percentage 降順 → 同率は created_on 降順 (新しい順) で並べて保存。
+ * これで「100% (active)」が先頭、その後に 0% の新しい version から並ぶ。
+ */
 export async function recordTraffic(
   kv: KVNamespace,
   input: {
@@ -45,9 +60,16 @@ export async function recordTraffic(
     now: string;
   },
 ): Promise<TrafficRecord> {
-  const versions = [...input.versions].sort(
-    (a, b) => b.percentage - a.percentage,
-  );
+  const versions = [...input.versions].sort((a, b) => {
+    if (b.percentage !== a.percentage) return b.percentage - a.percentage;
+    // 同 percentage は created_on 降順 (新しい version を上に)。null は末尾。
+    const ca = a.created_on ?? "";
+    const cb = b.created_on ?? "";
+    if (ca === cb) return 0;
+    if (!ca) return 1;
+    if (!cb) return -1;
+    return ca < cb ? 1 : -1;
+  });
   const record: TrafficRecord = {
     schema_version: SCHEMA_VERSION,
     repo: input.repo,
@@ -58,13 +80,16 @@ export async function recordTraffic(
   return record;
 }
 
-/** 単一 repo の traffic を取得 (無ければ null)。 */
+/**
+ * 単一 repo の traffic を取得 (無ければ null)。
+ * v1 / v2 どちらの record も許容する (v1 は created_on 無し)。古い v0 等は無視。
+ */
 export async function getTraffic(
   kv: KVNamespace,
   repo: string,
 ): Promise<TrafficRecord | null> {
   const v = await kv.get<TrafficRecord>(trafficKey(repo), "json");
-  if (!v || v.schema_version !== SCHEMA_VERSION) return null;
+  if (!v || (v.schema_version !== 1 && v.schema_version !== 2)) return null;
   return v;
 }
 

--- a/src/release-wave/webhook.ts
+++ b/src/release-wave/webhook.ts
@@ -444,12 +444,12 @@ export async function handleBackendCurrentImageWebhook(
  * `traffic::<repo>` (COMPAT_KV) に upsert する。Compatibility グラフ下に
  * 「100% がどの version / 0% (no-traffic) がどの version」を出すための入力。
  *
- * body:
+ * body (created_on は任意。`wrangler versions list` の metadata.created_on 由来):
  *   {
  *     "repo": "ippoan/auth-worker",
  *     "versions": [
- *       { "version_id": "530b908c-...", "percentage": 100 },
- *       { "version_id": "1a2b3c4d-...", "percentage": 0 }
+ *       { "version_id": "530b908c-...", "percentage": 100, "created_on": "2026-05-28T..." },
+ *       { "version_id": "1a2b3c4d-...", "percentage": 0,   "created_on": "2026-05-29T..." }
  *     ]
  *   }
  */
@@ -460,6 +460,7 @@ const trafficReportSchema = z.object({
       z.object({
         version_id: z.string().min(1),
         percentage: z.number().min(0).max(100),
+        created_on: z.string().min(1).optional(),
       }),
     )
     .min(1),
@@ -479,7 +480,11 @@ export async function handleTrafficReportWebhook(
   }
   const record = await recordTraffic(env.COMPAT_KV, {
     repo: v.data.repo,
-    versions: v.data.versions,
+    versions: v.data.versions.map((x) => ({
+      version_id: x.version_id,
+      percentage: x.percentage,
+      created_on: x.created_on ?? null,
+    })),
     now: new Date().toISOString(),
   });
   return jsonResponse(200, { ok: true, record });

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -269,6 +269,49 @@ describe("handleReleaseWaveListPage", () => {
     const formChunk = html.slice(formIdx, formIdx + 300);
     expect(formChunk).not.toContain('name="force"');
   });
+
+  it("shows version traffic (100% / 0%) in the compat graph frontend node hover", async () => {
+    const env = fakeEnv({
+      listReturn: [],
+      compatKv: memKv({
+        "backend::ippoan/rust-alc-api": {
+          schema_version: 1,
+          repo: "ippoan/rust-alc-api",
+          current_image: "cur-img",
+          deployed_at: "2026-05-27T00:00:00Z",
+          deployed_by: "x",
+          wave_id: null,
+        },
+        "frontend::ippoan/auth-worker": {
+          schema_version: 1,
+          repo: "ippoan/auth-worker",
+          prod_version: "v0.2.42",
+          prod_deployed_at: "2026-05-29T00:00:00Z",
+          tested_against: [
+            {
+              backend_repo: "ippoan/rust-alc-api",
+              backend_image: "cur-img",
+              tested_at: "2026-05-29T00:00:00Z",
+            },
+          ],
+        },
+        "traffic::ippoan/auth-worker": {
+          schema_version: 2,
+          repo: "ippoan/auth-worker",
+          versions: [
+            { version_id: "6403c1dc-full", percentage: 100, created_on: "2026-05-28T11:00:00Z" },
+            { version_id: "ac6841e4-zero", percentage: 0, created_on: "2026-05-29T07:00:00Z" },
+          ],
+          reported_at: "2026-05-29T07:02:00Z",
+        },
+      }),
+    });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    // SVG node の <title> (hover) に traffic 行が出る。
+    expect(html).toContain("traffic:");
+    expect(html).toContain("100% 6403c1dc-full");
+    expect(html).toContain("0% ac6841e4-zero");
+  });
 });
 
 // ============================================================================

--- a/test/release-wave/repo-status-section.test.ts
+++ b/test/release-wave/repo-status-section.test.ts
@@ -253,24 +253,38 @@ describe("renderTrafficVersionsBlock", () => {
     return { schema_version: 1, repo, versions, reported_at: "t" };
   }
 
-  it("shows 100% and 0% version ids for a repo", () => {
+  it("shows 100% and 0% version ids (+ deploy/upload 日時) for a repo", () => {
     const map = new Map([
       [
         "ippoan/auth-worker",
         rec("ippoan/auth-worker", [
-          { version_id: "530b908c-aaaa", percentage: 100 },
-          { version_id: "1a2b3c4d-bbbb", percentage: 0 },
+          { version_id: "530b908c-aaaa", percentage: 100, created_on: "2026-05-28T11:37:33Z" },
+          { version_id: "1a2b3c4d-bbbb", percentage: 0, created_on: "2026-05-29T07:02:27Z" },
         ]),
       ],
     ]);
     const html = renderTrafficVersionsBlock(["ippoan/auth-worker"], map);
     expect(html).toContain("Traffic (version split)");
     expect(html).toContain("ippoan/auth-worker");
-    expect(html).toContain("100% 530b908c-aaa"); // shortId truncates at 12 chars
-    expect(html).toContain("0% 1a2b3c4d-bbb");
-    // full id in title for 100% and 0%
-    expect(html).toContain("530b908c-aaaa = 100%");
-    expect(html).toContain("1a2b3c4d-bbbb = 0%");
+    // % と version id は別セル。short id は 12 文字短縮、full id は title。
+    expect(html).toContain(">100%</span>");
+    expect(html).toContain(">0%</span>");
+    expect(html).toContain("530b908c-aaa");
+    expect(html).toContain("1a2b3c4d-bbb");
+    expect(html).toContain('title="530b908c-aaaa"');
+    expect(html).toContain('title="1a2b3c4d-bbbb"');
+    // deploy/upload 日時 (UTC, MM-DD HH:mm)。
+    expect(html).toContain("05-28 11:37");
+    expect(html).toContain("05-29 07:02");
+  });
+
+  it("renders — for a version with no created_on (v1 record)", () => {
+    const map = new Map([
+      ["ippoan/x", rec("ippoan/x", [{ version_id: "v", percentage: 100 }])],
+    ]);
+    const html = renderTrafficVersionsBlock(["ippoan/x"], map);
+    expect(html).toContain(">100%</span>");
+    expect(html).toContain("—");
   });
 
   it("only lists repos that have a traffic record", () => {
@@ -478,8 +492,10 @@ describe("handleReleaseWaveListPageWithRepoStatus", () => {
     const res = await handleReleaseWaveListPageWithRepoStatus(env);
     const html = await res.text();
     expect(html).toContain("Traffic (version split)");
-    expect(html).toContain("100% full-100-id");
-    expect(html).toContain("0% zero-000-id");
+    expect(html).toContain(">100%</span>");
+    expect(html).toContain("full-100-id");
+    expect(html).toContain(">0%</span>");
+    expect(html).toContain("zero-000-id");
     // グラフ overlay の Staged previews より前 (= グラフ直下) に出る。
     expect(html.indexOf("Traffic (version split)")).toBeLessThan(
       html.indexOf("Staged previews (active waves)"),

--- a/test/release-wave/traffic.test.ts
+++ b/test/release-wave/traffic.test.ts
@@ -44,9 +44,31 @@ describe("traffic record", () => {
     });
     const rec = await getTraffic(kv, "ippoan/auth-worker");
     expect(rec).not.toBeNull();
-    expect(rec!.versions[0]).toEqual({ version_id: "full", percentage: 100 });
-    expect(rec!.versions[1]).toEqual({ version_id: "zero", percentage: 0 });
+    expect(rec!.versions[0].version_id).toBe("full");
+    expect(rec!.versions[1].version_id).toBe("zero");
     expect(rec!.reported_at).toBe("2026-05-29T00:00:00Z");
+    expect(rec!.schema_version).toBe(2);
+  });
+
+  it("recordTraffic breaks percentage ties by created_on desc (newest 0% first)", async () => {
+    const kv = memKv();
+    await recordTraffic(kv, {
+      repo: "ippoan/auth-worker",
+      versions: [
+        { version_id: "full", percentage: 100, created_on: "2026-05-20T00:00:00Z" },
+        { version_id: "zero-old", percentage: 0, created_on: "2026-05-28T00:00:00Z" },
+        { version_id: "zero-new", percentage: 0, created_on: "2026-05-29T00:00:00Z" },
+        { version_id: "zero-nodate", percentage: 0 },
+      ],
+      now: "t",
+    });
+    const rec = await getTraffic(kv, "ippoan/auth-worker");
+    expect(rec!.versions.map((v) => v.version_id)).toEqual([
+      "full", // 100% が先頭
+      "zero-new", // 0% は created_on 降順
+      "zero-old",
+      "zero-nodate", // created_on 無しは末尾
+    ]);
   });
 
   it("getTraffic returns null for a missing repo", async () => {

--- a/test/release-wave/webhook.test.ts
+++ b/test/release-wave/webhook.test.ts
@@ -650,7 +650,7 @@ const TRAFFIC_URL =
   "https://ci-dashboard.ippoan.org/webhooks/release-wave/traffic-report";
 
 describe("handleTrafficReportWebhook", () => {
-  it("records traffic split sorted by percentage desc (ok=true)", async () => {
+  it("records traffic split sorted by percentage desc (ok=true), carrying created_on", async () => {
     const kv = memKv();
     const { env } = fakeEnv({ compatKv: kv });
     const resp = await handleTrafficReportWebhook(
@@ -660,8 +660,8 @@ describe("handleTrafficReportWebhook", () => {
         body: {
           repo: "ippoan/auth-worker",
           versions: [
-            { version_id: "zero-id", percentage: 0 },
-            { version_id: "full-id", percentage: 100 },
+            { version_id: "zero-id", percentage: 0, created_on: "2026-05-29T07:00:00Z" },
+            { version_id: "full-id", percentage: 100, created_on: "2026-05-28T11:00:00Z" },
           ],
         },
       }),
@@ -670,8 +670,39 @@ describe("handleTrafficReportWebhook", () => {
     expect(resp.status).toBe(200);
     const rec = await getTraffic(kv, "ippoan/auth-worker");
     expect(rec).not.toBeNull();
-    expect(rec!.versions[0]).toEqual({ version_id: "full-id", percentage: 100 });
-    expect(rec!.versions[1]).toEqual({ version_id: "zero-id", percentage: 0 });
+    expect(rec!.versions[0]).toEqual({
+      version_id: "full-id",
+      percentage: 100,
+      created_on: "2026-05-28T11:00:00Z",
+    });
+    expect(rec!.versions[1]).toEqual({
+      version_id: "zero-id",
+      percentage: 0,
+      created_on: "2026-05-29T07:00:00Z",
+    });
+  });
+
+  it("defaults created_on to null when omitted", async () => {
+    const kv = memKv();
+    const { env } = fakeEnv({ compatKv: kv });
+    const resp = await handleTrafficReportWebhook(
+      jsonRequest({
+        url: TRAFFIC_URL,
+        secret: "expected-secret",
+        body: {
+          repo: "ippoan/x",
+          versions: [{ version_id: "v", percentage: 100 }],
+        },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(200);
+    const rec = await getTraffic(kv, "ippoan/x");
+    expect(rec!.versions[0]).toEqual({
+      version_id: "v",
+      percentage: 100,
+      created_on: null,
+    });
   });
 
   it("rejects an empty versions array with 400", async () => {


### PR DESCRIPTION
## 概要

要望「**0% の部分わかる？ いつ deploy されたかとかないと分からなくね？**」に対応。

これまで Traffic (version split) は `wrangler deployments list` の active deployment（通常 100% の1件）だけを出していて、**0%（no-traffic / promote 待ち）の version が出ず、deploy/upload 日時も無かった**。これを直す（ci-dashboard 受け側）。

## 変更点

### traffic.ts（schema v2）
- `TrafficVersion` に `created_on?` を追加（deploy(100%)/upload(0%) 日時）。
- `recordTraffic` は **percentage 降順 → 同率は created_on 降順**（新しい version が上）で並べる。
- `getTraffic` は v1 / v2 両方を許容（v1 = created_on 無し、後方互換）。

### webhook traffic-report
- `versions[].created_on`（任意）を受理して保存。

### 表示（repo-status-section.ts）
- Traffic テーブルを **version 1 行ずつ**「`%` / `version_id` / `Deployed・Uploaded (UTC MM-DD HH:mm)`」で描画。0%（promote 待ち）も日時付きで並ぶ。

### グラフノード（page.ts）— 「ここにも出して」
- Compatibility グラフの **frontend ノード hover (title)** に、その repo の全 version の `% version_id` を列挙。

## テスト
- page / traffic / repo-status-section / webhook、**全 green**（tsc 0 / 117+ tests）。

## 対の PR
送信側 ci-workflows#（次PR）で `deployments list` + `versions list` を join して 0% version + created_on を報告する変更とセット。

Refs ippoan/ci-workflows#83

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACYyQmmaf7LZH7XJYPEEBo)_