### PR TITLE
feat(release-wave): traffic rollback で候補外の 0% version を理由付き表示

### DIFF
--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -339,19 +339,47 @@ export function renderTrafficVersionsBlock(
 }
 
 /**
- * 1 repo の Traffic 行に続けて、過去に active だった version への rollback ボタン
- * 行を返す (Refs #196)。`deploy_history` から「現 active 以外」を rollback 先候補
- * とし、各候補に `Rollback to <tag/id>` ボタンを出す。候補が無ければ ""。
+ * 1 repo の Traffic 行に続けて、rollback 行を返す (Refs #196)。
+ *
+ * - rollback **候補** = `deploy_history` のうち「現 active 以外」(= 過去に active
+ *   だった version)。各候補に `Rollback to <tag/id>` ボタンを出す。
+ * - rollback **候補外** = `versions` のうち 0% (no-traffic) でまだ一度も active に
+ *   なっていない version (= deploy_history に載っていない)。rollback 先になれない
+ *   が、「なぜボタンが無いか」を画面で分かるよう理由付きで併記する。
+ * - 候補も候補外も無ければ "" (Traffic 行が 1 version だけ等)。
  *
  * 現 active は traffic の最大 percentage version。deploy_history[0] が現 active と
  * 一致する想定だが、念のため active version_id を除いて候補を作る。
  */
 function renderTrafficRollbackRow(repo: string, rec: TrafficRecord): string {
+  const versions = rec.versions ?? [];
   const history = rec.deploy_history ?? [];
-  if (history.length === 0) return "";
-  const activeId = rec.versions.find((v) => v.percentage > 0)?.version_id ?? null;
+  const activeId = versions.find((v) => v.percentage > 0)?.version_id ?? null;
+
+  // 候補: 過去に active だった (deploy_history) が現 active でないもの。
   const candidates = history.filter((e) => e.version_id !== activeId);
-  if (candidates.length === 0) return "";
+
+  // 候補外: 現存する 0% (no-traffic) で、まだ一度も active になっていない
+  // (= deploy_history に過去 active として載っていない) version。新しい順。
+  const historyIds = new Set(history.map((e) => e.version_id));
+  const nonActive = versions
+    .filter(
+      (v) =>
+        v.percentage <= 0 &&
+        v.version_id !== activeId &&
+        !historyIds.has(v.version_id),
+    )
+    .sort((a, b) => {
+      const ca = a.created_on ?? "";
+      const cb = b.created_on ?? "";
+      if (ca === cb) return 0;
+      if (!ca) return 1;
+      if (!cb) return -1;
+      return ca < cb ? 1 : -1; // 新しい順
+    });
+
+  // 候補も候補外も無ければ従来どおり行を出さない。
+  if (candidates.length === 0 && nonActive.length === 0) return "";
 
   const buttons = candidates
     .map((e) => {
@@ -369,12 +397,32 @@ function renderTrafficRollbackRow(repo: string, rec: TrafficRecord): string {
     })
     .join("");
 
+  // 候補が 1 件も無いとき、行が黙って消える挙動をやめて理由を出す (Refs #196)。
+  const noCandidateNote =
+    candidates.length === 0
+      ? `<div class="meta" style="margin-top:4px">過去に active だった version がまだないため、戻せる先がありません。</div>`
+      : "";
+
+  // 候補外 (0% / 一度も active になっていない) version を理由付きで併記する。
+  // 最新 1 件を代表表示し、残りは「他N件」で件数だけ示す。
+  let nonActiveNote = "";
+  if (nonActive.length > 0) {
+    const head = nonActive[0]!;
+    const label = head.tag
+      ? escapeHtml(head.tag)
+      : escapeHtml(shortId(head.version_id));
+    const more = nonActive.length > 1 ? ` 他${nonActive.length - 1}件` : "";
+    nonActiveNote = `<div class="meta" style="margin-top:4px">候補外 (rollback 先になりません): ${label} (0% · 一度も active になっていない)${more}</div>`;
+  }
+
   return `
             <tr>
               <td></td>
               <td colspan="3">
                 <span class="meta">Rollback to (過去の deployed version):</span>
-                <div style="margin-top:4px">${buttons}</div>
+                ${noCandidateNote}
+                ${buttons ? `<div style="margin-top:4px">${buttons}</div>` : ""}
+                ${nonActiveNote}
               </td>
             </tr>`;
 }

--- a/test/release-wave/repo-status-section.test.ts
+++ b/test/release-wave/repo-status-section.test.ts
@@ -399,6 +399,38 @@ describe("renderTrafficVersionsBlock", () => {
     const html = renderTrafficVersionsBlock(["ippoan/x"], new Map([["ippoan/x", r]]));
     expect(html).not.toContain("/api/release-wave/traffic-rollback");
   });
+
+  it("shows a reason (not a hidden row) when only no-traffic 0% versions exist (Refs #196)", () => {
+    // 現 active 1 つ + 0% no-traffic のみ。deploy_history は現 active だけなので
+    // rollback 候補は 0 件。従来は行ごと消えて理由が分からなかったが、候補外
+    // version を「rollback 先になりません」と理由付きで併記する。
+    const r: TrafficRecord = {
+      schema_version: 4,
+      repo: "ippoan/auth-worker",
+      versions: [
+        { version_id: "active-id", percentage: 100, created_on: "2026-05-28T11:37:00Z", tag: "v0.2.48" },
+        { version_id: "pending-id", percentage: 0, created_on: "2026-05-29T09:07:00Z", tag: "v0.2.49" },
+      ],
+      deploy_history: [
+        { version_id: "active-id", tag: "v0.2.48", became_active_at: "2026-05-28T11:37:00Z" },
+      ],
+      reported_at: "t",
+    };
+    const html = renderTrafficVersionsBlock(
+      ["ippoan/auth-worker"],
+      new Map([["ippoan/auth-worker", r]]),
+    );
+    // 行は黙って消えない。
+    expect(html).toContain("Rollback to (過去の deployed version):");
+    // 候補ゼロの理由が出る。
+    expect(html).toContain("戻せる先がありません");
+    // 候補外 version が理由付きで出る。
+    expect(html).toContain("候補外 (rollback 先になりません)");
+    expect(html).toContain("v0.2.49");
+    expect(html).toContain("一度も active になっていない");
+    // 実 rollback ボタン (dispatch) は出さない。
+    expect(html).not.toContain('action="/api/release-wave/traffic-rollback"');
+  });
 });
 
 describe("renderBackendRollbackBlock", () => {


### PR DESCRIPTION
## What

`/release-wave` の Traffic (version split) で、rollback 候補が0件のとき `renderTrafficRollbackRow` が**行ごと消えて理由が分からなかった**のを、候補外 version を理由付きで表示するよう変更。

- 候補0件 → 「過去に active だった version がまだないため、戻せる先がありません。」
- 0% (no-traffic) でまだ一度も active になっていない version → 「候補外 (rollback 先になりません): `<tag/id>` (0% · 一度も active になっていない)」(最新1件 + 他N件)
- 候補も候補外も無ければ従来どおり非表示

## Why

auth-worker のように「現 active 1 つ + no-traffic 0% version のみ」の状態だと Traffic セクションに Rollback ボタンも理由も出ず、なぜ rollback できないかが UI から分からなかった (実機確認済み)。

## Test

`test/release-wave/repo-status-section.test.ts` に「候補0件 + 候補外あり」のケースを追加。既存ケースは候補外 note が head の id のみ表示 (残りは「他N件」で id を出さない) なので `not.toContain` 系も含め影響なし。

> ⚠️ **CCoW からローカルで typecheck/test を実行できませんでした。** vitest-pool-workers が worker entry `src/index.ts` を読み込み、そこが `@ippoan/auth-client-worker` (GitHub Packages, token 必須) を import するため、token の無い CCoW では runner が起動しません (`E401`)。ロジックは既存テスト6ケース + 新ケースを手でトレースして確認済みですが、**CI (token あり) の typecheck + test 結果で最終検証**してください。

Refs #203
Refs #196

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6TRFPcQrDjH7HFmNLxzRV)_