### PR TITLE
fix(release-wave): グラフノードの 0%×N から deployed より古い version を除外

### DIFF
--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -1038,11 +1038,19 @@ function renderCompatibilitySvg(
           deployed && latest && deployed.version_id !== latest.version_id
             ? `deploy ${dep} · new ${lat}`
             : `deploy ${dep}`;
-        // line3: traffic %。100% version と 0% の件数を簡潔に。
+        // line3: traffic %。100% version と「promote 待ち」の 0% 件数。
+        // deployed(active) より古い 0% は用済みの過去履歴なので数えない
+        // (テーブル renderRepoReleaseStatusSection と同じ絞り込み)。
         const pos = tv.filter((v) => v.percentage > 0);
-        const zero = tv.length - pos.length;
+        const depWhen = deployed?.created_on ?? null;
+        const zeroPending = tv.filter(
+          (v) =>
+            v.percentage <= 0 &&
+            (!depWhen || (v.created_on != null && v.created_on > depWhen)),
+        ).length;
         const posPart = pos.map((v) => `${v.percentage}%`).join("/") || "—";
-        line3 = zero > 0 ? `traffic ${posPart} · 0%×${zero}` : `traffic ${posPart}`;
+        line3 =
+          zeroPending > 0 ? `traffic ${posPart} · 0%×${zeroPending}` : `traffic ${posPart}`;
       } else {
         line2 = testedImg ? `${ver} · vs @${shortSha(testedImg)}` : `prod ${ver}`;
       }

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -301,6 +301,8 @@ describe("handleReleaseWaveListPage", () => {
           versions: [
             { version_id: "6403c1dc-full", percentage: 100, created_on: "2026-05-28T11:00:00Z", tag: "v0.2.42" },
             { version_id: "ac6841e4-zero", percentage: 0, created_on: "2026-05-29T07:00:00Z", tag: "v0.2.49" },
+            // deployed(05-28 11:00) より古い 0% → promote 候補ではないので数えない。
+            { version_id: "old0-zero", percentage: 0, created_on: "2026-05-20T00:00:00Z" },
           ],
           reported_at: "2026-05-29T07:02:00Z",
         },


### PR DESCRIPTION
## 概要

Compatibility グラフの frontend ノード3行目 `traffic ... · 0%×N` が、**deployed(active) version より古い 0% version も数えていた**（`0%×20` のように過去履歴まで含む）。

テーブル側（`renderRepoReleaseStatusSection`）は既に「active より古い 0% は promote 候補ではないので除外」しているので、グラフノードの集計もそれに揃える。

## 修正
3行目の 0% 件数を、**deployed の `created_on` より新しい 0% version のみ**カウント（deployed の日時が無い場合は全 0% を数える従来挙動にフォールバック）。

## テスト
`page.test.ts` の compat グラフ traffic seed に「deployed より古い 0%」を1件追加し、`0%×1` のまま（古いものは数えない）を検証。`npm run typecheck` ✅ / page 37 tests ✅。

Refs ippoan/ci-dashboard#137

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACYyQmmaf7LZH7XJYPEEBo)_