### PR TITLE
fix(releases): exclude non-semver stamp tags from topTags

### DIFF
--- a/src/release-alert.ts
+++ b/src/release-alert.ts
@@ -28,6 +28,7 @@ import {
   extractPrNumber,
   extractBranchIssue,
   sortSemverDesc,
+  isSemverTag,
   previousTag,
 } from "./release-helpers";
 import {
@@ -128,7 +129,9 @@ export async function computeReleaseAlert(
   const token = await tokenForOrg(env, owner);
 
   const tags = await cachedTags(token, kv, owner, name, 30);
-  const tagNames = tags.map((t) => t.name);
+  // Drop non-semver stamp tags (e.g. `installer-*`) so a tag-less repo isn't
+  // treated as having release tags and routed into the tag-compare path. Refs #199.
+  const tagNames = tags.map((t) => t.name).filter(isSemverTag);
   if (tagNames.length === 0) return null;
 
   const sorted = sortSemverDesc(tagNames);

--- a/src/release-helpers.ts
+++ b/src/release-helpers.ts
@@ -69,6 +69,16 @@ export function sortSemverDesc(tags: readonly string[]): string[] {
 
 const SEMVER_RE = /^v?(\d+)\.(\d+)\.(\d+)/;
 
+// True for release-shaped tags ("v1.2.3" / "1.2.3"). Non-semver tags
+// (e.g. `installer-2026.05.15-…` install stamps) return false so callers can
+// drop them before treating a repo as "has release tags" — otherwise a
+// tag-less repo carrying a non-semver stamp tag is wrongly routed into the
+// tag-compare path instead of the synthetic (direct-push) path, and its open
+// Refs never surface on /releases. Refs #199.
+export function isSemverTag(tag: string): boolean {
+  return SEMVER_RE.test(tag);
+}
+
 function compareTagsDesc(a: string, b: string): number {
   const ma = a.match(SEMVER_RE);
   const mb = b.match(SEMVER_RE);

--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -3,6 +3,7 @@ import type { AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
 import {
   extractRefIssues,
   sortSemverDesc,
+  isSemverTag,
   previousTag,
   computeWarnings,
 } from "./release-helpers";
@@ -226,7 +227,11 @@ async function loadRepoView(
   // 1. Recent semver tags. 10 gives us 5 inline + room for the predecessor
   //    pairing on the oldest of those 5 + a small "older" strip.
   const allTags = await cachedTags(token, kv, owner, name, 10);
-  const sorted = sortSemverDesc(allTags.map((t) => t.name));
+  // Non-semver tags (e.g. `installer-*` install stamps) are not release tags;
+  // keep them out of topTags so a repo whose only tags are stamps still takes
+  // the synthetic (direct-push) path below instead of the stale tag-compare
+  // path — otherwise its open Refs never surface here. Refs #199.
+  const sorted = sortSemverDesc(allTags.map((t) => t.name).filter(isSemverTag));
   const topTags = sorted.slice(0, TOP_TAGS_INLINE);
   if (topTags.length === 0) {
     // Tag-less repos opted into synthetic-block rendering (either via the

--- a/test/release-helpers.test.ts
+++ b/test/release-helpers.test.ts
@@ -4,6 +4,7 @@ import {
   extractPrNumber,
   extractBranchIssue,
   sortSemverDesc,
+  isSemverTag,
   previousTag,
   computeWarnings,
 } from "../src/release-helpers";
@@ -108,6 +109,24 @@ describe("sortSemverDesc", () => {
     expect(out[0]).toBe("v1.0.0");
     expect(out[1]).toBe("v0.9.0");
     expect(out[2]).toBe("release-candidate");
+  });
+});
+
+describe("isSemverTag", () => {
+  it("accepts vX.Y.Z and X.Y.Z release tags", () => {
+    expect(isSemverTag("v1.2.3")).toBe(true);
+    expect(isSemverTag("1.2.3")).toBe(true);
+    expect(isSemverTag("v0.0.1")).toBe(true);
+    expect(isSemverTag("v1.2.3-rc.1")).toBe(true); // prefix match, suffix allowed
+  });
+
+  it("rejects non-semver stamp / arbitrary tags", () => {
+    // The regression that hid claude-md from /releases: install-stamp tags
+    // counted as "tags present" and forced the stale tag-compare path. Refs #199.
+    expect(isSemverTag("installer-2026.05.15-090249-05848fc")).toBe(false);
+    expect(isSemverTag("release-candidate")).toBe(false);
+    expect(isSemverTag("dev-0.0.1")).toBe(false); // not anchored at start
+    expect(isSemverTag("")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## 概要

`installer-*` 等の**非 semver tag を持つだけの TAGLESS repo**（例 `ippoan/claude-md`）が、/releases に open Refs を出さない問題を修正する。

## Root cause (Refs #199)

`loadRepoView` は「semver tag が無い → synthetic 経路 (`cachedCommits`, TTL 60s)」を意図しているが、`sortSemverDesc` は非 semver tag を末尾に並べるだけで除外しないため、`installer-*` があると `topTags.length` が 0 にならず、stale な tag-compare 経路 (`cachedCompare`, **TTL 86400s=1日**, key 固定で HEAD 移動を追わない) に流れる。結果、open issue を参照する新しい commit が cache に反映されず、/releases に出ない。

## 変更

- `release-helpers.ts`: `isSemverTag()` を追加（`SEMVER_RE.test`）+ unit test
- `releases-page.ts`: topTags 算出で `.filter(isSemverTag)` を適用
- `release-alert.ts`: banner の tag 判定でも同様に非 semver tag を除外（同 root cause）

## 効果

`installer-*` を持つ全 TAGLESS repo で再発防止。claude-md は semver tag 0 になり synthetic 経路 (60s) に乗って open Refs (#58 等) が /releases に出る。

## 検証メモ

ローカルは `@ippoan/auth-client-worker` (GitHub Packages) が CCoW で 401 のため typecheck/test 未実行。CI に委ねる。

Refs #199, Refs ippoan/claude-md#58

---
_Generated by [Claude Code](https://claude.ai/code/session_014V8jsLJeBETRWZ2aeRsbaX)_