### PR TITLE
feat: 鮮度比較 endpoint + incremental ingest + head endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { handleReleaseWaveTagRelease } from "./release-wave/tag-release-action";
 import { handleReleaseWaveListPageWithRepoStatus } from "./release-wave/repo-status-section";
 import { handleMcpRequest } from "./mcp/server";
 import { handleSymbolIndexIngest } from "./symbol-index";
+import { handleFreshness, handleRepoHead } from "./symbol-freshness";
 import {
   handleContractAppliedWebhook,
   handleStageReportWebhook,
@@ -229,6 +230,12 @@ app.all("/mcp", (c) => handleMcpRequest(c.req.raw, c.env));
 // LSP 抽出した symbol を投入する internal endpoint。Bearer 認証
 // (SYMBOL_INDEX_INGEST_SECRET)。設計: claude-skills cross-repo-symbol-index。
 app.post("/internal/symbol-index", (c) => handleSymbolIndexIngest(c.req.raw, c.env));
+
+// 鮮度比較: D1 の baseline (repos.src_hash) と各 repo の現在の main tree hash を
+// 比較し stale な repo を返す (open read、hash は機微でない)。hook が叩いて警告する。
+app.get("/symbol-index/freshness", (c) => handleFreshness(c.req.raw, c.env));
+// generator が incremental 差分の基点 (前回 head_sha) を取る read。
+app.get("/symbol-index/head/:repo", (c) => handleRepoHead(c.req.param("repo"), c.env));
 
 // Release Wave: GitHub Actions step が叩く HTTP webhook 3 本 (Refs #137
 // Phase 3d + Phase 4)。MCP 経路と機能等価だが OAuth 不要の shared secret

--- a/src/symbol-freshness.ts
+++ b/src/symbol-freshness.ts
@@ -1,0 +1,105 @@
+// cross-repo symbol index — 鮮度比較 (skills/map staleness)。
+//
+// D1 の repos.src_hash (= generator が index した時の tree hash) と、各 repo の
+// **現在の default branch の root tree hash** を比べ、ズレている repo を返す。
+// ズレ = index/derived skill が repo より古い ＝ stale。
+//
+// 設計: ippoan/claude-skills の cross-repo-symbol-index skill。
+// hook (claude-hooks) がこの endpoint を叩いて Claude に警告する想定。
+// 値 (tree hash) は機微でないので read は open。
+
+import { githubApi, parseRepo, tokenForOrg } from "./github-api";
+import type { AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
+import { readRepos, isStale, readRepoHead, type D1Like } from "./symbol-index";
+
+type FreshnessEnv = AuthClientWorkerEnv & { SYMBOL_INDEX?: D1Database };
+
+interface CommitListItem {
+  commit: { tree: { sha: string } };
+}
+
+export interface FreshnessRow {
+  repo: string;
+  indexed_src_hash: string | null;
+  current_tree_sha: string | null;
+  stale: boolean;
+  indexed_at: number | null;
+}
+
+/**
+ * D1 の各 repo について現在の tree hash を取得して baseline と比較する。
+ * current 取得失敗 (削除/権限/ネットワーク) の repo は current=null・stale=false
+ * (= 判定不能を stale に倒さない)。
+ */
+export async function computeFreshness(
+  db: D1Like,
+  fetchCurrentTreeSha: (repo: string) => Promise<string | null>,
+): Promise<FreshnessRow[]> {
+  const repos = await readRepos(db);
+  const rows: FreshnessRow[] = [];
+  for (const r of repos) {
+    let current: string | null = null;
+    try {
+      current = await fetchCurrentTreeSha(r.repo);
+    } catch {
+      current = null;
+    }
+    rows.push({
+      repo: r.repo,
+      indexed_src_hash: r.src_hash,
+      current_tree_sha: current,
+      stale: isStale(r.src_hash, current),
+      indexed_at: r.updated_at,
+    });
+  }
+  return rows;
+}
+
+/** GitHub API で repo の default branch 最新 commit の root tree sha を取る。 */
+async function currentTreeShaFromGitHub(
+  env: AuthClientWorkerEnv,
+  repo: string,
+): Promise<string | null> {
+  const { owner, repo: name } = parseRepo(repo);
+  const token = await tokenForOrg(env, owner);
+  const data = await githubApi<CommitListItem[]>(
+    token, "GET", `/repos/${owner}/${name}/commits`, undefined, { per_page: "1" },
+  );
+  return data[0]?.commit?.tree?.sha ?? null;
+}
+
+/** GET /symbol-index/freshness の handler。 */
+export async function handleFreshness(_request: Request, env: FreshnessEnv): Promise<Response> {
+  if (!env.SYMBOL_INDEX) {
+    return json(503, { error: "SYMBOL_INDEX (D1) is not bound" });
+  }
+  const rows = await computeFreshness(env.SYMBOL_INDEX, (repo) =>
+    currentTreeShaFromGitHub(env, repo),
+  );
+  const stale = rows.filter((r) => r.stale);
+  return json(200, {
+    total: rows.length,
+    stale_count: stale.length,
+    stale: stale.map((r) => r.repo),
+    repos: rows,
+  });
+}
+
+/**
+ * GET /symbol-index/head/:repo の handler。generator が incremental 差分の
+ * 基点 (前回 index した head_sha) を取るための read。未 index は head_sha=null
+ * → generator はフルスキャンに倒す。
+ */
+export async function handleRepoHead(repo: string, env: FreshnessEnv): Promise<Response> {
+  if (!env.SYMBOL_INDEX) return json(503, { error: "SYMBOL_INDEX (D1) is not bound" });
+  if (!repo) return json(400, { error: "repo is required" });
+  const row = await readRepoHead(env.SYMBOL_INDEX, repo);
+  return json(200, { repo, head_sha: row?.head_sha ?? null, src_hash: row?.src_hash ?? null });
+}
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/src/symbol-index.ts
+++ b/src/symbol-index.ts
@@ -76,6 +76,50 @@ export function formatSymbolResults(rows: SymbolRow[], q: SymbolQuery): string {
   return body ? `${header}\n\n${body}` : header;
 }
 
+// --- 鮮度比較 (skills/map staleness) ---
+
+/** repos テーブルの行 (鮮度比較に使う最小列)。 */
+export interface RepoState {
+  repo: string;
+  src_hash: string | null;
+  updated_at: number | null;
+}
+
+/** D1 に index 済みの全 repo の baseline (src_hash) を読む。 */
+export async function readRepos(db: D1Like): Promise<RepoState[]> {
+  const { results } = await db
+    .prepare(`SELECT repo, src_hash, updated_at FROM repos ORDER BY repo`)
+    .bind()
+    .all<RepoState>();
+  return results ?? [];
+}
+
+/**
+ * baseline (index した時の tree hash) と現在の tree hash を比べて stale 判定。
+ * 内容ハッシュ比較なので squash merge / pull 未済をまたいでも壊れない
+ * (cross-repo-symbol-index skill の設計参照)。current が不明 (null) のときは
+ * 判定不能として false (= stale 扱いしない。「不明」を「あり」に倒さない)。
+ */
+export function isStale(baseline: string | null, current: string | null): boolean {
+  if (!baseline || !current) return false;
+  return baseline !== current;
+}
+
+/**
+ * generator が incremental 差分の基点に使う、前回 index 時の head_sha / src_hash。
+ * 未 index (初回) は null を返す → generator はフルスキャンに倒す。
+ */
+export async function readRepoHead(
+  db: D1Like,
+  repo: string,
+): Promise<{ head_sha: string | null; src_hash: string | null } | null> {
+  const { results } = await db
+    .prepare(`SELECT head_sha, src_hash FROM repos WHERE repo = ? LIMIT 1`)
+    .bind(repo)
+    .all<{ head_sha: string | null; src_hash: string | null }>();
+  return results?.[0] ?? null;
+}
+
 /** 抽出済み symbol を D1 に投入する payload (generator → ingest endpoint)。 */
 export interface IngestPayload {
   repo: string;
@@ -83,6 +127,19 @@ export interface IngestPayload {
   head_sha?: string;
   summary?: string;
   lang?: string;
+  /**
+   * full  = repo 全体を ctags し直した (初回 / baseline 不明 / 大改修)。
+   * incremental = 前回 head_sha からの git 差分のみ再 ctags した。
+   * 省略時は full (後方互換)。
+   */
+  mode?: "full" | "incremental";
+  /**
+   * incremental 時、再 ctags した file path 群 (symbol が 0 になった file も含む)。
+   * これらの既存 symbol を file 単位で消してから symbols を入れ直す。
+   */
+  changed_files?: string[];
+  /** incremental 時、git diff で削除された file path 群。symbol を file 単位で消す。 */
+  deleted_files?: string[];
   symbols: Array<{
     name: string;
     kind: string;
@@ -95,12 +152,24 @@ export interface IngestPayload {
 }
 
 /**
- * generator から受けた payload を D1 に反映する。repo 単位の置き換え
- * (古い symbol を消してから入れ直す) — incremental の file 単位差分は
- * generator 側で file_hash を見て払い出す payload を絞る前提。
+ * generator から受けた payload を D1 に反映する。
+ * - full: repo 全 symbol を消してから入れ直す。
+ * - incremental: changed_files ∪ deleted_files ∪ symbols の file_path だけを
+ *   file 単位で消してから、changed の symbols を入れ直す (初回フル→以後 git 差分)。
  */
 export async function ingestSymbols(db: D1Like, p: IngestPayload): Promise<number> {
-  await db.prepare(`DELETE FROM symbols WHERE repo = ?`).bind(p.repo).run();
+  if (p.mode === "incremental") {
+    const clear = new Set<string>([
+      ...(p.changed_files ?? []),
+      ...(p.deleted_files ?? []),
+      ...p.symbols.map((s) => s.file_path),
+    ]);
+    for (const fp of clear) {
+      await db.prepare(`DELETE FROM symbols WHERE repo = ? AND file_path = ?`).bind(p.repo, fp).run();
+    }
+  } else {
+    await db.prepare(`DELETE FROM symbols WHERE repo = ?`).bind(p.repo).run();
+  }
   for (const s of p.symbols) {
     await db
       .prepare(

--- a/test/symbol-freshness.test.ts
+++ b/test/symbol-freshness.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import {
+  ingestSymbols,
+  isStale,
+  readRepos,
+  readRepoHead,
+  type D1Like,
+  type IngestPayload,
+} from "../src/symbol-index";
+import { computeFreshness } from "../src/symbol-freshness";
+
+// prepare/bind の呼び出しを captured に積み、.all() は allRows を返す fake D1。
+function fakeD1(allRows: unknown[] = []) {
+  const captured: Array<{ sql: string; binds: unknown[] }> = [];
+  const db: D1Like = {
+    prepare(sql: string) {
+      return {
+        bind(...binds: unknown[]) {
+          captured.push({ sql, binds });
+          return {
+            async all<T>() {
+              return { results: allRows as unknown as T[] };
+            },
+            async run() {
+              return {};
+            },
+          };
+        },
+      };
+    },
+  };
+  return { db, captured };
+}
+
+describe("ingestSymbols incremental", () => {
+  const base: IngestPayload = {
+    repo: "rust-alc-api",
+    src_hash: "tree2",
+    head_sha: "sha2",
+    mode: "incremental",
+    changed_files: ["src/a.rs", "src/empty.rs"],
+    deleted_files: ["src/gone.rs"],
+    symbols: [
+      { name: "f", kind: "function", file_path: "src/a.rs", start_line: 1, end_line: 9 },
+    ],
+  };
+
+  it("repo 全消しでなく file 単位 DELETE を発行する", async () => {
+    const { db, captured } = fakeD1();
+    await ingestSymbols(db, base);
+    const repoWide = captured.filter(
+      (c) => c.sql.includes("DELETE FROM symbols") && !c.sql.includes("file_path"),
+    );
+    expect(repoWide).toHaveLength(0); // 全消しは無い
+
+    const fileDeletes = captured.filter((c) => c.sql.includes("DELETE FROM symbols WHERE repo = ? AND file_path = ?"));
+    const deletedPaths = fileDeletes.map((c) => c.binds[1]);
+    // changed_files ∪ deleted_files ∪ symbols の file_path = a.rs, empty.rs, gone.rs
+    expect(new Set(deletedPaths)).toEqual(new Set(["src/a.rs", "src/empty.rs", "src/gone.rs"]));
+  });
+
+  it("changed の symbols を insert し repos を upsert", async () => {
+    const { db, captured } = fakeD1();
+    const n = await ingestSymbols(db, base);
+    expect(n).toBe(1);
+    expect(captured.some((c) => c.sql.includes("INSERT INTO symbols"))).toBe(true);
+    expect(captured.at(-1)!.sql).toContain("INSERT INTO repos");
+  });
+
+  it("mode 省略 (full) は従来通り repo 全消し", async () => {
+    const { db, captured } = fakeD1();
+    await ingestSymbols(db, { repo: "r", src_hash: "h", symbols: [] });
+    expect(captured[0]!.sql).toContain("DELETE FROM symbols WHERE repo = ?");
+    expect(captured[0]!.sql).not.toContain("file_path");
+  });
+});
+
+describe("isStale", () => {
+  it("内容ハッシュが違えば stale", () => expect(isStale("a", "b")).toBe(true));
+  it("一致なら fresh", () => expect(isStale("a", "a")).toBe(false));
+  it("どちらか不明 (null) なら stale 扱いしない", () => {
+    expect(isStale(null, "a")).toBe(false);
+    expect(isStale("a", null)).toBe(false);
+  });
+});
+
+describe("readRepos / readRepoHead", () => {
+  it("readRepos は repos 行を返す", async () => {
+    const { db } = fakeD1([{ repo: "x", src_hash: "h", updated_at: 1 }]);
+    const rows = await readRepos(db);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.repo).toBe("x");
+  });
+  it("readRepoHead は未 index で null", async () => {
+    const { db } = fakeD1([]);
+    expect(await readRepoHead(db, "x")).toBeNull();
+  });
+  it("readRepoHead は head_sha/src_hash を返す", async () => {
+    const { db } = fakeD1([{ head_sha: "s", src_hash: "t" }]);
+    expect(await readRepoHead(db, "x")).toEqual({ head_sha: "s", src_hash: "t" });
+  });
+});
+
+describe("computeFreshness", () => {
+  it("baseline と current を比較し stale フラグを立てる", async () => {
+    const { db } = fakeD1([
+      { repo: "a", src_hash: "t1", updated_at: 1 },
+      { repo: "b", src_hash: "t2", updated_at: 2 },
+    ]);
+    const current: Record<string, string> = { a: "t1", b: "tX" }; // b が変わった
+    const rows = await computeFreshness(db, async (repo) => current[repo] ?? null);
+    expect(rows.find((r) => r.repo === "a")!.stale).toBe(false);
+    expect(rows.find((r) => r.repo === "b")!.stale).toBe(true);
+  });
+
+  it("current 取得失敗 (throw) は current=null・stale=false", async () => {
+    const { db } = fakeD1([{ repo: "a", src_hash: "t1", updated_at: 1 }]);
+    const rows = await computeFreshness(db, async () => {
+      throw new Error("boom");
+    });
+    expect(rows[0]!.current_tree_sha).toBeNull();
+    expect(rows[0]!.stale).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要

cross-repo symbol index の**鮮度比較**と、generator の「**初回フル→以後 git 差分**」incremental 化に必要な ci-dashboard 側。

## 変更

- **`src/symbol-freshness.ts`**
  - `GET /symbol-index/freshness` — D1 の `repos.src_hash` (baseline) と各 repo の現在の default branch tree hash を比較し stale な repo を返す（open read、hash は機微でない）。hook が叩いて Claude に警告する想定
  - `GET /symbol-index/head/:repo` — generator が差分の基点（前回 head_sha）を取る read
- **`symbol-index.ts`** — `RepoState`/`readRepos`/`isStale`/`readRepoHead` 追加。`ingestSymbols` に `mode: full|incremental`。incremental は `changed_files ∪ deleted_files ∪ symbols の file_path` だけ file 単位で DELETE→insert（full は従来通り repo 全消し）
- **`index.ts`** — route 配線
- **`test/symbol-freshness.test.ts`** — incremental / isStale / freshness / readRepos・readRepoHead

## 検証

- `symbol-index.ts` は private 依存なしで隔離 typecheck 済み。フル typecheck + vitest は CI

## 関連

- generator (git 差分): ci-workflows 側で対応予定
- 設計: claude-skills の cross-repo-symbol-index skill

Refs #210

---
_Generated by [Claude Code](https://claude.ai/code/session_016MaUPgTR9AT361Q9ciEox5)_