### PR TITLE
feat(release-wave): version ごとの git tag を Traffic 表示に追加

### DIFF
--- a/docs/release-wave.md
+++ b/docs/release-wave.md
@@ -284,18 +284,25 @@ caller repo (e.g. `rust-alc-api`) の migration deploy workflow に以下 step �
 ## Traffic (version split) — Compatibility グラフ下 (Refs #137)
 
 Compatibility グラフの直下に「Traffic (version split)」テーブルを出す。各 repo の
-worker version を `percentage / version_id / deploy(100%)・upload(0%) 日時` で
+worker version を `percentage / tag・version_id / deploy(100%)・upload(0%) 日時` で
 並べ、**「どの version が 100% (active) で、次の promote 候補 (0%) は何か」**を
-一目で確認できる (緑 = 100% / 灰 = 0% / 黄 = その他)。version id は先頭 12 文字
-短縮 (full は hover)、日時は UTC `MM-DD HH:mm`。
+一目で確認できる (緑 = 100% / 灰 = 0% / 黄 = その他)。
 
+- **git release tag**: 各 version が upload された時点の git tag (例 `v0.2.42`) を
+  version id の前に太字で出す。100% (deployed) と 0% (uploaded) で **別 tag**に
+  なり得る。tag は deploy CI (`v*` push) が「その回 upload した version」分だけ
+  報告するため、ci-dashboard は version_id 単位に tag を **merge 蓄積** する
+  (過去 version の tag を保持)。報告前の version は tag 無し (id のみ)。
+- version id は先頭 12 文字短縮 (full は hover)、日時は UTC `MM-DD HH:mm`。
+
+行は created_on 降順 (新しい順) で並べ、**最新 0% が active(100%) より上**に出る。
 0% (no-traffic) version は時間経過でいくらでも増える (= ノイズ) ため、表示を絞る:
 
 - traffic を受けている version (100% / canary 等、`percentage > 0`) は全行表示。
 - **active (100%) version より古い** deploy/upload の 0% version は非表示
   (= もう用済みの過去履歴で promote 候補ではない)。
 - active より新しい 0% のうち **最新 1 件だけ**行表示 (= 次の flip 候補)。
-- それ以外の 0% は「他 N 件 (no-traffic) `最古〜最新`」の 1 行サマリに畳む。
+  残り件数は最新 0% 行の % セルに「(他N件)」で併記する。
 
 並び順は percentage 降順 → 同率は created_on 降順 (新しい version が上)。
 
@@ -319,12 +326,12 @@ versions list の全 version に percentage を join (無ければ 0%) + created
 これで **0% (no-traffic / promote 待ち) の version も日時付きで** 報告できる。
 
 ```jsonc
-// body (created_on は任意)
+// body (created_on / tag は任意)。tag は「今 upload した version」にだけ付く。
 {
   "repo": "ippoan/auth-worker",
   "versions": [
     { "version_id": "6403c1dc-...", "percentage": 100, "created_on": "2026-05-28T11:37:33Z" },
-    { "version_id": "ac6841e4-...", "percentage": 0,   "created_on": "2026-05-29T07:02:27Z" }
+    { "version_id": "ac6841e4-...", "percentage": 0,   "created_on": "2026-05-29T07:02:27Z", "tag": "v0.2.43" }
   ]
 }
 ```

--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -234,12 +234,10 @@ function shortWhen(iso: string | null | undefined): string {
  * Compatibility グラフに出ている repo の version traffic split を HTML で返す。
  * frontend CI が報告した `traffic::<repo>` を読み、repo ごとに:
  *   - traffic を受けている version (100% / canary 等、percentage > 0) は全行表示
- *   - 0% (no-traffic) は **最新 1 件だけ**行表示 (= 次に flip する候補)
- *   - 残りの 0% version は「他 N 件 0% (oldest 〜 newest)」の 1 行サマリに畳む
- * version は percentage 降順 → 同率 created_on 降順で並んでいる前提 (recordTraffic)。
- *
- * 0% の version history は時間経過でいくらでも増える (= ノイズ) ため、active と
- * 直近の promote 候補だけ出し、古いものは件数サマリに集約する。
+ *   - 0% (no-traffic) は active より新しいものだけ対象にし、**最新 1 件だけ**行表示
+ *     (= 次に flip する候補)。残り件数は最新 0% 行の % セルに「(他N件)」併記
+ *   - active より古い 0% は非表示 (= 用済みの過去履歴)
+ * 行は created_on 降順 (新しい順) で並べる → 最新 0% が active(100%) より上に出る。
  * traffic 報告のある repo が 1 つも無ければ ""。
  */
 export function renderTrafficVersionsBlock(
@@ -251,11 +249,23 @@ export function renderTrafficVersionsBlock(
     .sort();
   if (list.length === 0) return "";
 
-  const versionRow = (repo: string, v: TrafficVersion, first: boolean): string => {
+  // 1 行 = 1 version。% セルに余剰件数 (extra) を「(他N件)」で併記する。
+  const versionRow = (
+    repo: string,
+    v: TrafficVersion,
+    first: boolean,
+    extra: number,
+  ): string => {
     // 100% = 緑 / 0% = 灰 / その他 (canary 等) = 黄。
     const color = v.percentage >= 100 ? GREEN : v.percentage <= 0 ? GRAY : AMBER;
-    const pctBadge = `<span class="badge" style="background:${color}">${v.percentage}%</span>`;
-    const vid = `<code title="${escapeHtml(v.version_id)}">${escapeHtml(shortId(v.version_id))}</code>`;
+    const more = extra > 0 ? ` <span class="meta">(他${extra}件)</span>` : "";
+    const pctBadge = `<span class="badge" style="background:${color}">${v.percentage}%</span>${more}`;
+    // Version セルは「git tag (upload 時点) + wrangler version id」。tag は
+    // 100% (deployed) と 0% (uploaded) で異なり得る。tag 不明なら id のみ。
+    const tagPart = v.tag
+      ? `<strong>${escapeHtml(v.tag)}</strong> `
+      : "";
+    const vid = `${tagPart}<code title="${escapeHtml(v.version_id)}">${escapeHtml(shortId(v.version_id))}</code>`;
     const when = `<span class="meta" title="${escapeHtml(v.created_on ?? "")}">${escapeHtml(shortWhen(v.created_on))}</span>`;
     return `
             <tr>
@@ -285,31 +295,34 @@ export function renderTrafficVersionsBlock(
           if (!v.created_on) return false; // 日時不明の古い 0% は落とす
           return v.created_on > activeNewest; // active より新しいものだけ
         });
-      // versions は既に percentage 降順 → created_on 降順。zero[0] が最新 0%。
+      // 表示する version = active 全件 + 最新 0% 1 件。残り 0% 件数は最新 0% 行の
+      // % セルに「(他N件)」で併記する (= 別行サマリは作らない)。
       const zeroShown = zero.slice(0, 1);
-      const zeroRest = zero.slice(1);
+      const zeroExtra = Math.max(0, zero.length - 1);
 
       const shown = [...active, ...zeroShown];
-      let out = shown
-        .map((v, i) => versionRow(repo, v, i === 0))
-        .join("");
+      // 日時降順 (新しい順) で並べる。created_on 無しは末尾。これで 0% (最新)
+      // が 100% (より古い active) の上に来る。
+      shown.sort((a, b) => {
+        const ca = a.created_on ?? "";
+        const cb = b.created_on ?? "";
+        if (ca === cb) return 0;
+        if (!ca) return 1;
+        if (!cb) return -1;
+        return ca < cb ? 1 : -1;
+      });
 
-      // active が 1 件も無い (= traffic 不明) 場合に repo 名が消えないよう、
-      // shown が空なら summary 行に repo 名を載せる。
-      if (zeroRest.length > 0) {
-        // 残り 0% は件数 + 期間サマリ。created_on 降順なので末尾が最古。
-        const newest = shortWhen(zeroRest[0]?.created_on);
-        const oldest = shortWhen(zeroRest[zeroRest.length - 1]?.created_on);
-        const span = newest === oldest ? newest : `${oldest}〜${newest}`;
-        out += `
-            <tr>
-              <td>${shown.length === 0 ? escapeHtml(repo) : ""}</td>
-              <td><span class="badge" style="background:${GRAY}">0%</span></td>
-              <td class="meta">他 ${zeroRest.length} 件 (no-traffic)</td>
-              <td><span class="meta">${escapeHtml(span)}</span></td>
-            </tr>`;
-      }
-      return out;
+      return shown
+        .map((v, i) =>
+          versionRow(
+            repo,
+            v,
+            i === 0,
+            // 余剰件数は最新 0% (= zeroShown) の行にだけ付ける。
+            v === zeroShown[0] ? zeroExtra : 0,
+          ),
+        )
+        .join("");
     })
     .join("");
 
@@ -317,7 +330,7 @@ export function renderTrafficVersionsBlock(
     <div style="margin-top:10px">
       <strong class="meta">Traffic (version split)</strong>
       <table style="margin-top:6px">
-        <thead><tr><th>Repo</th><th>%</th><th>Version</th><th>Deployed / Uploaded (UTC)</th></tr></thead>
+        <thead><tr><th>Repo</th><th>%</th><th>Tag / Version</th><th>Deployed / Uploaded (UTC)</th></tr></thead>
         <tbody>${rows}</tbody>
       </table>
     </div>`;

--- a/src/release-wave/traffic.ts
+++ b/src/release-wave/traffic.ts
@@ -11,9 +11,14 @@
  */
 
 const TRAFFIC_PREFIX = "traffic::";
-// v2: TrafficVersion に created_on を追加 (deploy/upload 日時)。v1 record は
-// created_on 無しとして読めるよう、reader は両方許容する (後方互換)。
-const SCHEMA_VERSION = 2 as const;
+// schema 変遷:
+//   v1: { version_id, percentage }
+//   v2: + created_on (deploy/upload 日時)
+//   v3: + tag (upload 時点の git release tag)。tag は deploy CI ごとに「その回
+//       upload した version」分しか報告されないため、recordTraffic で version_id
+//       単位に **merge 蓄積** する (過去 version の tag を保持)。
+// reader は v1/v2/v3 全部許容する (後方互換)。
+const SCHEMA_VERSION = 3 as const;
 
 /** version 1 件の traffic 配分。 */
 export interface TrafficVersion {
@@ -27,6 +32,12 @@ export interface TrafficVersion {
    * 取得できなかった / v1 record では null。
    */
   created_on?: string | null;
+  /**
+   * upload された時点の git release tag (例 "v0.2.43")。deploy CI が
+   * github.ref_name を報告。100% と 0% で別 tag になり得る。
+   * 不明 (過去 version で報告前 / 報告無し) は null。
+   */
+  tag?: string | null;
 }
 
 /** `traffic::<repo>` value。repo ごとに最新の deployment 配分のみ保持 (upsert)。 */
@@ -48,9 +59,15 @@ function trafficKey(repo: string): string {
 }
 
 /**
- * upsert: repo ごとに最新報告で上書きする。
+ * 報告された versions[] で record を更新する。version 配分そのものは最新報告で
+ * 置き換える (wrangler 側で消えた version は残さない) が、各 version の **tag は
+ * 既存 record と merge 蓄積**する:
+ *   - 新報告に tag があればそれを採用
+ *   - 無ければ既存 record の同 version_id の tag を引き継ぐ
+ * deploy CI は「その回 upload した version」の tag しか送れないため、過去 version
+ * の tag を取りこぼさないようこの merge を行う。
+ *
  * versions は percentage 降順 → 同率は created_on 降順 (新しい順) で並べて保存。
- * これで「100% (active)」が先頭、その後に 0% の新しい version から並ぶ。
  */
 export async function recordTraffic(
   kv: KVNamespace,
@@ -60,7 +77,24 @@ export async function recordTraffic(
     now: string;
   },
 ): Promise<TrafficRecord> {
-  const versions = [...input.versions].sort((a, b) => {
+  // 既存 record から version_id → tag を引き継ぐ準備。
+  const prev = await getTraffic(kv, input.repo);
+  const prevTagById = new Map<string, string>();
+  if (prev) {
+    for (const v of prev.versions) {
+      if (v.tag) prevTagById.set(v.version_id, v.tag);
+    }
+  }
+
+  const merged = input.versions.map((v) => ({
+    version_id: v.version_id,
+    percentage: v.percentage,
+    created_on: v.created_on ?? null,
+    // 新報告の tag 優先、無ければ既存 record の tag を保持。
+    tag: v.tag ?? prevTagById.get(v.version_id) ?? null,
+  }));
+
+  merged.sort((a, b) => {
     if (b.percentage !== a.percentage) return b.percentage - a.percentage;
     // 同 percentage は created_on 降順 (新しい version を上に)。null は末尾。
     const ca = a.created_on ?? "";
@@ -73,7 +107,7 @@ export async function recordTraffic(
   const record: TrafficRecord = {
     schema_version: SCHEMA_VERSION,
     repo: input.repo,
-    versions,
+    versions: merged,
     reported_at: input.now,
   };
   await kv.put(trafficKey(input.repo), JSON.stringify(record));
@@ -82,14 +116,14 @@ export async function recordTraffic(
 
 /**
  * 単一 repo の traffic を取得 (無ければ null)。
- * v1 / v2 どちらの record も許容する (v1 は created_on 無し)。古い v0 等は無視。
+ * v1 / v2 / v3 の record を許容する (v1 は created_on 無し、v1/v2 は tag 無し)。
  */
 export async function getTraffic(
   kv: KVNamespace,
   repo: string,
 ): Promise<TrafficRecord | null> {
   const v = await kv.get<TrafficRecord>(trafficKey(repo), "json");
-  if (!v || (v.schema_version !== 1 && v.schema_version !== 2)) return null;
+  if (!v || v.schema_version < 1 || v.schema_version > 3) return null;
   return v;
 }
 

--- a/src/release-wave/webhook.ts
+++ b/src/release-wave/webhook.ts
@@ -461,6 +461,7 @@ const trafficReportSchema = z.object({
         version_id: z.string().min(1),
         percentage: z.number().min(0).max(100),
         created_on: z.string().min(1).optional(),
+        tag: z.string().min(1).optional(),
       }),
     )
     .min(1),
@@ -484,6 +485,7 @@ export async function handleTrafficReportWebhook(
       version_id: x.version_id,
       percentage: x.percentage,
       created_on: x.created_on ?? null,
+      tag: x.tag ?? null,
     })),
     now: new Date().toISOString(),
   });

--- a/test/release-wave/repo-status-section.test.ts
+++ b/test/release-wave/repo-status-section.test.ts
@@ -253,6 +253,24 @@ describe("renderTrafficVersionsBlock", () => {
     return { schema_version: 1, repo, versions, reported_at: "t" };
   }
 
+  it("shows the per-version git tag next to the version id", () => {
+    const map = new Map([
+      [
+        "ippoan/auth-worker",
+        rec("ippoan/auth-worker", [
+          { version_id: "deployed-id", percentage: 100, created_on: "2026-05-28T11:00:00Z", tag: "v0.2.42" },
+          { version_id: "uploaded-id", percentage: 0, created_on: "2026-05-29T08:00:00Z", tag: "v0.2.43" },
+        ]),
+      ],
+    ]);
+    const html = renderTrafficVersionsBlock(["ippoan/auth-worker"], map);
+    // 100% (deployed) と 0% (uploaded) で別 tag が出る。
+    expect(html).toContain("v0.2.42");
+    expect(html).toContain("v0.2.43");
+    expect(html).toContain("deployed-id");
+    expect(html).toContain("uploaded-id");
+  });
+
   it("shows 100% and 0% version ids (+ deploy/upload 日時) for a repo", () => {
     const map = new Map([
       [
@@ -326,7 +344,7 @@ describe("renderTrafficVersionsBlock", () => {
     expect(html).not.toContain("older-zero"); // active より古い 0% は隠す
   });
 
-  it("shows only the newest 0% as a row and folds the rest into a summary", () => {
+  it("shows only the newest 0% as a row and folds the rest into the % cell", () => {
     const map = new Map([
       [
         "ippoan/auth-worker",
@@ -343,8 +361,10 @@ describe("renderTrafficVersionsBlock", () => {
     expect(html).toContain("zero-newest");
     expect(html).not.toContain("zero-mid");
     expect(html).not.toContain("zero-old");
-    // 残りは件数サマリ。
-    expect(html).toContain("他 2 件 (no-traffic)");
+    // 残り件数は % セルに「(他N件)」併記 (別サマリ行ではない)。
+    expect(html).toContain("(他2件)");
+    // 0% (最新) が 100% (より古い active) より上に来る (日時降順)。
+    expect(html.indexOf("zero-newest")).toBeLessThan(html.indexOf("active-id"));
   });
 });
 

--- a/test/release-wave/traffic.test.ts
+++ b/test/release-wave/traffic.test.ts
@@ -47,7 +47,7 @@ describe("traffic record", () => {
     expect(rec!.versions[0].version_id).toBe("full");
     expect(rec!.versions[1].version_id).toBe("zero");
     expect(rec!.reported_at).toBe("2026-05-29T00:00:00Z");
-    expect(rec!.schema_version).toBe(2);
+    expect(rec!.schema_version).toBe(3);
   });
 
   it("recordTraffic breaks percentage ties by created_on desc (newest 0% first)", async () => {
@@ -95,8 +95,36 @@ describe("traffic record", () => {
       now: "t2",
     });
     const rec = await getTraffic(kv, "ippoan/x");
-    expect(rec!.versions).toEqual([{ version_id: "b", percentage: 100 }]);
+    expect(rec!.versions).toEqual([
+      { version_id: "b", percentage: 100, created_on: null, tag: null },
+    ]);
     expect(rec!.reported_at).toBe("t2");
+  });
+
+  it("merges (accumulates) tags across reports per version_id", async () => {
+    const kv = memKv();
+    // 1 回目: full に tag v1.0.0 が付く。
+    await recordTraffic(kv, {
+      repo: "ippoan/x",
+      versions: [
+        { version_id: "full", percentage: 100, tag: "v1.0.0" },
+        { version_id: "zero", percentage: 0 },
+      ],
+      now: "t1",
+    });
+    // 2 回目: zero に tag v1.0.1。full は tag を送らない (= 既存 v1.0.0 を保持)。
+    await recordTraffic(kv, {
+      repo: "ippoan/x",
+      versions: [
+        { version_id: "full", percentage: 100 },
+        { version_id: "zero", percentage: 0, tag: "v1.0.1" },
+      ],
+      now: "t2",
+    });
+    const rec = await getTraffic(kv, "ippoan/x");
+    const byId = Object.fromEntries(rec!.versions.map((v) => [v.version_id, v.tag]));
+    expect(byId["full"]).toBe("v1.0.0"); // 過去 report の tag を保持
+    expect(byId["zero"]).toBe("v1.0.1"); // 新 report の tag
   });
 
   it("getTrafficForRepos returns only repos that have a record", async () => {

--- a/test/release-wave/webhook.test.ts
+++ b/test/release-wave/webhook.test.ts
@@ -674,11 +674,13 @@ describe("handleTrafficReportWebhook", () => {
       version_id: "full-id",
       percentage: 100,
       created_on: "2026-05-28T11:00:00Z",
+      tag: null,
     });
     expect(rec!.versions[1]).toEqual({
       version_id: "zero-id",
       percentage: 0,
       created_on: "2026-05-29T07:00:00Z",
+      tag: null,
     });
   });
 
@@ -702,7 +704,27 @@ describe("handleTrafficReportWebhook", () => {
       version_id: "v",
       percentage: 100,
       created_on: null,
+      tag: null,
     });
+  });
+
+  it("stores the per-version tag and merges it across reports", async () => {
+    const kv = memKv();
+    const { env } = fakeEnv({ compatKv: kv });
+    const resp = await handleTrafficReportWebhook(
+      jsonRequest({
+        url: TRAFFIC_URL,
+        secret: "expected-secret",
+        body: {
+          repo: "ippoan/x",
+          versions: [{ version_id: "v1", percentage: 0, tag: "v0.2.43" }],
+        },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(200);
+    const rec = await getTraffic(kv, "ippoan/x");
+    expect(rec!.versions[0].tag).toBe("v0.2.43");
   });
 
   it("rejects an empty versions array with 400", async () => {


### PR DESCRIPTION
## 概要

Traffic (version split) の各 version に **「upload された時点の git release tag」** を出す。100% (deployed) と 0% (uploaded) で **別 tag** になり得るのを正しく表示する（要望: deploy ver の隣に tag、0% と deployed で tag が違う）。

## 仕組み（merge 蓄積）

deploy CI は `v*` タグ push で走るので「その回 upload した version の tag」しか分からない。過去 version の tag を取りこぼさないため、**version_id 単位で tag を merge 蓄積**する:

- `recordTraffic`: 既存 record の `version_id → tag` を読み、新報告に tag がある version はそれを採用、無い version は既存 tag を保持。
- version 配分自体は最新報告で置換（wrangler で消えた version は残さない）。

## 変更点
- `traffic.ts`: `TrafficVersion.tag` 追加（**schema v3**）、`recordTraffic` を read+merge に。`getTraffic` は v1/v2/v3 後方互換。
- `webhook.ts`: traffic-report が `versions[].tag`（任意）を受理。
- `repo-status-section.ts`: Version セルを「**tag (太字) + version_id**」に（列名 `Tag / Version`）。
- docs / test 追従。

## テスト
- tag の merge 蓄積（過去 report の tag 保持）/ webhook 受理 / 表示を追加。
- `npm run typecheck` ✅ / 関連 suite ✅ **123 tests**。

## 対の PR
送信側 ci-workflows#（別PR）が deploy step の uploaded version_id に `github.ref_name` を紐付けて報告。

Refs ippoan/ci-workflows#83

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACYyQmmaf7LZH7XJYPEEBo)_