### PR TITLE
feat(launch): open-multirepo 用の stateless launch redirect (/cc)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { handleReleaseClose } from "./release-close";
 import { handleReleaseCloseBatch } from "./release-close-batch";
 import { handleRecheck } from "./recheck";
 import { handleSecretGenPage } from "./secret-gen-page";
+import { handleLaunch } from "./launch";
 import { handleTagRelease } from "./tag-release";
 import { handleReleaseWaveTagRelease } from "./release-wave/tag-release-action";
 import { handleReleaseWaveListPageWithRepoStatus } from "./release-wave/repo-status-section";
@@ -113,6 +114,12 @@ app.get("/projects", (c) => handleProjectsPage(c.env));
 // state). Operators paste the output into Cloudflare Secrets Store / wrangler
 // secret put / GitHub Actions secrets.
 app.get("/secret-gen", () => handleSecretGenPage());
+
+// Launch redirect for the open-multirepo skill. Stateless: reconstructs the
+// long claude.ai/code URL from a compact `?i=<issue>` query and 302s to it, so
+// the skill can emit a short (render-safe) link without a third-party shortener
+// or KV. See src/launch.ts.
+app.get("/cc", (c) => handleLaunch(c.req.raw));
 
 // Release confirmation view (SSR + POST close action)
 // See issue #35 + CLAUDE.md `release / close フロー`.

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -1,0 +1,98 @@
+// Stateless launch-redirect for the `open-multirepo` skill.
+//
+// The full `claude.ai/code?repositories=...&prompt=...` URL is ~1 KB, and
+// GitHub / Claude markdown silently refuse to linkify URLs that long (observed
+// failures well under the documented 4 KB limit). Rather than shorten via a
+// third party (TinyURL) or a stateful KV shortener — both of which need a
+// create round-trip — this endpoint reconstructs the target from a compact,
+// semantic query at click time. The skill emits the short
+// `https://ci-dashboard.ippoan.org/cc?i=<issue>` form and we 302 to the
+// expanded URL. No storage, no create round-trip, no third party.
+//
+// Open-redirect safe: the Location is always built as a `claude.ai/code` URL.
+// `repositories` is restricted to validated `owner/repo` tokens and `prompt`
+// is percent-encoded — no user-controlled origin is ever echoed.
+
+const LAUNCH_BASE = "https://claude.ai/code";
+
+// Default "all" preset = the standard full attach set used by open-multirepo
+// (= the session's GitHub MCP scope). Keep in sync; update via PR when the
+// repo set changes. A request with no `r` (or an `r` keyword without a `/`,
+// e.g. `all` / `*` / `全部`) expands to this list.
+const ALL_REPOS = [
+  "ippoan/release-wave-gcp",
+  "ippoan/nuxt-notify",
+  "ippoan/rust-alc-api",
+  "yhonda-ohishi/claude-hooks",
+  "ippoan/claude-md",
+  "ippoan/auth-worker",
+  "ippoan/ci-dashboard",
+  "ippoan/secrets-inventory-gcp",
+  "ippoan/cc-relay",
+  "ippoan/mcp-relay-rs",
+  "ippoan/secrets-inventory",
+  "ippoan/nuxt-egov",
+  "ippoan/egov-shinsei-sdk",
+  "ippoan/ci-workflows",
+  "ippoan/nuxt-trouble",
+  "ippoan/mcp-cf-workers",
+  "ippoan/ref-files-worker",
+  "ohishi-exp/nuxt-dtako-admin",
+  "ohishi-exp/nuxt_dtako_logs",
+  "ippoan/nuxt-pwa-carins",
+  "ohishi-exp/dtako-scraper",
+  "ohishi-exp/nuxt-ichibanboshi",
+  "ippoan/alc-app",
+  "ippoan/nuxt-items",
+  "ohishi-exp/rust-ichibanboshi",
+  "ippoan/HealthConnectReaderWorker",
+  "ippoan/HealthConnectReader",
+  "ippoan/claude-hooks",
+  "ippoan/claude-skills",
+  "yhonda-ohishi/freee",
+  "ippoan/ui-preview",
+  "ippoan/ippoan-drift",
+];
+
+const REPO_RE = /^[^/\s,]+\/[^/\s,]+$/;
+
+// `r` is either a preset keyword (no `/` → full set) or a comma-separated
+// explicit `owner/repo` list (filtered to valid tokens).
+function resolveRepos(r: string | null): string[] {
+  if (!r || !r.includes("/")) return ALL_REPOS;
+  return r
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => REPO_RE.test(s));
+}
+
+/**
+ * `GET /cc?i=<owner/repo#N>[&r=<preset|owner/repo,...>][&p=<prompt>]`
+ * → 302 to the reconstructed `claude.ai/code` launch URL.
+ */
+export function handleLaunch(req: Request): Response {
+  const url = new URL(req.url);
+  const issue = url.searchParams.get("i")?.trim();
+  if (!issue) {
+    return new Response("missing required query param: i (owner/repo#N)", {
+      status: 400,
+    });
+  }
+
+  const repos = resolveRepos(url.searchParams.get("r"));
+  if (repos.length === 0) {
+    return new Response("no valid owner/repo entries in r=", { status: 400 });
+  }
+
+  const prompt =
+    url.searchParams.get("p")?.trim() ||
+    `${issue} を read してチェックリストを順に処理。全 repo default branch。`;
+
+  // Build the query by hand: commas in `repositories` must stay raw (claude.ai
+  // /code expects unescaped `,`), only `prompt` is percent-encoded.
+  const target =
+    `${LAUNCH_BASE}?repositories=${repos.join(",")}` +
+    `&prompt=${encodeURIComponent(prompt)}`;
+
+  return new Response(null, { status: 302, headers: { Location: target } });
+}

--- a/test/launch.test.ts
+++ b/test/launch.test.ts
@@ -1,0 +1,84 @@
+/**
+ * `/cc` is the stateless launch-redirect for the open-multirepo skill. It
+ * reconstructs the long `claude.ai/code` URL from a compact `?i=<issue>` query
+ * and 302s to it (no storage, no third-party shortener). These specs assert
+ * the redirect target, the default repo preset, explicit/invalid `r=` handling
+ * and the prompt template / override — and that it only ever builds a
+ * claude.ai/code URL (no open redirect).
+ */
+import { describe, it, expect } from "vitest";
+import worker from "../src/index";
+import type { Env } from "../src/index";
+
+// `/cc` never touches the env binding, so an empty cast is sufficient.
+const ENV = {} as unknown as Env;
+
+async function launch(qs: string): Promise<Response> {
+  return worker.fetch(
+    new Request("https://ci-dashboard.ippoan.org/cc" + qs),
+    ENV,
+    {} as ExecutionContext,
+  );
+}
+
+function location(res: Response): string {
+  const loc = res.headers.get("Location");
+  expect(loc).not.toBeNull();
+  return loc as string;
+}
+
+describe("GET /cc (open-multirepo launch redirect)", () => {
+  it("400 when i is missing", async () => {
+    const res = await launch("");
+    expect(res.status).toBe(400);
+  });
+
+  it("302 to claude.ai/code with the default repo preset + template prompt", async () => {
+    const res = await launch("?i=" + encodeURIComponent("ippoan/claude-hooks#8"));
+    expect(res.status).toBe(302);
+    const loc = location(res);
+    expect(loc.startsWith("https://claude.ai/code?repositories=")).toBe(true);
+    const u = new URL(loc);
+    const repos = u.searchParams.get("repositories") ?? "";
+    expect(repos).toContain("ippoan/ci-dashboard");
+    expect(repos).toContain("ippoan/ippoan-drift");
+    const prompt = u.searchParams.get("prompt") ?? "";
+    expect(prompt).toContain("ippoan/claude-hooks#8");
+    expect(prompt).toContain("default branch");
+  });
+
+  it("treats an r= keyword without a slash (all) as the default preset", async () => {
+    const res = await launch("?i=x/y%231&r=all");
+    expect(res.status).toBe(302);
+    expect(location(res)).toContain("ippoan/ippoan-drift");
+  });
+
+  it("narrows to an explicit owner/repo list", async () => {
+    const res = await launch(
+      "?i=x/y%231&r=" + encodeURIComponent("ippoan/a,ippoan/b"),
+    );
+    const repos = new URL(location(res)).searchParams.get("repositories");
+    expect(repos).toBe("ippoan/a,ippoan/b");
+  });
+
+  it("filters invalid tokens out of an explicit r= list", async () => {
+    const res = await launch(
+      "?i=x/y%231&r=" + encodeURIComponent("ippoan/a, bad token ,ippoan/b"),
+    );
+    const repos = new URL(location(res)).searchParams.get("repositories");
+    expect(repos).toBe("ippoan/a,ippoan/b");
+  });
+
+  it("400 when an explicit r= list has no valid entries", async () => {
+    const res = await launch("?i=x/y%231&r=" + encodeURIComponent("a/b/c"));
+    expect(res.status).toBe(400);
+  });
+
+  it("p= overrides the prompt verbatim", async () => {
+    const res = await launch(
+      "?i=x/y%231&p=" + encodeURIComponent("custom prompt 日本語"),
+    );
+    const prompt = new URL(location(res)).searchParams.get("prompt");
+    expect(prompt).toBe("custom prompt 日本語");
+  });
+});


### PR DESCRIPTION
## 概要

`open-multirepo` skill の launch URL を **第三者 (TinyURL) も KV も使わず** render-safe にするため、ci-dashboard に stateless な redirect エンドポイントを追加する。

Refs #214

## 背景

`claude.ai/code?repositories=...&prompt=...` は ~1 KB と長く、GitHub / Claude の markdown が clickable に linkify しない（実測 1189 char でも失敗）。TinyURL の役割は「**長い URL を render-safe な短いリンクにする**」ことで、速度ではない。これは自前で代替でき、しかも**短縮（コード→full URL を保存）すら不要**にできる — コンパクトな issue ref から CCoW URL を**組み立てて redirect** すれば、短い・stateless・生成 0 RTT になる。

## 変更

`src/launch.ts` + `src/index.ts` に `GET /cc` を追加:

```
GET /cc?i=<owner/repo#N>[&r=<preset|owner/repo,...>][&p=<prompt>]
  → 302 https://claude.ai/code?repositories=<repos>&prompt=<enc(prompt)>
```

- `i` 必須（無ければ 400）
- `r`: preset（`/` を含まない語 = `all` 等 → `ALL_REPOS` 既定 list）または明示 `owner/repo,...`（valid token のみ採用、空なら 400）
- `p`: カスタム prompt（既定は `${i} を read してチェックリストを順に処理。全 repo default branch。`）
- **open-redirect 安全**: Location は常に `claude.ai/code` を組み立てるだけ。`repositories` は `owner/repo` 検証済みトークン、`prompt` は percent-encode。`repositories` の comma は生のまま（claude.ai/code が raw `,` を要求するため、手組みで `prompt` のみ encode）。

## テスト

`test/launch.test.ts` — 400(i欠落) / 既定 preset + 雛形 prompt / `r=all` / 明示 list / invalid token filter / 全 invalid → 400 / `p` override の全分岐。

> CCoW container は GitHub Packages の private dep (`@ippoan/auth-client-worker`) を install できない (PAT 持ち込み不可) ため repo の vitest pool はローカル実行不可。依存ゼロの `launch.ts` を Node `--experimental-strip-types` で直接実行し **12 アサーション全 pass** を確認済み。正式な vitest + coverage 100% gate は CI で検証。

## follow-up

- `open-multirepo` skill（ippoan/claude-skills）を「`/cc` 直リンクを組む（0 RTT）→ 失敗時のみ TinyURL fallback」に更新（別 PR、本エンドポイント deploy 後）。

https://claude.ai/code/session_01NBNL3hbDZRqH4zJ4D23hf3

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBNL3hbDZRqH4zJ4D23hf3)_