### PR TITLE
feat(release-wave): deployed 履歴を記録して /release-wave から rollback

### DIFF
--- a/docs/release-wave-compatibility-kv.md
+++ b/docs/release-wave-compatibility-kv.md
@@ -101,11 +101,14 @@ context value)。lower-case / hyphen は GitHub 側の正規化に従う。
 
 ```jsonc
 {
-  "schema_version": 1,
+  // v1: current_image のみ / v2: + current_tag + deploy_history (Refs #197)
+  "schema_version": 2,
   "repo": "ippoan/rust-alc-api",
 
   // 現在 production traffic を受けている backend image identifier
   "current_image": "rust-alc-api-00042-abc",
+  // current_image に対応する git release tag (v2+、不明なら null)
+  "current_tag": "v1.4.2",
   "deployed_at": "2026-05-27T01:00:00Z",
 
   // 直近 deploy を行った主体 (= wave 経由 / 単独 deploy の区別が後で必要なら
@@ -113,13 +116,22 @@ context value)。lower-case / hyphen は GitHub 側の正規化に従う。
   "deployed_by": "release-wave-gcp",
 
   // 直近 deploy が wave 経由なら wave_id、単独 deploy なら null
-  "wave_id": "wave_2026_05_27_01"
+  "wave_id": "wave_2026_05_27_01",
+
+  // 過去 revision の遷移履歴 (新しい順、上限 20 件)。/release-wave からの
+  // backend rollback の戻し先候補。index 0 = 現 active、index 1 = 直前の active。
+  // v1 record では undefined。Refs #197。
+  "deploy_history": [
+    { "image": "rust-alc-api-00042-abc", "tag": "v1.4.2", "became_active_at": "2026-05-27T01:00:00Z" },
+    { "image": "rust-alc-api-00041-xyz", "tag": "v1.4.1", "became_active_at": "2026-05-26T10:00:00Z" }
+  ]
 }
 ```
 
-- 履歴は持たず **最新のみ**。deploy 完了 callback で upsert (= 上書き)
-- past history が必要な場面は wave events (= ci-dashboard 内に既にある audit log)
-  で代用、KV 側を audit log 化しない
+- `current_image` / `current_tag` は **最新のみ**。deploy 完了 callback で upsert (= 上書き)
+- `deploy_history` のみ append 蓄積 (= rollback 先候補を辿るため)。`current_image`
+  が前回と変わった時だけ先頭に積み、同 image の再報告では積まない。上限 20 件で trim
+- reader (`getBackendCurrent`) は v1/v2 双方を許容 (v1 は current_tag / deploy_history 無し)
 - `current_image` の identifier 形式は platform 別:
   - **Cloud Run**: revision name (`rust-alc-api-00042-abc`)
   - **Cloudflare Workers**: version id (uuid)
@@ -223,12 +235,16 @@ release-wave-gcp / 各 backend deploy workflow が deploy 成功時に打つ。
 {
   "repo": "ippoan/rust-alc-api",
   "current_image": "rust-alc-api-00042-abc",
+  "current_tag": "v1.4.2",
   "deployed_by": "release-wave-gcp",
   "wave_id": "wave_2026_05_27_01"
 }
 ```
 
 - ci-dashboard 側で `backend::<repo>` を upsert
+- `current_tag` は image に対応する git release tag (省略 / null 可、Refs #197)。
+  deploy workflow が `github.ref_name` を載せる。`current_image` が変わった時だけ
+  `deploy_history` に積まれる
 - `wave_id` は wave 経由でなければ omit (server 側で `null` 格納)
 
 ### `GET /backend-current-image?repo=ippoan/rust-alc-api`

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,8 @@ import {
   handleReleaseWaveAbort,
   handleReleaseWaveRetest,
   handleReleaseWavePendingReleaseFlip,
+  handleReleaseWaveTrafficRollback,
+  handleReleaseWaveBackendRollback,
 } from "./release-wave/api";
 import {
   handlePwaManifest,
@@ -286,6 +288,16 @@ app.post("/api/release-wave/:wave_id/retest", (c) =>
 // で区別されるため衝突しない。
 app.post("/api/release-wave/pending-release/flip", (c) =>
   handleReleaseWavePendingReleaseFlip(c.req.raw, c.env),
+);
+// frontend worker の traffic を任意の過去 version に即 100% で戻す (Refs #196)。
+// form field `repo` + `version_id`。release-wave-traffic-rollback を dispatch。
+app.post("/api/release-wave/traffic-rollback", (c) =>
+  handleReleaseWaveTrafficRollback(c.req.raw, c.env),
+);
+// backend (Cloud Run) の traffic を任意の過去 revision に即 100% で戻す (Refs #197)。
+// form field `repo` + `image`。release-wave-backend-rollback を dispatch。
+app.post("/api/release-wave/backend-rollback", (c) =>
+  handleReleaseWaveBackendRollback(c.req.raw, c.env),
 );
 
 export default app;

--- a/src/release-wave/api.ts
+++ b/src/release-wave/api.ts
@@ -12,9 +12,11 @@
 import type { Env } from "../index";
 import type { ReleaseWaveHub, RpcResult } from "./do";
 import type { WaveState } from "./types";
-import { computeWaveCompatibility } from "./compat";
+import { computeWaveCompatibility, getBackendCurrent } from "./compat";
 import { decideRetestDispatches, dispatchAll, type Dispatch } from "./dispatch";
 import { getPendingRelease, clearPendingRelease } from "./pending-release";
+import { getTraffic } from "./traffic";
+import { serviceNameFromRevision } from "./revision";
 
 function hubStub(env: Env): DurableObjectStub<ReleaseWaveHub> {
   const id = env.RELEASE_WAVE_HUB.idFromName("singleton");
@@ -293,6 +295,188 @@ export async function handleReleaseWavePendingReleaseFlip(
     return jsonResponse(502, {
       code: "DISPATCH_FAILED",
       error: `failed to dispatch flip for ${repo}: ${err}`,
+    });
+  }
+  return redirectToList();
+}
+
+// ----------------------------------------------------------------------------
+// POST /api/release-wave/traffic-rollback  (Refs #196)
+// ----------------------------------------------------------------------------
+
+/**
+ * frontend worker の traffic を任意の過去 version に即 100% で戻す。
+ *
+ * - form field `repo` ("owner/name") + `version_id` を受ける。
+ * - `traffic::<repo>` の deploy_history / versions に含まれる version_id のみ許可
+ *   (= 未知の version への誤 flip を防ぐ。任意選択だが「履歴にある」ことは強制)。
+ * - dispatch `release-wave-traffic-rollback` を frontend repo に送る。handler は
+ *   `wrangler versions deploy <version_id>@100%` で即 100% に戻す (canary 無し)。
+ * - wave 非依存なので callback は来ない。実 flip の成否は GitHub Actions 側で確認。
+ *
+ * `version_id` から tag を引いて payload の target_tag に載せる (handler の
+ * checkout ref には使わないが audit / 表示用)。tag 不明なら省略。
+ */
+export async function handleReleaseWaveTrafficRollback(
+  req: Request,
+  env: Env,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return jsonResponse(405, { code: "METHOD_NOT_ALLOWED", error: "use POST" });
+  }
+  if (!env.COMPAT_KV) {
+    return jsonResponse(500, {
+      code: "KV_NOT_CONFIGURED",
+      error: "COMPAT_KV is not bound",
+    });
+  }
+
+  let repo = "";
+  let versionId = "";
+  try {
+    const form = await req.formData();
+    repo = String(form.get("repo") ?? "").trim();
+    versionId = String(form.get("version_id") ?? "").trim();
+  } catch {
+    // form-data 以外は下で 400
+  }
+  if (!repo || !versionId) {
+    return jsonResponse(400, {
+      code: "BAD_REQUEST",
+      error: "form fields 'repo' and 'version_id' are required",
+    });
+  }
+
+  const traffic = await getTraffic(env.COMPAT_KV, repo);
+  if (!traffic) {
+    return jsonResponse(404, {
+      code: "NOT_FOUND",
+      error: `no traffic record for ${repo}`,
+    });
+  }
+  // version_id は履歴 (deploy_history) か現配分 (versions) のどちらかに居ること。
+  const fromHistory = (traffic.deploy_history ?? []).find(
+    (e) => e.version_id === versionId,
+  );
+  const fromVersions = traffic.versions.find((v) => v.version_id === versionId);
+  if (!fromHistory && !fromVersions) {
+    return jsonResponse(404, {
+      code: "VERSION_NOT_FOUND",
+      error: `version ${versionId} is not in traffic history for ${repo}`,
+    });
+  }
+  const tag = fromHistory?.tag ?? fromVersions?.tag ?? null;
+
+  const wave_id = `traffic-rollback-${repo.replace(/[^a-zA-Z0-9._-]/g, "-")}-${Date.now()}`;
+  const dispatch: Dispatch = {
+    repo,
+    event_type: "release-wave-traffic-rollback",
+    client_payload: {
+      wave_id,
+      ...(tag ? { target_tag: tag } : {}),
+      head_sha: "",
+      // handler が `wrangler versions deploy <id>@100%` の対象にする version。
+      previewed_version_id: versionId,
+      // handler が wave callback を skip するためのマーカー。
+      traffic_rollback: true,
+    },
+  };
+
+  const results = await dispatchAll(env, [dispatch]);
+  if (!(results.length > 0 && results[0]!.ok)) {
+    const err = results.length > 0 && !results[0]!.ok ? results[0]!.error : "dispatch failed";
+    return jsonResponse(502, {
+      code: "DISPATCH_FAILED",
+      error: `failed to dispatch traffic-rollback for ${repo}: ${err}`,
+    });
+  }
+  return redirectToList();
+}
+
+// ----------------------------------------------------------------------------
+// POST /api/release-wave/backend-rollback  (Refs #197)
+// ----------------------------------------------------------------------------
+
+/**
+ * backend (Cloud Run) の traffic を任意の過去 revision に即 100% で戻す。
+ *
+ * - form field `repo` ("owner/name") + `image` (Cloud Run revision name) を受ける。
+ * - `backend::<repo>` の deploy_history に含まれる image のみ許可。
+ * - dispatch `release-wave-backend-rollback` を backend repo に送る。handler は
+ *   既存 `/cloudrun/rollback` 経路で `rollback_target[<service>]` の revision に
+ *   即 100% traffic を振る。
+ * - service 名は revision name (`<service>-NNNNN-suffix`) から逆算して
+ *   `rollback_target` map を組む。逆算できない場合も `rollback_revision` 単一値を
+ *   載せ、handler 側 fallback に委ねる。
+ */
+export async function handleReleaseWaveBackendRollback(
+  req: Request,
+  env: Env,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return jsonResponse(405, { code: "METHOD_NOT_ALLOWED", error: "use POST" });
+  }
+  if (!env.COMPAT_KV) {
+    return jsonResponse(500, {
+      code: "KV_NOT_CONFIGURED",
+      error: "COMPAT_KV is not bound",
+    });
+  }
+
+  let repo = "";
+  let image = "";
+  try {
+    const form = await req.formData();
+    repo = String(form.get("repo") ?? "").trim();
+    image = String(form.get("image") ?? "").trim();
+  } catch {
+    // form-data 以外は下で 400
+  }
+  if (!repo || !image) {
+    return jsonResponse(400, {
+      code: "BAD_REQUEST",
+      error: "form fields 'repo' and 'image' are required",
+    });
+  }
+
+  const backend = await getBackendCurrent(env.COMPAT_KV, repo);
+  if (!backend) {
+    return jsonResponse(404, {
+      code: "NOT_FOUND",
+      error: `no backend deploy record for ${repo}`,
+    });
+  }
+  const entry = (backend.deploy_history ?? []).find((e) => e.image === image);
+  if (!entry) {
+    return jsonResponse(404, {
+      code: "REVISION_NOT_FOUND",
+      error: `revision ${image} is not in deploy history for ${repo}`,
+    });
+  }
+
+  const service = serviceNameFromRevision(image);
+  const wave_id = `backend-rollback-${repo.replace(/[^a-zA-Z0-9._-]/g, "-")}-${Date.now()}`;
+  const dispatch: Dispatch = {
+    repo,
+    event_type: "release-wave-backend-rollback",
+    client_payload: {
+      wave_id,
+      ...(entry.tag ? { target_tag: entry.tag } : {}),
+      head_sha: "",
+      // 既存 /cloudrun/rollback の戻し先 map。service 別。
+      rollback_target: service ? { [service]: image } : {},
+      // service 名を逆算できなかった場合の単一値 fallback。
+      rollback_revision: image,
+      backend_rollback: true,
+    },
+  };
+
+  const results = await dispatchAll(env, [dispatch]);
+  if (!(results.length > 0 && results[0]!.ok)) {
+    const err = results.length > 0 && !results[0]!.ok ? results[0]!.error : "dispatch failed";
+    return jsonResponse(502, {
+      code: "DISPATCH_FAILED",
+      error: `failed to dispatch backend-rollback for ${repo}: ${err}`,
     });
   }
   return redirectToList();

--- a/src/release-wave/compat.ts
+++ b/src/release-wave/compat.ts
@@ -13,8 +13,20 @@
 // 定数
 // ----------------------------------------------------------------------------
 
-/** 現行 schema version。破壊的変更時に bump。 */
+/** 現行 schema version (`frontend::*`)。破壊的変更時に bump。 */
 export const SCHEMA_VERSION = 1;
+
+/**
+ * `backend::*` record の schema version。
+ *   v1: { current_image, deployed_at, deployed_by, wave_id }
+ *   v2: + current_tag (image に対応する git release tag)
+ *       + deploy_history (過去 revision の遷移履歴、新しい順、rollback 先候補)
+ * reader (`getBackendCurrent`) は v1/v2 双方を許容する。Refs #197。
+ */
+export const BACKEND_SCHEMA_VERSION = 2;
+
+/** backend `deploy_history` の保持件数上限 (新しい順に trim)。 */
+export const BACKEND_DEPLOY_HISTORY_MAX = 20;
 
 /** `tested_against` の最大保持件数 (sliding window の件数上限)。 */
 export const TESTED_AGAINST_MAX = 50;
@@ -59,15 +71,36 @@ export interface FrontendCompatRecord {
   tested_against: TestedAgainstEntry[];
 }
 
+/**
+ * 過去に active だった backend revision 1 件分の履歴 entry。
+ * rollback 先候補として `deploy_history[]` に新しい順で積む。Refs #197。
+ */
+export interface BackendDeployHistoryEntry {
+  /** Cloud Run revision name 等の image identifier。 */
+  image: string;
+  /** その image に対応する git release tag (不明なら null)。 */
+  tag: string | null;
+  /** active になったと検知した UTC ISO。 */
+  became_active_at: string;
+}
+
 /** `backend::<repo>` value。最新 deploy のみ保持 (upsert)。 */
 export interface BackendCompatRecord {
   schema_version: number;
   repo: string;
   current_image: string;
+  /** current_image に対応する git release tag (v2+、不明なら null)。Refs #197。 */
+  current_tag?: string | null;
   deployed_at: string;
   deployed_by: string;
   /** wave 経由 deploy なら wave_id、単独 deploy なら null。 */
   wave_id: string | null;
+  /**
+   * 過去 revision の遷移履歴 (新しい順、上限 BACKEND_DEPLOY_HISTORY_MAX)。
+   * index 0 = 現在 active、index 1 = 直前の active (= rollback 先候補)。
+   * v1 record では undefined。Refs #197。
+   */
+  deploy_history?: BackendDeployHistoryEntry[];
 }
 
 // ----------------------------------------------------------------------------
@@ -160,39 +193,83 @@ function trimTestedAgainst(
 export interface RecordBackendDeployInput {
   repo: string;
   current_image: string;
+  /** image に対応する git release tag (省略 / null 可)。Refs #197。 */
+  current_tag?: string | null;
   deployed_by: string;
   wave_id?: string | null;
   now: string;
 }
 
-/** backend deploy 成功時の upsert (最新のみ、TTL なし)。 */
+/**
+ * backend deploy 成功時の upsert (最新のみ、TTL なし)。
+ *
+ * current_image が前回 record と変わっていれば `deploy_history` の先頭に
+ * 旧→新の遷移として積む (新しい順、上限件数で trim)。同 image の再報告では
+ * 履歴を変えない (重複を積まない)。Refs #197。
+ */
 export async function recordBackendDeploy(
   kv: KVNamespace,
   input: RecordBackendDeployInput,
 ): Promise<BackendCompatRecord> {
+  const prev = await getBackendCurrent(kv, input.repo);
+  const deploy_history = nextBackendDeployHistory(
+    prev?.deploy_history,
+    input.current_image,
+    input.current_tag ?? null,
+    input.now,
+  );
   const record: BackendCompatRecord = {
-    schema_version: SCHEMA_VERSION,
+    schema_version: BACKEND_SCHEMA_VERSION,
     repo: input.repo,
     current_image: input.current_image,
+    current_tag: input.current_tag ?? null,
     deployed_at: input.now,
     deployed_by: input.deployed_by,
     wave_id: input.wave_id ?? null,
+    ...(deploy_history.length > 0 ? { deploy_history } : {}),
   };
   await kv.put(backendKey(input.repo), JSON.stringify(record));
   return record;
+}
+
+/**
+ * 新 current_image から backend deploy_history を導出する純粋関数。traffic.ts の
+ * `nextDeployHistory` と対称。current_image が履歴先頭と異なれば積み、同じなら
+ * 据え置く。再 deploy で履歴が重複しないよう同 image は除去して積み直す。
+ */
+export function nextBackendDeployHistory(
+  prevHistory: BackendDeployHistoryEntry[] | undefined,
+  currentImage: string,
+  currentTag: string | null,
+  now: string,
+): BackendDeployHistoryEntry[] {
+  const prior = Array.isArray(prevHistory) ? prevHistory : [];
+  if (!currentImage) return prior.slice(0, BACKEND_DEPLOY_HISTORY_MAX);
+  if (prior[0]?.image === currentImage) {
+    return prior.slice(0, BACKEND_DEPLOY_HISTORY_MAX);
+  }
+  const entry: BackendDeployHistoryEntry = {
+    image: currentImage,
+    tag: currentTag,
+    became_active_at: now,
+  };
+  const rest = prior.filter((e) => e.image !== currentImage);
+  return [entry, ...rest].slice(0, BACKEND_DEPLOY_HISTORY_MAX);
 }
 
 // ----------------------------------------------------------------------------
 // Read: backend current image
 // ----------------------------------------------------------------------------
 
-/** `backend::<repo>` を読む。無ければ null。 */
+/** `backend::<repo>` を読む。無ければ null。v1/v2 双方を許容する (Refs #197)。 */
 export async function getBackendCurrent(
   kv: KVNamespace,
   repo: string,
 ): Promise<BackendCompatRecord | null> {
   const v = await kv.get<BackendCompatRecord>(backendKey(repo), "json");
-  if (!v || v.schema_version !== SCHEMA_VERSION) return null;
+  if (!v || v.schema_version < SCHEMA_VERSION || v.schema_version > BACKEND_SCHEMA_VERSION) {
+    return null;
+  }
   return v;
 }
 
@@ -281,6 +358,10 @@ export interface WaveBackendCompat {
   backend_repo: string;
   /** `backend::<repo>` に記録された現 production image (record 無しなら null)。 */
   current_image: string | null;
+  /** current_image に対応する git release tag (v2 record のみ、無ければ null)。Refs #197。 */
+  current_tag: string | null;
+  /** 過去 revision の rollback 先候補 (新しい順、record 無し / v1 なら空)。Refs #197。 */
+  deploy_history: BackendDeployHistoryEntry[];
   /** 当該 backend を test 済みの frontend の matrix (consumer 無しなら空)。 */
   matrix: CompatMatrixEntry[];
 }
@@ -318,6 +399,8 @@ export async function computeWaveCompatibility(
     backends.push({
       backend_repo: repo,
       current_image: rec.current_image,
+      current_tag: rec.current_tag ?? null,
+      deploy_history: Array.isArray(rec.deploy_history) ? rec.deploy_history : [],
       matrix: compat.matrix,
     });
   }

--- a/src/release-wave/dispatch.ts
+++ b/src/release-wave/dispatch.ts
@@ -28,7 +28,11 @@ export type DispatchEventType =
   | "release-wave-stage"
   | "release-wave-flip"
   | "release-wave-rollback"
-  | "release-wave-retest";
+  | "release-wave-retest"
+  // 単独 rollback (wave 非依存)。/release-wave の Traffic / Compatibility UI から
+  // 任意の過去 version / revision に即 100% で戻す。Refs #196 / #197。
+  | "release-wave-traffic-rollback"
+  | "release-wave-backend-rollback";
 
 export interface Dispatch {
   /** "owner/name" 形式 */

--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -769,7 +769,7 @@ function renderCompatibilitySection(
               .join("");
       return `
       <h3>${escapeHtml(b.backend_repo)}
-        <span class="meta">@ ${escapeHtml(b.current_image ?? "—")}</span>
+        <span class="meta">${b.current_tag ? `${escapeHtml(b.current_tag)} · ` : ""}@ ${escapeHtml(b.current_image ?? "—")}</span>
       </h3>
       <table>
         <thead>
@@ -857,6 +857,8 @@ function renderCompatibilitySvg(
   const backendOrder: string[] = [];
   const frontendOrder: string[] = [];
   const backendImage = new Map<string, string | null>();
+  // backend image に対応する git release tag (v2 record のみ)。node line2 に併記。
+  const backendTag = new Map<string, string | null>();
   const frontendVersion = new Map<string, string | null>();
   // frontend が 1 つでも赤 edge を持てば赤扱い (node 枠色)。
   const frontendHasRed = new Map<string, boolean>();
@@ -873,6 +875,7 @@ function renderCompatibilitySvg(
     if (!backendOrder.includes(b.backend_repo)) {
       backendOrder.push(b.backend_repo);
       backendImage.set(b.backend_repo, b.current_image);
+      backendTag.set(b.backend_repo, b.current_tag ?? null);
     }
     for (const m of b.matrix) {
       if (!frontendOrder.includes(m.frontend)) {
@@ -986,13 +989,16 @@ function renderCompatibilitySvg(
   const backendSvg = backendOrder
     .map((repo) => {
       const img = backendImage.get(repo) ?? "—";
+      const tag = backendTag.get(repo) ?? null;
+      // line2: git tag があれば "<tag> · @ <sha>"、無ければ従来の "@ <sha>"。Refs #197。
+      const line2 = tag ? `${tag} · @ ${shortSha(img)}` : `@ ${shortSha(img)}`;
       return node(
         leftX,
         bY(repo),
         repo,
-        `@ ${shortSha(img)}`,
+        line2,
         BLUE,
-        `${repo}\ncurrent image: ${img ?? "—"}`,
+        `${repo}\ncurrent image: ${img ?? "—"}${tag ? `\ncurrent tag: ${tag}` : ""}`,
       );
     })
     .join("");

--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -22,7 +22,7 @@ import {
   getRepoReleaseStatuses,
   type RepoReleaseStatus,
 } from "./repo-release-status";
-import { computeGlobalCompatibility } from "./compat";
+import { computeGlobalCompatibility, type WaveCompatibility } from "./compat";
 import { parseTaglessRepos } from "../tagless-repos";
 import {
   getTrafficForRepos,
@@ -312,7 +312,7 @@ export function renderTrafficVersionsBlock(
         return ca < cb ? 1 : -1;
       });
 
-      return shown
+      const versionRows = shown
         .map((v, i) =>
           versionRow(
             repo,
@@ -323,6 +323,8 @@ export function renderTrafficVersionsBlock(
           ),
         )
         .join("");
+      // 直前以前の active version への rollback ボタン行を続ける。
+      return versionRows + renderTrafficRollbackRow(repo, rec);
     })
     .join("");
 
@@ -331,6 +333,102 @@ export function renderTrafficVersionsBlock(
       <strong class="meta">Traffic (version split)</strong>
       <table style="margin-top:6px">
         <thead><tr><th>Repo</th><th>%</th><th>Tag / Version</th><th>Deployed / Uploaded (UTC)</th></tr></thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>`;
+}
+
+/**
+ * 1 repo の Traffic 行に続けて、過去に active だった version への rollback ボタン
+ * 行を返す (Refs #196)。`deploy_history` から「現 active 以外」を rollback 先候補
+ * とし、各候補に `Rollback to <tag/id>` ボタンを出す。候補が無ければ ""。
+ *
+ * 現 active は traffic の最大 percentage version。deploy_history[0] が現 active と
+ * 一致する想定だが、念のため active version_id を除いて候補を作る。
+ */
+function renderTrafficRollbackRow(repo: string, rec: TrafficRecord): string {
+  const history = rec.deploy_history ?? [];
+  if (history.length === 0) return "";
+  const activeId = rec.versions.find((v) => v.percentage > 0)?.version_id ?? null;
+  const candidates = history.filter((e) => e.version_id !== activeId);
+  if (candidates.length === 0) return "";
+
+  const buttons = candidates
+    .map((e) => {
+      const label = e.tag ? escapeHtml(e.tag) : escapeHtml(shortId(e.version_id));
+      const when = escapeHtml(shortWhen(e.became_active_at));
+      return `
+            <form method="post" action="/api/release-wave/traffic-rollback" style="margin:0 6px 4px 0;display:inline-block">
+              <input type="hidden" name="repo" value="${escapeHtml(repo)}">
+              <input type="hidden" name="version_id" value="${escapeHtml(e.version_id)}">
+              <button type="submit" class="danger"
+                title="${escapeHtml(repo)} を ${escapeHtml(e.version_id)} に即 100% で戻す (wrangler versions deploy ${escapeHtml(e.version_id)}@100%)">
+                Rollback to ${label} <span class="meta">(${when})</span>
+              </button>
+            </form>`;
+    })
+    .join("");
+
+  return `
+            <tr>
+              <td></td>
+              <td colspan="3">
+                <span class="meta">Rollback to (過去の deployed version):</span>
+                <div style="margin-top:4px">${buttons}</div>
+              </td>
+            </tr>`;
+}
+
+/**
+ * Compatibility グラフに出ている backend repo の Cloud Run revision rollback
+ * ボタンを HTML で返す (Refs #197)。`backend::<repo>.deploy_history` から
+ * 「現 active 以外」の過去 revision を rollback 先候補とし、各候補に
+ * `Rollback to <tag/revision>` ボタンを出す。候補がある repo が無ければ ""。
+ *
+ * frontend の Traffic rollback と方針を揃える: 任意の過去 revision を選択 / 即 100%。
+ */
+export function renderBackendRollbackBlock(compat: WaveCompatibility): string {
+  const rows = compat.backends
+    .map((b) => {
+      const history = b.deploy_history ?? [];
+      if (history.length === 0) return "";
+      const candidates = history.filter((e) => e.image !== b.current_image);
+      if (candidates.length === 0) return "";
+
+      const buttons = candidates
+        .map((e) => {
+          const label = e.tag ? escapeHtml(e.tag) : escapeHtml(shortId(e.image));
+          const when = escapeHtml(shortWhen(e.became_active_at));
+          return `
+            <form method="post" action="/api/release-wave/backend-rollback" style="margin:0 6px 4px 0;display:inline-block">
+              <input type="hidden" name="repo" value="${escapeHtml(b.backend_repo)}">
+              <input type="hidden" name="image" value="${escapeHtml(e.image)}">
+              <button type="submit" class="danger"
+                title="${escapeHtml(b.backend_repo)} の Cloud Run traffic を ${escapeHtml(e.image)} に即 100% で戻す">
+                Rollback to ${label} <span class="meta">(${when})</span>
+              </button>
+            </form>`;
+        })
+        .join("");
+
+      const curTag = b.current_tag ? `${escapeHtml(b.current_tag)} · ` : "";
+      return `
+        <tr>
+          <td>${escapeHtml(b.backend_repo)}</td>
+          <td class="meta" title="${escapeHtml(b.current_image ?? "—")}">${curTag}${escapeHtml(shortId(b.current_image ?? "—"))}</td>
+          <td><div>${buttons}</div></td>
+        </tr>`;
+    })
+    .filter((r) => r !== "")
+    .join("");
+
+  if (rows === "") return "";
+
+  return `
+    <div style="margin-top:10px">
+      <strong class="meta">Backend rollback (Cloud Run revision)</strong>
+      <table style="margin-top:6px">
+        <thead><tr><th>Backend repo</th><th>Current</th><th>Rollback to (過去 revision)</th></tr></thead>
         <tbody>${rows}</tbody>
       </table>
     </div>`;
@@ -398,8 +496,14 @@ export async function handleReleaseWaveListPageWithRepoStatus(
       const trafficByRepo = await getTrafficForRepos(env.COMPAT_KV, repos);
       const trafficBlock = renderTrafficVersionsBlock(repos, trafficByRepo);
 
-      // traffic を上、Tag Release ボタンを下にして 1 回で注入する。
-      html = injectCompatTagReleaseButtons(html, trafficBlock + buttons);
+      // backend (Cloud Run) revision の rollback ボタンをグラフ下に出す (Refs #197)。
+      const backendRollbackBlock = renderBackendRollbackBlock(compat);
+
+      // traffic → backend rollback → Tag Release ボタンの順で 1 回で注入する。
+      html = injectCompatTagReleaseButtons(
+        html,
+        trafficBlock + backendRollbackBlock + buttons,
+      );
     } catch {
       // compat 取得失敗時はボタンだけ落とす
     }

--- a/src/release-wave/revision.ts
+++ b/src/release-wave/revision.ts
@@ -1,0 +1,21 @@
+/**
+ * Cloud Run revision name から service 名を導出するヘルパ。
+ *
+ * Cloud Run の revision name は `<service>-NNNNN-<suffix>` 形式
+ * (例 `rust-alc-api-00042-abc`)。ci-dashboard は backend repo の current_image
+ * (= revision name) しか持たず service 名を別途持たないため、backend rollback の
+ * dispatch で `rollback_target[<service>] = <revision>` map を作るのに revision
+ * から service 名を逆算する。Refs ippoan/ci-dashboard#197。
+ */
+
+/** `<service>-NNNNN-<suffix>` の suffix を剥がす正規表現。 */
+const REVISION_RE = /^(.+)-\d{5}-[a-z0-9]+$/;
+
+/**
+ * revision name から service 名を返す。形式に合わなければ null
+ * (= handler 側で rollback_revision の単一値 fallback に委ねる)。
+ */
+export function serviceNameFromRevision(revision: string): string | null {
+  const m = REVISION_RE.exec(revision.trim());
+  return m ? m[1]! : null;
+}

--- a/src/release-wave/traffic.ts
+++ b/src/release-wave/traffic.ts
@@ -17,8 +17,14 @@ const TRAFFIC_PREFIX = "traffic::";
 //   v3: + tag (upload 時点の git release tag)。tag は deploy CI ごとに「その回
 //       upload した version」分しか報告されないため、recordTraffic で version_id
 //       単位に **merge 蓄積** する (過去 version の tag を保持)。
-// reader は v1/v2/v3 全部許容する (後方互換)。
-const SCHEMA_VERSION = 3 as const;
+//   v4: + deploy_history (過去に 100% deployed だった version の遷移履歴、
+//       新しい順、上限 DEPLOY_HISTORY_MAX 件)。/release-wave から rollback 先
+//       候補を辿るために蓄積する。Refs ippoan/ci-dashboard#196。
+// reader は v1〜v4 全部許容する (後方互換)。
+const SCHEMA_VERSION = 4 as const;
+
+/** `deploy_history` の保持件数上限 (新しい順に trim)。 */
+export const DEPLOY_HISTORY_MAX = 20;
 
 /** version 1 件の traffic 配分。 */
 export interface TrafficVersion {
@@ -40,6 +46,19 @@ export interface TrafficVersion {
   tag?: string | null;
 }
 
+/**
+ * 過去に active (100% deployed) だった version 1 件分の履歴 entry。
+ * rollback 先候補として `deploy_history[]` に新しい順で積む。Refs #196。
+ */
+export interface DeployHistoryEntry {
+  /** active になった version の wrangler version id。 */
+  version_id: string;
+  /** その version の git release tag (不明なら null)。 */
+  tag: string | null;
+  /** active (100%) になったと検知した UTC ISO (created_on 優先、無ければ報告時刻)。 */
+  became_active_at: string;
+}
+
 /** `traffic::<repo>` value。repo ごとに最新の deployment 配分のみ保持 (upsert)。 */
 export interface TrafficRecord {
   schema_version: number;
@@ -50,6 +69,12 @@ export interface TrafficRecord {
    * 100% (active) と 0% (no-traffic / promote 待ち) が混在する。
    */
   versions: TrafficVersion[];
+  /**
+   * 過去に active だった version の遷移履歴 (新しい順、上限 DEPLOY_HISTORY_MAX)。
+   * index 0 = 現在 active、index 1 = 直前の active (= rollback 先候補)。
+   * v3 以前の record では undefined。Refs #196。
+   */
+  deploy_history?: DeployHistoryEntry[];
   /** 報告を受けた UTC ISO。 */
   reported_at: string;
 }
@@ -104,10 +129,22 @@ export async function recordTraffic(
     if (!cb) return -1;
     return ca < cb ? 1 : -1;
   });
+
+  // deploy_history を更新する。sort 済み merged の先頭で percentage>0 の version を
+  // 「現 active」とみなし、前回履歴の先頭 (= 直前の active) と version_id が異なれば
+  // 新しい active として履歴の先頭に積む。canary 等で active が確定しない (全て 0%)
+  // 場合や、active が前回と同じ場合は履歴を変えない (重複を積まない)。
+  const deploy_history = nextDeployHistory(
+    prev?.deploy_history,
+    merged,
+    input.now,
+  );
+
   const record: TrafficRecord = {
     schema_version: SCHEMA_VERSION,
     repo: input.repo,
     versions: merged,
+    ...(deploy_history.length > 0 ? { deploy_history } : {}),
     reported_at: input.now,
   };
   await kv.put(trafficKey(input.repo), JSON.stringify(record));
@@ -115,15 +152,47 @@ export async function recordTraffic(
 }
 
 /**
+ * 新しい traffic 配分から deploy_history を導出する純粋関数。
+ *
+ * - 「現 active」= sort 済み versions の先頭で percentage>0 のもの (= 最大 traffic)。
+ *   全て 0% なら active 無しとして履歴据え置き。
+ * - 既存履歴の先頭 version_id と一致すれば据え置き (= 同じ version が active のまま)。
+ * - 異なれば新 active を先頭に積む。became_active_at は active version の created_on
+ *   を優先、無ければ報告時刻 now。
+ * - 上限 DEPLOY_HISTORY_MAX 件で trim。同 version_id が既に履歴下方にある場合は
+ *   それを除去して先頭に積み直す (再 promote で履歴が重複しないように)。
+ */
+export function nextDeployHistory(
+  prevHistory: DeployHistoryEntry[] | undefined,
+  versions: TrafficVersion[],
+  now: string,
+): DeployHistoryEntry[] {
+  const prior = Array.isArray(prevHistory) ? prevHistory : [];
+  const active = versions.find((v) => v.percentage > 0);
+  if (!active) return prior.slice(0, DEPLOY_HISTORY_MAX);
+  if (prior[0]?.version_id === active.version_id) {
+    return prior.slice(0, DEPLOY_HISTORY_MAX);
+  }
+  const entry: DeployHistoryEntry = {
+    version_id: active.version_id,
+    tag: active.tag ?? null,
+    became_active_at: active.created_on ?? now,
+  };
+  const rest = prior.filter((e) => e.version_id !== active.version_id);
+  return [entry, ...rest].slice(0, DEPLOY_HISTORY_MAX);
+}
+
+/**
  * 単一 repo の traffic を取得 (無ければ null)。
- * v1 / v2 / v3 の record を許容する (v1 は created_on 無し、v1/v2 は tag 無し)。
+ * v1〜v4 の record を許容する (v1 は created_on 無し、v1/v2 は tag 無し、
+ * v3 以前は deploy_history 無し)。
  */
 export async function getTraffic(
   kv: KVNamespace,
   repo: string,
 ): Promise<TrafficRecord | null> {
   const v = await kv.get<TrafficRecord>(trafficKey(repo), "json");
-  if (!v || v.schema_version < 1 || v.schema_version > 3) return null;
+  if (!v || v.schema_version < 1 || v.schema_version > 4) return null;
   return v;
 }
 

--- a/src/release-wave/webhook.ts
+++ b/src/release-wave/webhook.ts
@@ -299,6 +299,7 @@ export async function handleFrontendTestReportWebhook(
  *   {
  *     "repo": "ippoan/rust-alc-api",
  *     "current_image": "rust-alc-api-00042-abc",
+ *     "current_tag": "v1.4.2",          // optional (image に対応する git tag、Refs #197)
  *     "deployed_by": "release-wave-gcp",
  *     "wave_id": "wave_2026_05_27_01"   // optional (単独 deploy 時は省略)
  *   }
@@ -306,6 +307,8 @@ export async function handleFrontendTestReportWebhook(
 const backendDeployReportSchema = z.object({
   repo: z.string().min(1),
   current_image: z.string().min(1),
+  // null / undefined / 省略すべて許容 (旧 deploy workflow は載せない)。
+  current_tag: z.string().min(1).nullish(),
   deployed_by: z.string().min(1),
   wave_id: z.string().min(1).nullable().optional(),
 });
@@ -319,6 +322,7 @@ export async function handleBackendDeployReportWebhook(
   const record = await recordBackendDeploy(env.COMPAT_KV, {
     repo: v.data.repo,
     current_image: v.data.current_image,
+    current_tag: v.data.current_tag ?? null,
     deployed_by: v.data.deployed_by,
     wave_id: v.data.wave_id ?? null,
     now: new Date().toISOString(),

--- a/test/release-wave/api.test.ts
+++ b/test/release-wave/api.test.ts
@@ -5,6 +5,8 @@ import {
   handleReleaseWaveAbort,
   handleReleaseWaveRetest,
   handleReleaseWavePendingReleaseFlip,
+  handleReleaseWaveTrafficRollback,
+  handleReleaseWaveBackendRollback,
 } from "../../src/release-wave/api";
 import { getPendingRelease } from "../../src/release-wave/pending-release";
 import type { Env } from "../../src/index";
@@ -548,5 +550,184 @@ describe("handleReleaseWavePendingReleaseFlip", () => {
     expect(resp.status).toBe(502);
     // 着火失敗時は record を残す (operator が再試行可能)
     expect(await getPendingRelease(kv, "ippoan/auth-worker")).not.toBeNull();
+  });
+});
+
+// ============================================================================
+// /api/release-wave/traffic-rollback  (Refs #196)
+// ============================================================================
+
+const ROLLBACK_VID = "8664c989-1111-2222-3333-444455556666";
+
+/** deploy_history 付き traffic record を仕込んだ COMPAT_KV。 */
+function trafficRollbackKv(): KVNamespace {
+  return memKv({
+    "traffic::ippoan/auth-worker": {
+      schema_version: 4,
+      repo: "ippoan/auth-worker",
+      versions: [{ version_id: "current-vid", percentage: 100, tag: "v0.2.50" }],
+      deploy_history: [
+        { version_id: "current-vid", tag: "v0.2.50", became_active_at: "2026-05-29T09:30:00Z" },
+        { version_id: ROLLBACK_VID, tag: "v0.2.49", became_active_at: "2026-05-28T11:37:00Z" },
+      ],
+      reported_at: "2026-05-29T09:30:00Z",
+    },
+  });
+}
+
+describe("handleReleaseWaveTrafficRollback", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns 405 on GET", async () => {
+    const req = new Request(
+      "https://ci-dashboard.ippoan.org/api/release-wave/traffic-rollback",
+      { method: "GET" },
+    );
+    const resp = await handleReleaseWaveTrafficRollback(req, pendingFlipEnv(trafficRollbackKv()));
+    expect(resp.status).toBe(405);
+  });
+
+  it("returns 400 when repo or version_id missing", async () => {
+    const resp = await handleReleaseWaveTrafficRollback(
+      postRequest("/api/release-wave/traffic-rollback", {
+        formBody: { repo: "ippoan/auth-worker" },
+      }),
+      pendingFlipEnv(trafficRollbackKv()),
+    );
+    expect(resp.status).toBe(400);
+  });
+
+  it("returns 404 when no traffic record", async () => {
+    const resp = await handleReleaseWaveTrafficRollback(
+      postRequest("/api/release-wave/traffic-rollback", {
+        formBody: { repo: "ippoan/none", version_id: ROLLBACK_VID },
+      }),
+      pendingFlipEnv(trafficRollbackKv()),
+    );
+    expect(resp.status).toBe(404);
+  });
+
+  it("returns 404 when version_id not in traffic history", async () => {
+    const resp = await handleReleaseWaveTrafficRollback(
+      postRequest("/api/release-wave/traffic-rollback", {
+        formBody: { repo: "ippoan/auth-worker", version_id: "unknown-vid" },
+      }),
+      pendingFlipEnv(trafficRollbackKv()),
+    );
+    expect(resp.status).toBe(404);
+  });
+
+  it("dispatches release-wave-traffic-rollback with previewed_version_id + marker", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    const resp = await handleReleaseWaveTrafficRollback(
+      postRequest("/api/release-wave/traffic-rollback", {
+        formBody: { repo: "ippoan/auth-worker", version_id: ROLLBACK_VID },
+      }),
+      pendingFlipEnv(trafficRollbackKv()),
+    );
+    expect(resp.status).toBe(303);
+    const call = fetchSpy.mock.calls.find((c) =>
+      String(c[0]).includes("/repos/ippoan/auth-worker/dispatches"),
+    );
+    expect(call).toBeDefined();
+    const body = JSON.parse(call![1].body);
+    expect(body.event_type).toBe("release-wave-traffic-rollback");
+    expect(body.client_payload).toMatchObject({
+      previewed_version_id: ROLLBACK_VID,
+      target_tag: "v0.2.49",
+      traffic_rollback: true,
+    });
+    expect(body.client_payload.wave_id).toMatch(/^[a-zA-Z0-9._-]{1,128}$/);
+  });
+
+  it("returns 502 when dispatch fails", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response("boom", { status: 500 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    const resp = await handleReleaseWaveTrafficRollback(
+      postRequest("/api/release-wave/traffic-rollback", {
+        formBody: { repo: "ippoan/auth-worker", version_id: ROLLBACK_VID },
+      }),
+      pendingFlipEnv(trafficRollbackKv()),
+    );
+    expect(resp.status).toBe(502);
+  });
+});
+
+// ============================================================================
+// /api/release-wave/backend-rollback  (Refs #197)
+// ============================================================================
+
+/** deploy_history 付き backend record を仕込んだ COMPAT_KV。 */
+function backendRollbackKv(): KVNamespace {
+  return memKv({
+    "backend::ippoan/rust-alc-api": {
+      schema_version: 2,
+      repo: "ippoan/rust-alc-api",
+      current_image: "rust-alc-api-00042-abc",
+      current_tag: "v1.4.2",
+      deployed_at: "2026-05-29T09:30:00Z",
+      deployed_by: "release-wave-gcp",
+      wave_id: null,
+      deploy_history: [
+        { image: "rust-alc-api-00042-abc", tag: "v1.4.2", became_active_at: "2026-05-29T09:30:00Z" },
+        { image: "rust-alc-api-00041-xyz", tag: "v1.4.1", became_active_at: "2026-05-28T11:37:00Z" },
+      ],
+    },
+  });
+}
+
+describe("handleReleaseWaveBackendRollback", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns 400 when repo or image missing", async () => {
+    const resp = await handleReleaseWaveBackendRollback(
+      postRequest("/api/release-wave/backend-rollback", {
+        formBody: { repo: "ippoan/rust-alc-api" },
+      }),
+      pendingFlipEnv(backendRollbackKv()),
+    );
+    expect(resp.status).toBe(400);
+  });
+
+  it("returns 404 when revision not in deploy history", async () => {
+    const resp = await handleReleaseWaveBackendRollback(
+      postRequest("/api/release-wave/backend-rollback", {
+        formBody: { repo: "ippoan/rust-alc-api", image: "rust-alc-api-99999-zzz" },
+      }),
+      pendingFlipEnv(backendRollbackKv()),
+    );
+    expect(resp.status).toBe(404);
+  });
+
+  it("dispatches release-wave-backend-rollback with rollback_target map derived from revision", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    const resp = await handleReleaseWaveBackendRollback(
+      postRequest("/api/release-wave/backend-rollback", {
+        formBody: { repo: "ippoan/rust-alc-api", image: "rust-alc-api-00041-xyz" },
+      }),
+      pendingFlipEnv(backendRollbackKv()),
+    );
+    expect(resp.status).toBe(303);
+    const call = fetchSpy.mock.calls.find((c) =>
+      String(c[0]).includes("/repos/ippoan/rust-alc-api/dispatches"),
+    );
+    expect(call).toBeDefined();
+    const body = JSON.parse(call![1].body);
+    expect(body.event_type).toBe("release-wave-backend-rollback");
+    expect(body.client_payload).toMatchObject({
+      target_tag: "v1.4.1",
+      rollback_revision: "rust-alc-api-00041-xyz",
+      backend_rollback: true,
+    });
+    // service 名は revision から逆算され rollback_target に入る。
+    expect(body.client_payload.rollback_target).toEqual({
+      "rust-alc-api": "rust-alc-api-00041-xyz",
+    });
   });
 });

--- a/test/release-wave/compat.test.ts
+++ b/test/release-wave/compat.test.ts
@@ -10,6 +10,8 @@ import {
   TESTED_AGAINST_MAX,
   WINDOW_DAYS,
   SCHEMA_VERSION,
+  BACKEND_SCHEMA_VERSION,
+  nextBackendDeployHistory,
   type FrontendCompatRecord,
 } from "../../src/release-wave/compat";
 
@@ -246,6 +248,63 @@ describe("recordBackendDeploy / getBackendCurrent", () => {
       JSON.stringify({ schema_version: 99, repo: "ippoan/rust-alc-api" }),
     );
     expect(await getBackendCurrent(kv(), "ippoan/rust-alc-api")).toBeNull();
+  });
+
+  it("stores current_tag and writes v2 schema", async () => {
+    const rec = await recordBackendDeploy(kv(), {
+      repo: "ippoan/rust-alc-api",
+      current_image: "rust-alc-api-00042-abc",
+      current_tag: "v1.4.2",
+      deployed_by: "release-wave-gcp",
+      now: daysAgo(0),
+    });
+    expect(rec.schema_version).toBe(BACKEND_SCHEMA_VERSION);
+    expect(rec.current_tag).toBe("v1.4.2");
+  });
+
+  it("accumulates deploy_history when the revision changes", async () => {
+    await recordBackendDeploy(kv(), {
+      repo: "ippoan/rust-alc-api",
+      current_image: "rust-alc-api-00041-xyz",
+      current_tag: "v1.4.1",
+      deployed_by: "x",
+      now: daysAgo(1),
+    });
+    await recordBackendDeploy(kv(), {
+      repo: "ippoan/rust-alc-api",
+      current_image: "rust-alc-api-00042-abc",
+      current_tag: "v1.4.2",
+      deployed_by: "y",
+      now: daysAgo(0),
+    });
+    const got = await getBackendCurrent(kv(), "ippoan/rust-alc-api");
+    expect(got!.deploy_history!.map((e) => e.image)).toEqual([
+      "rust-alc-api-00042-abc",
+      "rust-alc-api-00041-xyz",
+    ]);
+    expect(got!.deploy_history![1].tag).toBe("v1.4.1");
+  });
+
+  it("reads a legacy v1 backend record (no current_tag / deploy_history)", async () => {
+    await kv().put(
+      "backend::ippoan/rust-alc-api",
+      JSON.stringify({
+        schema_version: 1,
+        repo: "ippoan/rust-alc-api",
+        current_image: "img-legacy",
+        deployed_at: "t",
+        deployed_by: "z",
+        wave_id: null,
+      }),
+    );
+    const got = await getBackendCurrent(kv(), "ippoan/rust-alc-api");
+    expect(got!.current_image).toBe("img-legacy");
+    expect(got!.current_tag ?? null).toBeNull();
+  });
+
+  it("nextBackendDeployHistory: no-op when image is unchanged", () => {
+    const prior = [{ image: "img-1", tag: "v1", became_active_at: "t1" }];
+    expect(nextBackendDeployHistory(prior, "img-1", "v1", "t2")).toEqual(prior);
   });
 });
 

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -916,6 +916,26 @@ describe("handleReleaseWaveDetailPage compatibility section", () => {
     expect(html).toContain("<svg");
     expect(html).toContain("cur-img");
   });
+
+  it("shows the git tag on the backend node when the v2 record has current_tag (Refs #197)", async () => {
+    const env = fakeEnv({
+      getReturn: { ok: true, data: makeWave() },
+      compatKv: memKv({
+        "backend::ippoan/rust-alc-api": {
+          schema_version: 2,
+          repo: "ippoan/rust-alc-api",
+          current_image: "rust-alc-api-00042-abc",
+          current_tag: "v1.4.2",
+          deployed_at: "2026-05-29T00:00:00Z",
+          deployed_by: "release-wave-gcp",
+          wave_id: null,
+        },
+      }),
+    });
+    const html = await (await handleReleaseWaveDetailPage(env, "w1")).text();
+    // node line2 は "<tag> · @ <sha>" 形式 (tag を併記)。
+    expect(html).toContain("v1.4.2");
+  });
 });
 
 // ============================================================================

--- a/test/release-wave/repo-status-section.test.ts
+++ b/test/release-wave/repo-status-section.test.ts
@@ -7,9 +7,11 @@ import {
   renderCompatTagReleaseButtons,
   injectCompatTagReleaseButtons,
   renderTrafficVersionsBlock,
+  renderBackendRollbackBlock,
   handleReleaseWaveListPageWithRepoStatus,
 } from "../../src/release-wave/repo-status-section";
 import type { TrafficRecord } from "../../src/release-wave/traffic";
+import type { WaveCompatibility } from "../../src/release-wave/compat";
 import type { RepoReleaseStatus } from "../../src/release-wave/repo-release-status";
 import type { Env } from "../../src/index";
 
@@ -365,6 +367,81 @@ describe("renderTrafficVersionsBlock", () => {
     expect(html).toContain("(他2件)");
     // 0% (最新) が 100% (より古い active) より上に来る (日時降順)。
     expect(html.indexOf("zero-newest")).toBeLessThan(html.indexOf("active-id"));
+  });
+
+  it("renders a Rollback button for prior deployed versions (Refs #196)", () => {
+    const r: TrafficRecord = {
+      schema_version: 4,
+      repo: "ippoan/auth-worker",
+      versions: [{ version_id: "cur", percentage: 100, tag: "v0.2.50" }],
+      deploy_history: [
+        { version_id: "cur", tag: "v0.2.50", became_active_at: "2026-05-29T09:30:00Z" },
+        { version_id: "prev", tag: "v0.2.49", became_active_at: "2026-05-28T11:37:00Z" },
+      ],
+      reported_at: "t",
+    };
+    const html = renderTrafficVersionsBlock(["ippoan/auth-worker"], new Map([["ippoan/auth-worker", r]]));
+    expect(html).toContain("/api/release-wave/traffic-rollback");
+    expect(html).toContain('name="version_id" value="prev"');
+    expect(html).toContain("Rollback to v0.2.49");
+    // 現 active (cur) への rollback ボタンは出さない。
+    expect(html).not.toContain('name="version_id" value="cur"');
+  });
+
+  it("renders no Rollback button when deploy_history has only the active version", () => {
+    const r: TrafficRecord = {
+      schema_version: 4,
+      repo: "ippoan/x",
+      versions: [{ version_id: "cur", percentage: 100 }],
+      deploy_history: [{ version_id: "cur", tag: null, became_active_at: "t" }],
+      reported_at: "t",
+    };
+    const html = renderTrafficVersionsBlock(["ippoan/x"], new Map([["ippoan/x", r]]));
+    expect(html).not.toContain("/api/release-wave/traffic-rollback");
+  });
+});
+
+describe("renderBackendRollbackBlock", () => {
+  function compat(backends: WaveCompatibility["backends"]): WaveCompatibility {
+    return { verified: true, checked: true, backends };
+  }
+
+  it("renders Rollback buttons for prior Cloud Run revisions (Refs #197)", () => {
+    const html = renderBackendRollbackBlock(
+      compat([
+        {
+          backend_repo: "ippoan/rust-alc-api",
+          current_image: "rust-alc-api-00042-abc",
+          current_tag: "v1.4.2",
+          deploy_history: [
+            { image: "rust-alc-api-00042-abc", tag: "v1.4.2", became_active_at: "2026-05-29T09:30:00Z" },
+            { image: "rust-alc-api-00041-xyz", tag: "v1.4.1", became_active_at: "2026-05-28T11:37:00Z" },
+          ],
+          matrix: [],
+        },
+      ]),
+    );
+    expect(html).toContain("Backend rollback (Cloud Run revision)");
+    expect(html).toContain("/api/release-wave/backend-rollback");
+    expect(html).toContain('name="image" value="rust-alc-api-00041-xyz"');
+    expect(html).toContain("Rollback to v1.4.1");
+    // 現 active (00042) への rollback ボタンは出さない。
+    expect(html).not.toContain('name="image" value="rust-alc-api-00042-abc"');
+  });
+
+  it("returns empty string when no backend has rollback candidates", () => {
+    const html = renderBackendRollbackBlock(
+      compat([
+        {
+          backend_repo: "ippoan/rust-alc-api",
+          current_image: "cur",
+          current_tag: null,
+          deploy_history: [{ image: "cur", tag: null, became_active_at: "t" }],
+          matrix: [],
+        },
+      ]),
+    );
+    expect(html).toBe("");
   });
 });
 

--- a/test/release-wave/revision.test.ts
+++ b/test/release-wave/revision.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { serviceNameFromRevision } from "../../src/release-wave/revision";
+
+describe("serviceNameFromRevision", () => {
+  it("strips the -NNNNN-suffix and returns the service name", () => {
+    expect(serviceNameFromRevision("rust-alc-api-00042-abc")).toBe("rust-alc-api");
+  });
+
+  it("handles a single-token service name", () => {
+    expect(serviceNameFromRevision("api-00001-x")).toBe("api");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(serviceNameFromRevision("  svc-00007-q9z  ")).toBe("svc");
+  });
+
+  it("returns null when the revision does not match the expected shape", () => {
+    expect(serviceNameFromRevision("not-a-revision")).toBeNull();
+    expect(serviceNameFromRevision("svc-123-abc")).toBeNull(); // 5桁でない
+    expect(serviceNameFromRevision("")).toBeNull();
+  });
+});

--- a/test/release-wave/traffic.test.ts
+++ b/test/release-wave/traffic.test.ts
@@ -3,6 +3,8 @@ import {
   recordTraffic,
   getTraffic,
   getTrafficForRepos,
+  nextDeployHistory,
+  DEPLOY_HISTORY_MAX,
   type TrafficRecord,
 } from "../../src/release-wave/traffic";
 
@@ -47,7 +49,7 @@ describe("traffic record", () => {
     expect(rec!.versions[0].version_id).toBe("full");
     expect(rec!.versions[1].version_id).toBe("zero");
     expect(rec!.reported_at).toBe("2026-05-29T00:00:00Z");
-    expect(rec!.schema_version).toBe(3);
+    expect(rec!.schema_version).toBe(4);
   });
 
   it("recordTraffic breaks percentage ties by created_on desc (newest 0% first)", async () => {
@@ -125,6 +127,83 @@ describe("traffic record", () => {
     const byId = Object.fromEntries(rec!.versions.map((v) => [v.version_id, v.tag]));
     expect(byId["full"]).toBe("v1.0.0"); // 過去 report の tag を保持
     expect(byId["zero"]).toBe("v1.0.1"); // 新 report の tag
+  });
+
+  it("records deploy_history when the active (100%) version changes", async () => {
+    const kv = memKv();
+    // 1 回目: v1 が 100%。
+    await recordTraffic(kv, {
+      repo: "ippoan/x",
+      versions: [{ version_id: "v1", percentage: 100, tag: "v1.0.0" }],
+      now: "2026-05-01T00:00:00Z",
+    });
+    let rec = await getTraffic(kv, "ippoan/x");
+    expect(rec!.deploy_history).toEqual([
+      { version_id: "v1", tag: "v1.0.0", became_active_at: "2026-05-01T00:00:00Z" },
+    ]);
+
+    // 2 回目: v2 が 100% に (v1 は 0% に落ちる) → 履歴先頭に v2。
+    await recordTraffic(kv, {
+      repo: "ippoan/x",
+      versions: [
+        { version_id: "v2", percentage: 100, tag: "v2.0.0", created_on: "2026-05-02T00:00:00Z" },
+        { version_id: "v1", percentage: 0, tag: "v1.0.0" },
+      ],
+      now: "2026-05-02T09:00:00Z",
+    });
+    rec = await getTraffic(kv, "ippoan/x");
+    expect(rec!.deploy_history!.map((e) => e.version_id)).toEqual(["v2", "v1"]);
+    // became_active_at は created_on 優先。
+    expect(rec!.deploy_history![0].became_active_at).toBe("2026-05-02T00:00:00Z");
+  });
+
+  it("does not duplicate deploy_history when active stays the same", async () => {
+    const kv = memKv();
+    await recordTraffic(kv, {
+      repo: "ippoan/x",
+      versions: [{ version_id: "v1", percentage: 100 }],
+      now: "t1",
+    });
+    await recordTraffic(kv, {
+      repo: "ippoan/x",
+      versions: [{ version_id: "v1", percentage: 100 }],
+      now: "t2",
+    });
+    const rec = await getTraffic(kv, "ippoan/x");
+    expect(rec!.deploy_history!.map((e) => e.version_id)).toEqual(["v1"]);
+  });
+
+  it("nextDeployHistory: re-promoting an old version moves it back to the front", () => {
+    const prior = [
+      { version_id: "v2", tag: "v2", became_active_at: "t2" },
+      { version_id: "v1", tag: "v1", became_active_at: "t1" },
+    ];
+    const next = nextDeployHistory(
+      prior,
+      [{ version_id: "v1", percentage: 100, tag: "v1" }],
+      "t3",
+    );
+    expect(next.map((e) => e.version_id)).toEqual(["v1", "v2"]);
+  });
+
+  it("nextDeployHistory: no active (all 0%) keeps prior history", () => {
+    const prior = [{ version_id: "v1", tag: null, became_active_at: "t1" }];
+    const next = nextDeployHistory(prior, [{ version_id: "v1", percentage: 0 }], "t2");
+    expect(next).toEqual(prior);
+  });
+
+  it("nextDeployHistory trims to DEPLOY_HISTORY_MAX", () => {
+    let history: ReturnType<typeof nextDeployHistory> = [];
+    for (let i = 0; i < DEPLOY_HISTORY_MAX + 5; i++) {
+      history = nextDeployHistory(
+        history,
+        [{ version_id: `v${i}`, percentage: 100 }],
+        `t${i}`,
+      );
+    }
+    expect(history.length).toBe(DEPLOY_HISTORY_MAX);
+    // 先頭は最新。
+    expect(history[0].version_id).toBe(`v${DEPLOY_HISTORY_MAX + 4}`);
   });
 
   it("getTrafficForRepos returns only repos that have a record", async () => {


### PR DESCRIPTION
## 概要

frontend (Cloudflare Workers traffic) と backend (Cloud Run revision) の両方で
「過去に deployed だった version/revision」を KV に蓄積し、`/release-wave` から
**任意の過去 version へ即 100% で戻せる** ようにする。Refs #196 / #197。

設計方針 (要決定論点の決定):
- rollback 先: `deploy_history` からの**任意選択**
- dispatch 経路: **新 event を新設** (`release-wave-traffic-rollback` / `release-wave-backend-rollback`)
- 戻し方: **即 100%** (canary 無し)

## frontend (Refs #196)

- `traffic::` schema **v4**: `deploy_history[]` を追加 (新しい順、上限 20)。
  `recordTraffic` が active(100%) version の遷移を検知して積む (重複は積まない / 再 promote は先頭へ移動)。
- `POST /api/release-wave/traffic-rollback`: form `repo` + `version_id` を受け、
  履歴/現配分に含まれる version のみ許可し `release-wave-traffic-rollback` を dispatch
  (`previewed_version_id`@100%)。
- Traffic (version split) テーブルに過去 version への「Rollback to `<tag>`」ボタン。

## backend (Refs #197)

- `backend::` schema **v2**: `current_tag` + `deploy_history[]` を追加。
  reader (`getBackendCurrent`) は **v1/v2 双方を許容** (後方互換)。
  `recordBackendDeploy` が revision 遷移を積む。
- `backend-deploy-report` webhook に `current_tag` (optional) を追加。
- Compatibility グラフの backend ノード line2 / matrix header に git tag を併記 (`<tag> · @ <sha>`)。
- `POST /api/release-wave/backend-rollback`: form `repo` + `image` を受け、
  revision name (`<service>-NNNNN-suffix`) から service 名を逆算して
  `rollback_target` map を組み、`release-wave-backend-rollback` を dispatch。
- グラフ下に「Backend rollback (Cloud Run revision)」ボタン群。

## 送信側 (別 PR)

新 dispatch event (`release-wave-traffic-rollback` / `release-wave-backend-rollback`) を
受ける handler step は `ippoan/ci-workflows` 側で、`current_tag` の供給は
backend deploy workflow 側で別 PR にて対応する。

## テスト

`test/release-wave/` に 26 件追加 (deploy_history 蓄積 / backend v1/v2 後方互換 /
両 rollback API / revision 逆算 / UI ボタン / backend ノード tag 表示)。全 306 件 green。
`tsc --noEmit` も pass。`docs/release-wave-compatibility-kv.md` を v2 shape に更新。

Refs #196
Refs #197

https://claude.ai/code/session_01EJFTACCCwM9nnQStpcW7vH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJFTACCCwM9nnQStpcW7vH)_