### PR TITLE
feat(releases): tag-less な CCoW repo を TAGLESS_REPOS に追加 + 診断ログ整理

### DIFF
--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -152,16 +152,14 @@ export async function handleIssuesPage(env: AuthClientWorkerEnv): Promise<Respon
 
   const cached = await listCachedOpenIssues(env.CI_STATUS);
 
-  // observability (#217 診断): reconcile の結果と KV cache の実態を 1 行で
-  // 出す。repo section が欠ける問題が「reconcile が走っていない (fetched=
-  // false)」「fetch したが KV list に反映されない」「表示段で除外」の
-  // どこで起きているかを wrangler tail で切り分けるため。
+  // observability: reconcile が GitHub を引いたか (fetched) / 何件 upsert・
+  // evict したか (patched/removed) と KV cache 件数。/issues の表示が古い時に
+  // reconcile が走っているかを wrangler tail で確認できる (Refs #217)。
   console.log(JSON.stringify({
     msg: "issues-page",
     reconcile: reconcileResult,
     reconcileError,
     cachedCount: cached.length,
-    cachedRepos: [...new Set(cached.map((i) => i.repo))].sort(),
   }));
   // KV には過去設定の repo が残っている可能性があるので allowlist で
   // filter。mainOrgs 配下は全 repo 許可、yhonda-ohishi は YHONDA_REPOS のみ。
@@ -205,21 +203,6 @@ export async function handleIssuesPage(env: AuthClientWorkerEnv): Promise<Respon
     if (refs && refs.length > 0) projectTagged.push({ issue: item, projects: refs });
     else ungrouped.push(item);
   }
-
-  // observability (#217 診断 2nd): project 振り分け結果。KV には 4 repo 在る
-  // のに per-repo section から消える件で、各 repo が projectTagged (Project
-  // 付き section) と ungrouped (repo 別 section) のどちらに流れたか、projectMap
-  // のサイズ / fetch error を出す。ci-dashboard だけ repo 別に出る = 残り 3 repo
-  // が projectMap に居て Project 付きに吸われている、を確認する。
-  console.log(JSON.stringify({
-    msg: "issues-page-split",
-    projectTaggedRepos: [...new Set(projectTagged.map((p) => p.issue.repo))].sort(),
-    ungroupedRepos: [...new Set(ungrouped.map((i) => i.repo))].sort(),
-    projectMapSize: projectMap.size,
-    projectError: project.error,
-    projectStale: project.stale,
-  }));
-
   // Top section is one flat list ordered by recency across repos.
   projectTagged.sort((a, b) => b.issue.updated_at.localeCompare(a.issue.updated_at));
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -124,7 +124,7 @@
         // cut release tags: dashboard はこれらの PR merge を mini-release 扱いし、
         // merged PR の `Refs #N` を逆引きして /releases synthetic block + banner に
         // 出す (= stable tag 前でも早期 close 可能)。未掲載 repo は tag-driven flow。
-        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs,ippoan/cc-relay,ippoan/mcp-cf-workers,yhonda-ohishi/claude-hooks"
+        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs,ippoan/cc-relay,ippoan/mcp-cf-workers,yhonda-ohishi/claude-hooks,ippoan/claude-skills,ippoan/ci-workflows,ippoan/ref-files-worker,ippoan/claude-hooks"
       },
       "kv_namespaces": [
         {


### PR DESCRIPTION
## 背景

`/issues` の「4 repo が出ない」問題は `#218`(full snapshot 化)で解決済み。続いて「**merged PR を持つ claude-skills 等が `/releases` に出ない**」「cc-relay / ci-dashboard / rust-alc-api しか出ない」とのフィードバック。

## 原因

`/releases` の watched(表示対象)は **hub(CI run)+ direct-push allowlist + `TAGLESS_REPOS`** の和で、release 候補(未 close の `Refs #N` を持つ merged PR、または tag)がある repo だけ表示する。

`claude-skills` / `ci-workflows` / `ref-files-worker` / `claude-hooks` は **tag を切らないのに `TAGLESS_REPOS` 未登録**だったため、merged PR の `Refs` があっても watched に入らず `/releases` に出なかった(cc-relay / ci-dashboard は登録済み、rust-alc-api は tag repo なので出ていた)。

## 変更

1. **`TAGLESS_REPOS`(`env.staging.vars`)に4 repo 追加**: `ippoan/claude-skills` / `ippoan/ci-workflows` / `ippoan/ref-files-worker` / `ippoan/claude-hooks`。これで synthetic block(default branch の merged PR から `Refs` 逆引き)で `/releases` に出る。
2. **`#217` 調査用の診断ログを整理**: `issues-page-split` は撤去、`issues-page` は reconcile summary(`fetched`/`patched`/`removed` + `cachedCount`)に簡素化して observability として残す。

## 検証

- typecheck パス、test 34件 green(issue-cache + issues-page)
- deploy 後、`/releases` に4 repo の synthetic block が出ることを確認予定

Refs #217

https://claude.ai/code/session_01Vkz47bFQd4wooWGih3Hit7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vkz47bFQd4wooWGih3Hit7)_