### PR TITLE
feat(release-wave): Traffic 表示の 0% version を絞ってノイズ削減

### DIFF
--- a/docs/release-wave.md
+++ b/docs/release-wave.md
@@ -284,11 +284,23 @@ caller repo (e.g. `rust-alc-api`) の migration deploy workflow に以下 step �
 ## Traffic (version split) — Compatibility グラフ下 (Refs #137)
 
 Compatibility グラフの直下に「Traffic (version split)」テーブルを出す。各 repo の
-worker version を **1 行ずつ** `percentage / version_id / deploy(100%)・upload(0%)
-日時` で並べ、**「どの version が 100% (active) / 0% (promote 待ち) で、それぞれ
-いつ deploy/upload されたか」**を一目で確認できる (緑 = 100% / 灰 = 0% / 黄 = その他)。
-version id は先頭 12 文字短縮 (full は hover)、日時は UTC `MM-DD HH:mm`。
+worker version を `percentage / version_id / deploy(100%)・upload(0%) 日時` で
+並べ、**「どの version が 100% (active) で、次の promote 候補 (0%) は何か」**を
+一目で確認できる (緑 = 100% / 灰 = 0% / 黄 = その他)。version id は先頭 12 文字
+短縮 (full は hover)、日時は UTC `MM-DD HH:mm`。
+
+0% (no-traffic) version は時間経過でいくらでも増える (= ノイズ) ため、表示を絞る:
+
+- traffic を受けている version (100% / canary 等、`percentage > 0`) は全行表示。
+- **active (100%) version より古い** deploy/upload の 0% version は非表示
+  (= もう用済みの過去履歴で promote 候補ではない)。
+- active より新しい 0% のうち **最新 1 件だけ**行表示 (= 次の flip 候補)。
+- それ以外の 0% は「他 N 件 (no-traffic) `最古〜最新`」の 1 行サマリに畳む。
+
 並び順は percentage 降順 → 同率は created_on 降順 (新しい version が上)。
+
+加えて Compatibility グラフの **frontend ノード hover (title)** にも、その repo の
+全 version の `% version_id` を列挙する (要望: グラフにも traffic)。
 
 加えて Compatibility グラフの **frontend ノード hover (title)** にも、その repo の
 全 version の `% version_id` を列挙する (要望: グラフにも traffic)。

--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -24,7 +24,11 @@ import {
 } from "./repo-release-status";
 import { computeGlobalCompatibility } from "./compat";
 import { parseTaglessRepos } from "../tagless-repos";
-import { getTrafficForRepos, type TrafficRecord } from "./traffic";
+import {
+  getTrafficForRepos,
+  type TrafficRecord,
+  type TrafficVersion,
+} from "./traffic";
 
 function escapeHtml(s: string): string {
   return s
@@ -228,11 +232,14 @@ function shortWhen(iso: string | null | undefined): string {
 
 /**
  * Compatibility グラフに出ている repo の version traffic split を HTML で返す。
- * frontend CI が報告した `traffic::<repo>` を読み、repo ごとに各 version を
- * 「percentage / version_id / deploy(100%)・upload(0%) 日時」で 1 行ずつ並べる。
+ * frontend CI が報告した `traffic::<repo>` を読み、repo ごとに:
+ *   - traffic を受けている version (100% / canary 等、percentage > 0) は全行表示
+ *   - 0% (no-traffic) は **最新 1 件だけ**行表示 (= 次に flip する候補)
+ *   - 残りの 0% version は「他 N 件 0% (oldest 〜 newest)」の 1 行サマリに畳む
+ * version は percentage 降順 → 同率 created_on 降順で並んでいる前提 (recordTraffic)。
  *
- * これで「100% (active) がどの version / 0% (promote 待ち) がどの version で、
- * それぞれいつ deploy/upload されたか」が一目で分かる。
+ * 0% の version history は時間経過でいくらでも増える (= ノイズ) ため、active と
+ * 直近の promote 候補だけ出し、古いものは件数サマリに集約する。
  * traffic 報告のある repo が 1 つも無ければ ""。
  */
 export function renderTrafficVersionsBlock(
@@ -244,28 +251,65 @@ export function renderTrafficVersionsBlock(
     .sort();
   if (list.length === 0) return "";
 
-  // 各 repo の各 version を 1 行ずつ (repo 名は最初の version 行にだけ出す)。
-  const rows = list
-    .map((repo) => {
-      const rec = trafficByRepo.get(repo)!;
-      return rec.versions
-        .map((v, i) => {
-          // 100% = 緑 / 0% = 灰 / その他 (canary 等) = 黄。
-          const color =
-            v.percentage >= 100 ? GREEN : v.percentage <= 0 ? GRAY : AMBER;
-          const pctBadge = `<span class="badge" style="background:${color}">${v.percentage}%</span>`;
-          const vid = `<code title="${escapeHtml(v.version_id)}">${escapeHtml(shortId(v.version_id))}</code>`;
-          const when = `<span class="meta" title="${escapeHtml(v.created_on ?? "")}">${escapeHtml(shortWhen(v.created_on))}</span>`;
-          const repoCell = i === 0 ? escapeHtml(repo) : "";
-          return `
+  const versionRow = (repo: string, v: TrafficVersion, first: boolean): string => {
+    // 100% = 緑 / 0% = 灰 / その他 (canary 等) = 黄。
+    const color = v.percentage >= 100 ? GREEN : v.percentage <= 0 ? GRAY : AMBER;
+    const pctBadge = `<span class="badge" style="background:${color}">${v.percentage}%</span>`;
+    const vid = `<code title="${escapeHtml(v.version_id)}">${escapeHtml(shortId(v.version_id))}</code>`;
+    const when = `<span class="meta" title="${escapeHtml(v.created_on ?? "")}">${escapeHtml(shortWhen(v.created_on))}</span>`;
+    return `
             <tr>
-              <td>${repoCell}</td>
+              <td>${first ? escapeHtml(repo) : ""}</td>
               <td>${pctBadge}</td>
               <td>${vid}</td>
               <td>${when}</td>
             </tr>`;
-        })
+  };
+
+  const rows = list
+    .map((repo) => {
+      const rec = trafficByRepo.get(repo)!;
+      const active = rec.versions.filter((v) => v.percentage > 0);
+      // active (100%) version の最新 created_on。これより古い 0% は「もう用済みの
+      // 過去履歴」(promote 候補ではない) なので除外する。active に日時が無い /
+      // active が無い場合は比較できないので 0% は全件残す。
+      const activeNewest = active
+        .map((v) => v.created_on)
+        .filter((c): c is string => !!c)
+        .sort()
+        .at(-1);
+      const zero = rec.versions
+        .filter((v) => v.percentage <= 0)
+        .filter((v) => {
+          if (!activeNewest) return true; // 比較不能 → 残す
+          if (!v.created_on) return false; // 日時不明の古い 0% は落とす
+          return v.created_on > activeNewest; // active より新しいものだけ
+        });
+      // versions は既に percentage 降順 → created_on 降順。zero[0] が最新 0%。
+      const zeroShown = zero.slice(0, 1);
+      const zeroRest = zero.slice(1);
+
+      const shown = [...active, ...zeroShown];
+      let out = shown
+        .map((v, i) => versionRow(repo, v, i === 0))
         .join("");
+
+      // active が 1 件も無い (= traffic 不明) 場合に repo 名が消えないよう、
+      // shown が空なら summary 行に repo 名を載せる。
+      if (zeroRest.length > 0) {
+        // 残り 0% は件数 + 期間サマリ。created_on 降順なので末尾が最古。
+        const newest = shortWhen(zeroRest[0]?.created_on);
+        const oldest = shortWhen(zeroRest[zeroRest.length - 1]?.created_on);
+        const span = newest === oldest ? newest : `${oldest}〜${newest}`;
+        out += `
+            <tr>
+              <td>${shown.length === 0 ? escapeHtml(repo) : ""}</td>
+              <td><span class="badge" style="background:${GRAY}">0%</span></td>
+              <td class="meta">他 ${zeroRest.length} 件 (no-traffic)</td>
+              <td><span class="meta">${escapeHtml(span)}</span></td>
+            </tr>`;
+      }
+      return out;
     })
     .join("");
 

--- a/test/release-wave/repo-status-section.test.ts
+++ b/test/release-wave/repo-status-section.test.ts
@@ -308,6 +308,44 @@ describe("renderTrafficVersionsBlock", () => {
     expect(html).not.toContain("<b>");
     expect(html).toContain("&lt;b&gt;");
   });
+
+  it("hides 0% versions older than the active (100%) version", () => {
+    const map = new Map([
+      [
+        "ippoan/auth-worker",
+        rec("ippoan/auth-worker", [
+          { version_id: "active-id", percentage: 100, created_on: "2026-05-28T11:00:00Z" },
+          { version_id: "newer-zero", percentage: 0, created_on: "2026-05-29T07:00:00Z" },
+          { version_id: "older-zero", percentage: 0, created_on: "2026-05-28T02:00:00Z" },
+        ]),
+      ],
+    ]);
+    const html = renderTrafficVersionsBlock(["ippoan/auth-worker"], map);
+    expect(html).toContain("active-id");
+    expect(html).toContain("newer-zero"); // active より新しい 0% は出る
+    expect(html).not.toContain("older-zero"); // active より古い 0% は隠す
+  });
+
+  it("shows only the newest 0% as a row and folds the rest into a summary", () => {
+    const map = new Map([
+      [
+        "ippoan/auth-worker",
+        rec("ippoan/auth-worker", [
+          { version_id: "active-id", percentage: 100, created_on: "2026-05-28T00:00:00Z" },
+          { version_id: "zero-newest", percentage: 0, created_on: "2026-05-29T09:00:00Z" },
+          { version_id: "zero-mid", percentage: 0, created_on: "2026-05-29T08:00:00Z" },
+          { version_id: "zero-old", percentage: 0, created_on: "2026-05-29T07:00:00Z" },
+        ]),
+      ],
+    ]);
+    const html = renderTrafficVersionsBlock(["ippoan/auth-worker"], map);
+    // 最新 0% だけ行表示。
+    expect(html).toContain("zero-newest");
+    expect(html).not.toContain("zero-mid");
+    expect(html).not.toContain("zero-old");
+    // 残りは件数サマリ。
+    expect(html).toContain("他 2 件 (no-traffic)");
+  });
 });
 
 describe("isUpToDate", () => {


### PR DESCRIPTION
## 概要

Traffic (version split) テーブルで **0% version が大量に並んで見づらい**問題を解消する。スクショでは active 1 件（100%）に対し 0% が 10 件以上並んでいた（version history の蓄積）。

## 表示ロジック（送信データは変更なし、ci-dashboard 表示のみ）

- traffic を受けている version（100% / canary、`percentage > 0`）→ **全行表示**
- **active (100%) より古い** deploy/upload の 0% → **非表示**（用済みの過去履歴で promote 候補ではない）
- active より新しい 0% のうち **最新 1 件だけ**行表示（= 次の flip 候補）
- 残りの 0% → 「**他 N 件 (no-traffic) `最古〜最新`**」の 1 行サマリに畳む

並びは percentage 降順 → 同率 created_on 降順（新しい version が上）。

### Before / After（auth-worker の例）
- Before: `100% 6403c1dc` + `0%` × 10件以上（05-29 も 05-28 も全部）
- After: `100% 6403c1dc (05-28 11:37)` + `0% <最新> (05-29 ...)` + `他 N 件 (no-traffic) 05-29 ...〜...`（05-28 11:37 より古い 0% は消える）

## テスト
- 「active より古い 0% を隠す」「最新 0% のみ行表示 + 残りサマリ」を追加。
- `npm run typecheck` ✅ / 関連 suite ✅ 41 tests。

Refs ippoan/ci-workflows#83

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACYyQmmaf7LZH7XJYPEEBo)_