### PR TITLE
infra: bind SYMBOL_INDEX D1 (read 経路有効化)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -50,6 +50,18 @@
       "new_sqlite_classes": ["ReleaseWaveHub"]
     }
   ],
+  // cross-repo symbol index (D1)。CI (ci-workflows symbol-index.yml) が ctags/LSP
+  // 抽出した symbol を `/internal/symbol-index` 経由で投入し、MCP の search_symbols
+  // が読む。schema は migrations/0001_symbol_index.sql。未投入/空のときは
+  // search_symbols が GitHub code-search に fallback する。設計は claude-skills の
+  // cross-repo-symbol-index skill。
+  "d1_databases": [
+    {
+      "binding": "SYMBOL_INDEX",
+      "database_name": "symbol-index",
+      "database_id": "fcc78c58-d1fd-4e3c-8548-eb07c87755c0"
+    }
+  ],
   // GitHub auth は @ippoan/auth-client-worker 経由で auth-worker に delegate
   // (issue #118)。`/oauth/login` ブラウザフロー (Auth Code + PKCE) でログイン後、
   // access_token + refresh_token は CI_STATUS KV に SDK が保存する。
@@ -156,6 +168,13 @@
         {
           "tag": "v2",
           "new_sqlite_classes": ["ReleaseWaveHub"]
+        }
+      ],
+      "d1_databases": [
+        {
+          "binding": "SYMBOL_INDEX",
+          "database_name": "symbol-index",
+          "database_id": "fcc78c58-d1fd-4e3c-8548-eb07c87755c0"
         }
       ],
       "secrets_store_secrets": [


### PR DESCRIPTION
## 概要

cross-repo symbol index 用の D1 を実際に作成し、`wrangler.jsonc` に binding を追加する (#206 の provisioning follow-up)。

## やったこと

- D1 作成: `symbol-index` (uuid `fcc78c58-d1fd-4e3c-8548-eb07c87755c0`, APAC)
- schema 適用: `migrations/0001_symbol_index.sql` (repos/symbols/deps/links, 全 7 文成功)
- `wrangler.jsonc` の **top-level と env.staging (実運用 env) 両方**に `SYMBOL_INDEX` binding を追加

これで `search_symbols` の **D1 read 経路が有効**になる。D1 が空の間は従来通り GitHub code-search に fallback するので無害。generator (ci-workflows#91 の `symbol-index.yml`) が投入を始めると `repo/file:start-end` 付きの正確な結果を返す。

## 残り (このPR外)

ingest 用 `SYMBOL_INDEX_INGEST_SECRET` (Secrets Store + GitHub Actions secret) の設定。未設定の間は ingest endpoint が 503 を返すのみで、**read 経路・deploy には影響しない**。

## 検証

- `wrangler.jsonc` の JSONC 妥当性 + 両 env に binding が入っていることを確認

Refs #205

---
_Generated by [Claude Code](https://claude.ai/code/session_016MaUPgTR9AT361Q9ciEox5)_