### PR TITLE
feat(nav): ダッシュボードに Repo Maps (GitHub Pages) リンクを追加

### DIFF
--- a/src/nav-tabs.ts
+++ b/src/nav-tabs.ts
@@ -15,7 +15,7 @@ export type TabKey =
   | "secret-gen";
 
 interface TabDef {
-  key: TabKey | "branch-protection" | "gcp-secrets" | "security-inventory";
+  key: TabKey | "branch-protection" | "gcp-secrets" | "security-inventory" | "repo-maps";
   href: string;
   label: string;
   // External tabs live on a different origin, so they open in a new tab and
@@ -54,6 +54,14 @@ const TABS: ReadonlyArray<TabDef> = [
     key: "security-inventory",
     href: "https://security-inventory.ippoan.org/",
     label: "🔍 Security Inventory",
+    external: true,
+  },
+  // ippoan/claude-skills の <repo>-map スキルを MkDocs で整形した閲覧サイト
+  // (GitHub Pages、認証不要)。各 repo のどこに何があるかの構造ナビゲーション。
+  {
+    key: "repo-maps",
+    href: "https://ippoan.github.io/claude-skills/",
+    label: "🗺️ Repo Maps",
     external: true,
   },
 ];


### PR DESCRIPTION
## 変更

`src/nav-tabs.ts` の共有ナビに、`ippoan/claude-skills` の `<repo>-map` スキルを MkDocs で整形した閲覧サイトへの external タブを追加。

- リンク先: https://ippoan.github.io/claude-skills/ (GitHub Pages、認証不要)
- ラベル: `🗺️ Repo Maps`
- 既存の external タブ (Branch Protection / GCP Secrets / Security Inventory) と同じ `target=_blank` パターン
- `TabDef.key` の union に `"repo-maps"` を追加

## 背景

Repo Maps サイトは ippoan/claude-skills#26 で構築した各 repo の構造ナビゲーション。ci-dashboard を運用の入口にしているので、ここからワンクリックで辿れるようにする。

Refs #221

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjepZG1h3tzgvA4dNephAX)_