### PR TITLE
feat(release-wave): Compatibility グラフの frontend ノードに traffic (tag/%) を表示

### DIFF
--- a/docs/release-wave.md
+++ b/docs/release-wave.md
@@ -306,11 +306,13 @@ worker version を `percentage / tag・version_id / deploy(100%)・upload(0%) �
 
 並び順は percentage 降順 → 同率は created_on 降順 (新しい version が上)。
 
-加えて Compatibility グラフの **frontend ノード hover (title)** にも、その repo の
-全 version の `% version_id` を列挙する (要望: グラフにも traffic)。
+加えて Compatibility グラフの **frontend ノード**にも traffic を出す (要望: グラフにも):
+- 2 行目: `deploy <deployed tag>`。直近 upload version が別なら `· new <latest tag>` も。
+  tag が無い version は short version id で代替。
+- 3 行目: `traffic <100% 等の %> · 0%×<件数>`。
+- hover (title): 全 version の `% tag version_id` を列挙。
 
-加えて Compatibility グラフの **frontend ノード hover (title)** にも、その repo の
-全 version の `% version_id` を列挙する (要望: グラフにも traffic)。
+(traffic 報告が無い repo のノードは従来どおり `prod version · vs @<tested image sha>`。)
 
 データソースは frontend CI からの webhook 報告:
 

--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -912,7 +912,8 @@ function renderCompatibilitySvg(
 
   // ---- layout ----
   const boxW = 250;
-  const boxH = 38;
+  // 3 行 (repo / deployed・latest tag / traffic %) 入るよう高さを確保。
+  const boxH = 54;
   const vGap = 22;
   const topPad = 28; // legend 用
   const sidePad = 16;
@@ -961,14 +962,20 @@ function renderCompatibilitySvg(
     border: string,
     fullTitle: string,
     href?: string,
+    line3?: string,
   ): string => {
+    const line3Svg = line3
+      ? `<text x="${x + 10}" y="${y + 45}" font-family="monospace" font-size="10.5"
+        fill="${GRAY}">${escapeHtml(truncLabel(line3, 40))}</text>`
+      : "";
     const g = `<g><title>${escapeHtml(fullTitle)}</title>
       <rect x="${x}" y="${y}" width="${boxW}" height="${boxH}" rx="6"
         fill="#ffffff" stroke="${border}" stroke-width="1.5"/>
-      <text x="${x + 10}" y="${y + 15}" font-family="monospace" font-size="12"
+      <text x="${x + 10}" y="${y + 16}" font-family="monospace" font-size="12"
         fill="#202124">${escapeHtml(truncLabel(line1, 32))}</text>
-      <text x="${x + 10}" y="${y + 29}" font-family="monospace" font-size="10.5"
-        fill="${GRAY}">${escapeHtml(truncLabel(line2, 36))}</text>
+      <text x="${x + 10}" y="${y + 31}" font-family="monospace" font-size="10.5"
+        fill="${GRAY}">${escapeHtml(truncLabel(line2, 40))}</text>
+      ${line3Svg}
     </g>`;
     // active wave 中の frontend node は詳細ページへの link にする (node link 化)。
     return href
@@ -998,9 +1005,6 @@ function renderCompatibilitySvg(
       const verdictTxt = frontendHasRed.get(repo)
         ? "has untested edge(s)"
         : "all tested";
-      // line2 に突合 SHA を出して backend ノードの @<sha> と目視照合できるように
-      // する。tested 済 image が無ければ prod version に fallback。
-      const line2 = testedImg ? `${ver} · vs @${shortSha(testedImg)}` : `prod ${ver}`;
       const waveId = active?.waveOf.get(repo);
       const href = waveId
         ? `/release-wave/${encodeURIComponent(waveId)}`
@@ -1008,16 +1012,51 @@ function renderCompatibilitySvg(
       const previewNote = active?.preview.has(repo)
         ? `\npreview: ${active.preview.get(repo)!.url}`
         : "";
-      // traffic (version split) を hover (title) に出す。active(100%) / 0% の
-      // version id と % を、報告があれば列挙する (要望: ノードにも traffic)。
+
+      // traffic (version split) からノードに出す値を組む:
+      //   - deployed: 現在 traffic を受けている (percentage 最大) version の tag
+      //   - latest:   created_on が最新 (= 直近 upload) version の tag
+      //   - traffic %: 各 version の % を簡潔に (例 "100% / 0%×N")
       const traffic = trafficByRepo?.get(repo);
-      const trafficNote =
-        traffic && traffic.versions.length > 0
-          ? "\ntraffic:\n" +
-            traffic.versions
-              .map((v) => `  ${v.percentage}% ${v.version_id}`)
-              .join("\n")
-          : "";
+      const tv = traffic?.versions ?? [];
+      const labelOf = (v: TrafficRecord["versions"][number] | undefined): string =>
+        v ? (v.tag ?? shortSha(v.version_id)) : "—";
+      const deployed = tv.length
+        ? [...tv].sort((a, b) => b.percentage - a.percentage)[0]
+        : undefined;
+      const latest = tv.length
+        ? [...tv].sort((a, b) => (a.created_on ?? "") < (b.created_on ?? "") ? 1 : -1)[0]
+        : undefined;
+      // line2: deployed tag / latest tag (異なる時だけ latest も出す)。traffic が
+      // 無ければ従来どおり prod version + tested image SHA。
+      let line2: string;
+      let line3: string | undefined;
+      if (tv.length) {
+        const dep = labelOf(deployed);
+        const lat = labelOf(latest);
+        line2 =
+          deployed && latest && deployed.version_id !== latest.version_id
+            ? `deploy ${dep} · new ${lat}`
+            : `deploy ${dep}`;
+        // line3: traffic %。100% version と 0% の件数を簡潔に。
+        const pos = tv.filter((v) => v.percentage > 0);
+        const zero = tv.length - pos.length;
+        const posPart = pos.map((v) => `${v.percentage}%`).join("/") || "—";
+        line3 = zero > 0 ? `traffic ${posPart} · 0%×${zero}` : `traffic ${posPart}`;
+      } else {
+        line2 = testedImg ? `${ver} · vs @${shortSha(testedImg)}` : `prod ${ver}`;
+      }
+
+      // hover (title) には全 version の % / tag / id を列挙。
+      const trafficNote = tv.length
+        ? "\ntraffic:\n" +
+          tv
+            .map(
+              (v) =>
+                `  ${v.percentage}% ${v.tag ? v.tag + " " : ""}${v.version_id}`,
+            )
+            .join("\n")
+        : "";
       return node(
         rightX,
         fY(repo),
@@ -1026,6 +1065,7 @@ function renderCompatibilitySvg(
         border,
         `${repo}\nprod version: ${ver}\ntested vs image: ${testedImg ?? "—"}\n${verdictTxt}${previewNote}${trafficNote}`,
         href,
+        line3,
       );
     })
     .join("");

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -296,21 +296,27 @@ describe("handleReleaseWaveListPage", () => {
           ],
         },
         "traffic::ippoan/auth-worker": {
-          schema_version: 2,
+          schema_version: 3,
           repo: "ippoan/auth-worker",
           versions: [
-            { version_id: "6403c1dc-full", percentage: 100, created_on: "2026-05-28T11:00:00Z" },
-            { version_id: "ac6841e4-zero", percentage: 0, created_on: "2026-05-29T07:00:00Z" },
+            { version_id: "6403c1dc-full", percentage: 100, created_on: "2026-05-28T11:00:00Z", tag: "v0.2.42" },
+            { version_id: "ac6841e4-zero", percentage: 0, created_on: "2026-05-29T07:00:00Z", tag: "v0.2.49" },
           ],
           reported_at: "2026-05-29T07:02:00Z",
         },
       }),
     });
     const html = await (await handleReleaseWaveListPage(env)).text();
-    // SVG node の <title> (hover) に traffic 行が出る。
+    // SVG node の可視ラベル: deployed tag (100% = v0.2.42) と latest tag
+    // (最新 created_on = v0.2.49)、traffic %。
+    expect(html).toContain("deploy v0.2.42");
+    expect(html).toContain("new v0.2.49");
+    expect(html).toContain("traffic 100%");
+    expect(html).toContain("0%×1");
+    // hover (title) には全 version の % / tag / id を列挙。
     expect(html).toContain("traffic:");
-    expect(html).toContain("100% 6403c1dc-full");
-    expect(html).toContain("0% ac6841e4-zero");
+    expect(html).toContain("100% v0.2.42 6403c1dc-full");
+    expect(html).toContain("0% v0.2.49 ac6841e4-zero");
   });
 });
 


### PR DESCRIPTION
## 概要

Compatibility (all consumers) グラフの **frontend ノード**に traffic 情報を表示する（要望: テーブルだけでなく SVG グラフのノードにも tag / traffic を出す）。

これまでノードは `prod version · vs @<tested image sha>` の2行だけだった。これを traffic KV の値で拡張:

- **2 行目**: `deploy <deployed tag>`（traffic % 最大の version の tag）。直近 upload version が別なら `· new <latest tag>` も併記。
- **3 行目**: `traffic <100% 等の %> · 0%×<件数>`。
- **hover (title)**: 全 version の `% tag version_id` を列挙。
- tag が無い version は short version id で代替。**traffic 報告が無い repo** のノードは従来どおり `prod version · vs @sha`。

## 変更点
- ノードボックスを 3 行に拡張（`boxH` 38→54、`node()` に `line3` 引数追加）。backend ノードは2行のまま（余白増）。
- frontend ノード生成で traffic から deployed/latest/% を算出。

## テスト
- `page.test.ts` の compat グラフ traffic テストを拡張（`deploy v0.2.42` / `new v0.2.49` / `traffic 100%` / `0%×1` + hover の tag 付き列挙を assert）。
- `npm run typecheck` ✅ / page・traffic・section・webhook テスト ✅。

Refs ippoan/ci-dashboard#137

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACYyQmmaf7LZH7XJYPEEBo)_