### PR TITLE
fix: symbol-index endpoint を /webhooks/ 配下に移す (CF Access bypass)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,10 +82,10 @@ export interface Env extends AuthClientWorkerEnv {
    */
   COMPAT_KV: KVNamespace;
   /**
-   * cross-repo symbol index (D1)。CI (ci-workflows symbol-index.yml) が LSP
-   * 抽出した symbol を `/internal/symbol-index` 経由で投入し、MCP の
-   * `search_symbols` が読む。未投入時は search_symbols が GitHub code-search に
-   * fallback するため optional。設計: claude-skills の cross-repo-symbol-index skill。
+   * cross-repo symbol index (D1)。CI (ci-workflows symbol-index.yml) が ctags
+   * 抽出した symbol を `/webhooks/symbol-index` 経由で投入し、鮮度比較 / 横断 query
+   * に使う (symbol 検索自体はローカル)。未投入時 read は空を返すため optional。
+   * 設計: claude-skills の cross-repo-symbol-index skill。
    */
   SYMBOL_INDEX?: D1Database;
   /** symbol index generator の認証用 shared secret (Secrets Store)。 */
@@ -227,15 +227,17 @@ app.get("/oauth/callback", (c) => handleOAuthCallback(c.req.raw, c.env, OAUTH_OP
 app.all("/mcp", (c) => handleMcpRequest(c.req.raw, c.env));
 
 // cross-repo symbol index: CI generator (ci-workflows symbol-index.yml) が
-// LSP 抽出した symbol を投入する internal endpoint。Bearer 認証
-// (SYMBOL_INDEX_INGEST_SECRET)。設計: claude-skills cross-repo-symbol-index。
-app.post("/internal/symbol-index", (c) => handleSymbolIndexIngest(c.req.raw, c.env));
+// ctags 抽出した symbol を投入する endpoint。Bearer 認証 (SYMBOL_INDEX_INGEST_SECRET)。
+// ★ `/webhooks/*` 配下に置く: この prefix は CF Access が bypass するため外部 (CI)
+//   から到達できる。`/internal/*` は CF Access の裏で 302 になり generator が
+//   到達不能だった (index.ts の /webhook 注記参照)。設計: claude-skills cross-repo-symbol-index。
+app.post("/webhooks/symbol-index", (c) => handleSymbolIndexIngest(c.req.raw, c.env));
 
 // 鮮度比較: D1 の baseline (repos.src_hash) と各 repo の現在の main tree hash を
 // 比較し stale な repo を返す (open read、hash は機微でない)。hook が叩いて警告する。
-app.get("/symbol-index/freshness", (c) => handleFreshness(c.req.raw, c.env));
+app.get("/webhooks/symbol-index/freshness", (c) => handleFreshness(c.req.raw, c.env));
 // generator が incremental 差分の基点 (前回 head_sha) を取る read。
-app.get("/symbol-index/head/:repo", (c) => handleRepoHead(c.req.param("repo"), c.env));
+app.get("/webhooks/symbol-index/head/:repo", (c) => handleRepoHead(c.req.param("repo"), c.env));
 
 // Release Wave: GitHub Actions step が叩く HTTP webhook 3 本 (Refs #137
 // Phase 3d + Phase 4)。MCP 経路と機能等価だが OAuth 不要の shared secret

--- a/src/mcp/tools/repository.ts
+++ b/src/mcp/tools/repository.ts
@@ -158,7 +158,7 @@ export function registerRepositoryTools(server: McpServer, env: AuthClientWorker
   // symbol 検索はローカル (smart-read skill / session 内 LSP) で行う方が速く、
   // MCP 往復が要らない。symbol index の D1 は残すが、用途は MCP query ではなく
   // (1) skills/map の鮮度比較 (repos.src_hash) と (2) 人間向け view 生成。
-  // 投入は POST /internal/symbol-index (src/symbol-index.ts)。
+  // 投入は POST /webhooks/symbol-index (src/symbol-index.ts)。
   // 設計: ippoan/claude-skills の cross-repo-symbol-index skill。
 }
 

--- a/src/symbol-index.ts
+++ b/src/symbol-index.ts
@@ -224,7 +224,7 @@ function clampPerPage(n: number | undefined): number {
   return Math.max(1, Math.min(50, Math.floor(n)));
 }
 
-// --- ingest endpoint (generator → POST /internal/symbol-index) ---
+// --- ingest endpoint (generator → POST /webhooks/symbol-index) ---
 
 export interface SymbolIndexEnv {
   /** cross-repo symbol index (optional)。未投入なら ingest は 503。 */


### PR DESCRIPTION
## 原因

`ci-dashboard.ippoan.org` は CF Access の裏。**`/internal/*` は bypass されておらず 302 (login redirect)** になり、generator の ingest POST も freshness/head read も**外部から到達できなかった**。これが D1 が空のままだった真因（pilot の auth-worker generator が走っても ingest が 302 で失敗していた）。

CF Access が bypass する prefix は **`/webhooks/*`**（`src/index.ts` の `/webhook` 注記で明記済み）。

## 修正

symbol-index の 3 route を `/webhooks/` 配下に移設:

```
POST /internal/symbol-index   → POST /webhooks/symbol-index
GET  /symbol-index/freshness  → GET  /webhooks/symbol-index/freshness
GET  /symbol-index/head/:repo → GET  /webhooks/symbol-index/head/:repo
```

- ingest は従来通り Bearer (`SYMBOL_INDEX_INGEST_SECRET`) 認証（release-wave webhook と同じ shared-secret パターン）
- read は open（hash は機微でない）

## 追従

generator 側の URL（`ingest_url` default + head 取得）は ci-workflows 側 PR で `/webhooks/symbol-index` に合わせる。

Refs #205

---
_Generated by [Claude Code](https://claude.ai/code/session_016MaUPgTR9AT361Q9ciEox5)_