### PR TITLE
fix(release-wave): traffic-report schema を null 許容に (堅牢化)

### DIFF
--- a/src/release-wave/webhook.ts
+++ b/src/release-wave/webhook.ts
@@ -460,8 +460,9 @@ const trafficReportSchema = z.object({
       z.object({
         version_id: z.string().min(1),
         percentage: z.number().min(0).max(100),
-        created_on: z.string().min(1).optional(),
-        tag: z.string().min(1).optional(),
+        // null / undefined / 省略すべて許容 (送信側が null を載せても弾かない)。
+        created_on: z.string().min(1).nullish(),
+        tag: z.string().min(1).nullish(),
       }),
     )
     .min(1),

--- a/test/release-wave/webhook.test.ts
+++ b/test/release-wave/webhook.test.ts
@@ -727,6 +727,30 @@ describe("handleTrafficReportWebhook", () => {
     expect(rec!.versions[0].tag).toBe("v0.2.43");
   });
 
+  it("accepts explicit null created_on / tag (does not 400)", async () => {
+    const kv = memKv();
+    const { env } = fakeEnv({ compatKv: kv });
+    const resp = await handleTrafficReportWebhook(
+      jsonRequest({
+        url: TRAFFIC_URL,
+        secret: "expected-secret",
+        body: {
+          repo: "ippoan/x",
+          versions: [
+            { version_id: "a", percentage: 100, created_on: null, tag: null },
+            { version_id: "b", percentage: 0, created_on: "2026-05-29T00:00:00Z", tag: "v9.9.9" },
+          ],
+        },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(200);
+    const rec = await getTraffic(kv, "ippoan/x");
+    const byId = Object.fromEntries(rec!.versions.map((v) => [v.version_id, v.tag]));
+    expect(byId["a"]).toBeNull();
+    expect(byId["b"]).toBe("v9.9.9");
+  });
+
   it("rejects an empty versions array with 400", async () => {
     const kv = memKv();
     const { env } = fakeEnv({ compatKv: kv });


### PR DESCRIPTION
## 概要

traffic-report の zod schema を **null 許容**にする堅牢化（受け側ガード）。

auth-worker `v0.2.48` で送信側が `"tag":null` を載せた際、`created_on` / `tag` の `.optional()`（= `undefined` のみ許容）が **null を弾いて 400 → deploy CI fail** した。送信側（ci-workflows #87）で null を省略する修正と**二重に**防ぐ。

## 変更
- `trafficReportSchema` の `created_on` / `tag` を `.optional()` → **`.nullish()`**（`string | null | undefined | 省略` すべて許容）。
- handler は既に `x.created_on ?? null` / `x.tag ?? null` で coerce 済みなので record 形は不変。

## テスト
- 「explicit null created_on / tag を 200 で受理」する回帰テストを追加。
- `npm run typecheck` ✅ / 関連テスト ✅ 45 passed。

## 対の PR
送信側 ci-workflows#87（null 省略 + version 件数制限）とセット。

Refs ippoan/ci-workflows#83

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACYyQmmaf7LZH7XJYPEEBo)_