### PR TITLE
fix(issues): reconcile を full open snapshot 化して欠落 repo section を解消

### DIFF
--- a/src/issue-cache.ts
+++ b/src/issue-cache.ts
@@ -9,10 +9,11 @@ import type { AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
 //                                                      list-since reconcile)
 //
 // 設計方針 (Refs #129):
-// - SSR は KV から read のみ。reconcile は watermark が古い時だけ走る。
+// - SSR は KV から read のみ。reconcile は watermark が古い時だけ走り、その時
+//   GitHub の現在の open 集合を full snapshot で取り直して KV を一致させる。
 // - Webhook (issues / issue_comment) は個別 issue を patch するが watermark
-//   は触らない。watermark の意味は「ここまでは list-since が確実に拾った」。
-//   webhook 配信ミスは次の reconcile の delta クエリが必ず救う。
+//   は触らない。watermark の意味は「ここまでは full snapshot が確実に拾った」。
+//   webhook 配信ミスは次の reconcile の full snapshot が必ず救う。
 
 const KEY_WATERMARK = "issues:watermark";
 const KEY_PREFIX = "issue:";
@@ -22,9 +23,9 @@ const KEY_PREFIX = "issue:";
 // ラグは webhook 側でほぼ埋まる。
 const FRESH_THRESHOLD_MS = 60 * 1000;
 
-// Watermark を `now - SAFETY_WINDOW_MS` でセット。次回 delta の
-// `updated:>=watermark` が clock skew 5s ぶんを overlap 検索するための
-// バッファ。upsert は idempotent なので overlap は無害。
+// Watermark は `now - SAFETY_WINDOW_MS` でセット。full snapshot 方式では
+// delta query が無いので overlap の意味は無く、次 reconcile の fresh 判定を
+// 5s ぶん早く解除する保険として残す (= 連続アクセス時の取りこぼし余地を縮める)。
 const SAFETY_WINDOW_MS = 5 * 1000;
 
 export function issueKey(repo: string, number: number): string {
@@ -71,11 +72,21 @@ export interface ReconcileResult {
   patched: number;
   /** Whether we actually hit GitHub. false = within FRESH_THRESHOLD_MS. */
   fetched: boolean;
+  /** Stale entries evicted (open in KV but no longer in GitHub's open set).
+   *  0 when the snapshot was incomplete (eviction skipped) or fresh window hit. */
+  removed: number;
 }
 
-/** Watermark を見て GitHub に当てに行く。fresh window 内なら no-op。
- *  Cold start (watermark なし) は state:open の全件取得、それ以降は
- *  state:all + updated:>=watermark の delta。auth error 等はそのまま throw。 */
+/** GitHub の現在の open 集合を full snapshot で取得し、KV をそれに一致させる。
+ *  fresh window 内なら no-op。auth error 等はそのまま throw。
+ *
+ *  旧実装は初回 cold start (state:open) の後ずっと `state:all + updated:>=`
+ *  の warm delta しか走らせなかったため、per_page:100 truncation や KV write
+ *  欠落で一度漏れた open issue を二度と復活できず、特定 repo の section が
+ *  丸ごと消えていた (= MCP の list_org_issues は直叩きで全件見えるのに /issues
+ *  だけ欠ける非対称)。毎回 state:open を引き直し「KV にあるが GitHub の open
+ *  集合に無い entry」を削除すれば、漏れも stale も構造的に起きない。SSR は
+ *  従来どおり KV read のみなので高速性は維持される (Refs #129)。 */
 export async function reconcileIssues(
   env: AuthClientWorkerEnv,
   params: ReconcileParams,
@@ -84,34 +95,22 @@ export async function reconcileIssues(
   const watermark = await kv.get(KEY_WATERMARK);
   const now = Date.now();
   if (watermark && now - Date.parse(watermark) < FRESH_THRESHOLD_MS) {
-    return { patched: 0, fetched: false };
+    return { patched: 0, fetched: false, removed: 0 };
   }
 
-  const isCold = !watermark;
-  // Cold start: state:open で「現時点の open 集合」をブートストラップ。
-  // Warm: state:all + updated:>= で delta のみ (close も拾う)。
-  const sinceQ = watermark ? `updated:>=${watermark}` : "";
-  const stateFilter: FetchOrgIssuesParams["state"] = isCold ? "open" : "all";
-
-  // 既存の issues-page.ts と同じ 2-query pattern。GitHub search は org: と
-  // repo: を組み合わせると repo: 側を黙って drop するので yhonda-ohishi
-  // 特定 repo は別 query に分離する必要がある (mcp/tools/issues.ts 参照)。
+  // 2-query pattern: GitHub search は org: と repo: を混ぜると repo: 側を黙って
+  // drop するので、yhonda-ohishi の特定 repo だけ別 query に分離する
+  // (mcp/tools/issues.ts 参照)。両方とも state:open の full snapshot。
   const mainParams: FetchOrgIssuesParams = {
     orgs: params.mainOrgs,
-    state: stateFilter,
+    state: "open",
     per_page: 100,
   };
-  if (sinceQ) mainParams.query = sinceQ;
-
-  const yhondaQ = [
-    ...params.yhondaRepos.map((r) => `repo:${r}`),
-    sinceQ,
-  ].filter(Boolean).join(" ");
   const yhondaParams: FetchOrgIssuesParams = {
     orgs: ["yhonda-ohishi"],
-    state: stateFilter,
+    state: "open",
     per_page: 100,
-    query: yhondaQ,
+    query: params.yhondaRepos.map((r) => `repo:${r}`).join(" "),
   };
 
   const [main, yhonda] = await Promise.all([
@@ -119,15 +118,34 @@ export async function reconcileIssues(
     fetchOrgIssues(env, yhondaParams),
   ]);
 
-  const all = [...main.items, ...yhonda.items];
-  for (const issue of all) {
-    await upsertIssue(kv, issue);
+  const fresh = [...main.items, ...yhonda.items];
+  const freshKeys = new Set(fresh.map((i) => issueKey(i.repo, i.number)));
+
+  // GitHub search が truncate された (incomplete_results) snapshot は不完全
+  // なので削除を skip する (= まだ open な issue を誤って evict しない)。upsert
+  // は常に安全。yhonda は repo: pin で件数が小さく truncate しないが、main は
+  // 将来 open が 100 超になり得るのでガードする。100 を恒常的に超えたら
+  // per_page pagination を入れる (現状 ippoan+ohishi-exp は ~70 件)。
+  const complete = !main.incomplete && !yhonda.incomplete;
+  let removed = 0;
+  if (complete) {
+    const existing = await listCachedOpenIssues(kv);
+    for (const e of existing) {
+      if (!freshKeys.has(issueKey(e.repo, e.number))) {
+        await kv.delete(issueKey(e.repo, e.number));
+        removed++;
+      }
+    }
+  }
+
+  for (const issue of fresh) {
+    await kv.put(issueKey(issue.repo, issue.number), JSON.stringify(issue));
   }
 
   const newWm = new Date(now - SAFETY_WINDOW_MS).toISOString();
   await kv.put(KEY_WATERMARK, newWm);
 
-  return { patched: all.length, fetched: true };
+  return { patched: fresh.length, fetched: true, removed };
 }
 
 // ───── Webhook payload → OrgIssue 正規化 ─────

--- a/test/issue-cache.test.ts
+++ b/test/issue-cache.test.ts
@@ -113,7 +113,7 @@ describe("issue-cache", () => {
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
-    it("cold start で全件 fetch + watermark セット", async () => {
+    it("watermark 無し (初回) は full snapshot で fetch + watermark セット", async () => {
       vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
         const url = typeof input === "string" ? input : (input as Request).url;
         // auth-worker token 取得呼び出しは skip して mock 値返す
@@ -139,6 +139,65 @@ describe("issue-cache", () => {
       const wm = await env.CI_STATUS.get(__testing.KEY_WATERMARK);
       expect(wm).toBeTruthy();
       expect(Date.parse(wm!)).toBeLessThanOrEqual(Date.now());
+    });
+
+    it("full snapshot で GitHub の open 集合に無い KV entry を削除する (stale eviction)", async () => {
+      // KV に「もう open でない」古い issue を仕込む (= 旧実装ではこれが永久に
+      // 残り続け、section が消える原因だった)。
+      await upsertIssue(env.CI_STATUS, makeIssue({ number: 99 }));
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+        const url = typeof input === "string" ? input : (input as Request).url;
+        if (url.includes("auth-worker") || url.includes("/mcp/token")) {
+          return Response.json({ access_token: "tok" });
+        }
+        if (url.includes("/search/issues")) {
+          // GitHub の現 open 集合に #99 は含まれない (= 既に closed)
+          return mockSearchResponse([makeIssue({ number: 10 })]);
+        }
+        return new Response("ignored", { status: 404 });
+      });
+
+      const result = await reconcileIssues(env, { mainOrgs: ["ippoan"], yhondaRepos: [] });
+      expect(result.fetched).toBe(true);
+      expect(result.removed).toBeGreaterThanOrEqual(1);
+
+      // #99 は evict され、#10 (現 open) は残る
+      const gone = await env.CI_STATUS.get(issueKey("ippoan/ci-dashboard", 99));
+      expect(gone).toBeNull();
+      const kept = await env.CI_STATUS.get(issueKey("ippoan/ci-dashboard", 10), "json");
+      expect(kept).toBeTruthy();
+    });
+
+    it("incomplete snapshot (search truncated) の時は削除を skip する", async () => {
+      await upsertIssue(env.CI_STATUS, makeIssue({ number: 99 }));
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+        const url = typeof input === "string" ? input : (input as Request).url;
+        if (url.includes("auth-worker") || url.includes("/mcp/token")) {
+          return Response.json({ access_token: "tok" });
+        }
+        if (url.includes("/search/issues")) {
+          // 不完全な snapshot (truncated)。削除すると誤 evict になるので skip 期待。
+          return Response.json({
+            total_count: 1000,
+            incomplete_results: true,
+            items: [{
+              number: 10, title: "t", state: "open", user: { login: "y" },
+              labels: [], assignees: [], comments: 0,
+              created_at: "2026-05-27T00:00:00Z", updated_at: "2026-05-27T00:00:00Z",
+              html_url: "https://github.com/ippoan/ci-dashboard/issues/10",
+              repository_url: "https://api.github.com/repos/ippoan/ci-dashboard",
+            }],
+          });
+        }
+        return new Response("ignored", { status: 404 });
+      });
+
+      const result = await reconcileIssues(env, { mainOrgs: ["ippoan"], yhondaRepos: [] });
+      expect(result.fetched).toBe(true);
+      expect(result.removed).toBe(0);
+      // incomplete なので #99 は誤 evict しない
+      const still = await env.CI_STATUS.get(issueKey("ippoan/ci-dashboard", 99));
+      expect(still).not.toBeNull();
     });
   });
 


### PR DESCRIPTION
## 症状

`/issues` で一部 repo の open issue section が出ない(`ippoan/ci-dashboard` / `ci-workflows` / `claude-skills` / `ref-files-worker`)。GitHub には open issue が存在し、MCP `list_org_issues`(直叩き)では全件見えるのに `/issues` だけ欠ける。これらは Project board 未登録なので本来 per-repo section に出るべき。

## 原因

`reconcileIssues`(`src/issue-cache.ts`)が初回 cold start(`state:open` 全件)後はずっと warm delta(`state:all + updated:>=watermark`)しか走らない。delta は「更新された issue」だけを upsert するため、per_page:100 truncation や KV write 欠落で**一度漏れた open issue を、再更新されない限り永久に復活できない**(full re-sync 経路が無い)。

`ref-files-worker` 等の更新が止まった issue は一度漏れたら戻らず、section が丸ごと消えていた。MCP は直叩きなので正常、という非対称が全てこれで説明できる。

## 修正

`reconcileIssues` を **full open snapshot** 方式へ:

- 毎回 `state:open` の現在の open 集合を取得
- KV にあるが GitHub の open 集合に無い entry を削除(stale eviction)
- 現 open を全 upsert

→ 漏れも stale も構造的に起きない。SSR は従来どおり KV read のみで高速性を維持(Refs #129)。GitHub call 数も 60s に2回で不変。truncation(`incomplete_results`)時は誤 evict 防止で削除を skip。将来 open が恒常的に 100 件超になったら `per_page` pagination を追加(現状 ippoan+ohishi-exp は ~70 件)。

## テスト

- `test/issue-cache.test.ts` に **stale eviction**(GitHub の open 集合に無い KV entry を削除)と **incomplete skip**(truncated snapshot 時は誤 evict しない)の2ケースを追加
- ローカルで typecheck + 全 647 tests green

Refs #217

https://claude.ai/code/session_01Vkz47bFQd4wooWGih3Hit7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vkz47bFQd4wooWGih3Hit7)_