### PR TITLE
feat(releases): add cc-relay / mcp-cf-workers / claude-hooks to TAGLESS_REPOS

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -124,7 +124,7 @@
         // cut release tags: dashboard はこれらの PR merge を mini-release 扱いし、
         // merged PR の `Refs #N` を逆引きして /releases synthetic block + banner に
         // 出す (= stable tag 前でも早期 close 可能)。未掲載 repo は tag-driven flow。
-        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs"
+        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs,ippoan/cc-relay,ippoan/mcp-cf-workers,yhonda-ohishi/claude-hooks"
       },
       "kv_namespaces": [
         {


### PR DESCRIPTION
## 概要

`/releases` から PR-merge ベースで早期 issue close できるよう、`TAGLESS_REPOS` に 3 repo を追加する。

## 追加

- `ippoan/cc-relay` — semver tag (`v0.0.x`) ありの混合運用。Unreleased block で latest tag → HEAD の merged PR `Refs` を出す。
- `ippoan/mcp-cf-workers`
- `yhonda-ohishi/claude-hooks` — yhonda-ohishi org（`ALLOWED_ORGS` 済みなので token 解決可）

`ippoan/ci-dashboard` は既登録のため対象外。

## 前提

#200 で `isSemverTag` フィルタが入ったため、`dev-*` / `installer-*` 等の非 semver tag を持つ repo も正しく synthetic 経路に乗る。

Refs #201

---
_Generated by [Claude Code](https://claude.ai/code/session_014V8jsLJeBETRWZ2aeRsbaX)_