### PR TITLE
chore(issues): project 振り分け結果を診断ログに追加 (#217 切り分け 2nd)

### DIFF
--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -205,6 +205,21 @@ export async function handleIssuesPage(env: AuthClientWorkerEnv): Promise<Respon
     if (refs && refs.length > 0) projectTagged.push({ issue: item, projects: refs });
     else ungrouped.push(item);
   }
+
+  // observability (#217 診断 2nd): project 振り分け結果。KV には 4 repo 在る
+  // のに per-repo section から消える件で、各 repo が projectTagged (Project
+  // 付き section) と ungrouped (repo 別 section) のどちらに流れたか、projectMap
+  // のサイズ / fetch error を出す。ci-dashboard だけ repo 別に出る = 残り 3 repo
+  // が projectMap に居て Project 付きに吸われている、を確認する。
+  console.log(JSON.stringify({
+    msg: "issues-page-split",
+    projectTaggedRepos: [...new Set(projectTagged.map((p) => p.issue.repo))].sort(),
+    ungroupedRepos: [...new Set(ungrouped.map((i) => i.repo))].sort(),
+    projectMapSize: projectMap.size,
+    projectError: project.error,
+    projectStale: project.stale,
+  }));
+
   // Top section is one flat list ordered by recency across repos.
   projectTagged.sort((a, b) => b.issue.updated_at.localeCompare(a.issue.updated_at));
 


### PR DESCRIPTION
## これまでの判明事項

- `#218`(full snapshot)+ `#219`(診断ログ)で、**KV cache には4 repo 全部入っている**ことが確定(`cachedCount=77`、`cachedRepos` に ci-dashboard/ci-workflows/claude-skills/ref-files-worker 全部)。reconcile も正常(`fetched=true, patched=77`)。
- なのに画面では **ci-dashboard だけ repo 別 section に出て、ci-workflows/claude-skills/ref-files-worker が出ない**(ユーザー確認済み)。

## Agent による board 全数調査

全 project board(ippoan #1–8、yhonda-ohishi #1–3)を `list_project_items` で調査 → **4 repo はどの board にも1件も登録されていない**(board に載るのは auth-worker / github-mcp-server-rs / rust-alc-api / alc-app / ippoan-dev-plans / yhonda 系のみ)。

→ 「board 登録 → Project 付き section に集約されて repo 別から消える」説は **否定**。`projectMap`(`getOrFetchProjectIssueMap` の結果)が GitHub の実態と乖離している(KV `project:items:*` cache の幽霊データ、または content 解決のバグ)疑いが濃厚。

## 本 PR

`handleIssuesPage` の振り分け直後に `issues-page-split` ログを追加:
- `projectTaggedRepos` / `ungroupedRepos` — 各 repo がどちらの section に流れたか
- `projectMapSize` — projectMap が異常に肥大していないか
- `projectError` / `projectStale` — project fetch の状態

これで「他3 repo が `projectMap` に(誤って)含まれている」かが確定し、根本修正に入れる。ログのみでロジック不変。

Refs #217

https://claude.ai/code/session_01Vkz47bFQd4wooWGih3Hit7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vkz47bFQd4wooWGih3Hit7)_