### PR TITLE
feat(releases): /releases で watched repo を常に全件カード表示

### DIFF
--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -329,10 +329,11 @@ async function loadRepoView(
 // Build a synthetic block for tag-less direct-push-OK repos (#57).
 //
 // We scan the most recent SYNTHETIC_COMMIT_WINDOW commits on the default
-// branch for `Refs #N`, hydrate the referenced issues, and keep only the ones
-// still `open`. Closed issues drop out entirely (no <details>): the alternative
-// view's case for collapsing them is "they got auto-closed by `Closes #N` in a
-// PR merge", which can't happen on direct-push-OK repos by construction.
+// branch for `Refs #N` and hydrate the referenced issues. Both open and
+// closed issues are kept (Refs #224): the operator wants tag-less / direct-
+// push repos to keep showing their card even after every ref is closed.
+// renderTagBlock collapses the closed rows into a <details>, mirroring the
+// tag-compare path, so the card stays low-noise.
 //
 // The "tag" identity is `<branch>@<sha7>` so the post-close comment
 // ("Closed by release main@e8e90a4") stays traceable even though the synthetic
@@ -392,8 +393,11 @@ async function loadSyntheticBlock(
   }
 
   const issues = await fetchIssuesByNumbers(token, owner, name, refs, kv);
-  const openRows: IssueRow[] = issues
-    .filter((i) => !i.pull_request && i.state === "open")
+  // Keep both open and closed referenced issues (was open-only): a tag-less /
+  // direct-push repo whose refs are all closed should still surface its card
+  // with the closed history collapsed into a <details>. Refs #224.
+  const rows: IssueRow[] = issues
+    .filter((i) => !i.pull_request)
     .map((i) => {
       const labels = i.labels.map((l) => l.name);
       return {
@@ -409,7 +413,7 @@ async function loadSyntheticBlock(
     })
     .sort((a, b) => a.number - b.number);
 
-  if (openRows.length === 0) return null;
+  if (rows.length === 0) return null;
 
   // commits の並び順:
   //   - 通常 (sinceTag 無し): cachedCommits は最新 first (GitHub /commits API 既定)
@@ -423,7 +427,7 @@ async function loadSyntheticBlock(
   return {
     tag: tagLabel,
     prevTag: sinceTag ?? null,
-    issues: openRows,
+    issues: rows,
     synthetic: true,
   };
 }
@@ -751,15 +755,15 @@ function renderIndex(
   failedReasons: Map<number, string>,
   flashRepo: string | null,
 ): string {
-  // Show repos with at least one referenced issue in their displayed tag
-  // window; repos that haven't had a Refs-bearing release yet would just
-  // be a noise card.
-  const populated = views.filter((v) =>
-    v.tagBlocks.some((b) => b.issues.length > 0),
-  );
-  const body = populated.length === 0
+  // Show every watched repo as a card — including ones with no referenced
+  // issues yet or whose refs are all closed. The operator asked for the full
+  // roster always-on (Refs #224); empty/closed repos render as a passive card
+  // with a "no referenced issues" note (see renderIndexRepo) instead of being
+  // dropped as noise. The bottom empty-state copy only kicks in when nothing
+  // is watched at all (views is empty), so a fresh env still reads cleanly.
+  const body = views.length === 0
     ? `<div class="empty">🤷 No releases with referenced issues in the recent window. Look one up below.</div>`
-    : populated.map(renderIndexRepo).join("\n");
+    : views.map(renderIndexRepo).join("\n");
 
   // Banner sits above the cards so a successful batch close redirect always
   // lands the operator on the list with confirmation of what got closed.
@@ -815,6 +819,14 @@ function renderIndexRepo(view: RepoView): string {
       </div>`
     : "";
 
+  // No tag block carried a referenced issue (no semver tags, no Refs in the
+  // recent range, or the synthetic path found nothing). The repo is still
+  // shown — operator wants the full roster (Refs #224) — with a passive note
+  // standing in for the table/actions so an empty card doesn't read as broken.
+  const noRefsNote = tagSections === ""
+    ? `<div class="no-refs">No referenced issues in the recent release window.</div>`
+    : "";
+
   // Whole repo card is one form so the operator can tick across tags and
   // close them in one shot; the POST handler groups by tag for comment
   // attribution.
@@ -823,6 +835,7 @@ function renderIndexRepo(view: RepoView): string {
     <form method="POST" action="/api/release-close-batch" class="batch-close-form">
       <input type="hidden" name="repo" value="${escapeHtml(view.repo)}">
       ${tagSections}
+      ${noRefsNote}
       ${actions}
     </form>
     ${olderHtml}
@@ -1002,6 +1015,10 @@ const STYLES = `
   .repo-card > h2 a { color: #c9d1d9; text-decoration: none; }
   .repo-card > h2 a:hover { color: #58a6ff; }
   .batch-close-form { display: block; }
+  .no-refs {
+    font-size: 12px; color: #8b949e;
+    padding: 4px 0 2px 0;
+  }
   .tag-block { margin-bottom: 14px; }
   .tag-block-header {
     display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap;

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -544,10 +544,10 @@ describe("GET /releases", () => {
     expect(html).toContain("worktree-naming-guard hook");
   });
 
-  it("omits a synthetic block when the recent commit window has no Refs", async () => {
-    // Direct-push-OK repo, but the recent commits don't reference any issue —
-    // we drop the whole RepoView so the landing page doesn't grow a noisy
-    // empty card.
+  it("renders an empty card (no synthetic block) when the recent commit window has no Refs", async () => {
+    // Direct-push-OK repo, but the recent commits don't reference any issue.
+    // Per Refs #224 the repo still shows as a card with a "no referenced
+    // issues" note — but it must NOT grow a synthetic tag block.
     vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
       const url = typeof req === "string" ? req : (req as Request).url;
 
@@ -578,9 +578,11 @@ describe("GET /releases", () => {
 
     expect(res.status).toBe(200);
     const html = await res.text();
-    // Repo dropped → empty-state hint shown, no synthetic block markup.
-    expect(html).toContain("No releases with referenced issues");
-    expect(html).not.toContain("yhonda-ohishi/claude-hooks");
+    // Repo card present with the no-refs note; no synthetic block / tag label.
+    expect(html).toContain("yhonda-ohishi/claude-hooks");
+    expect(html).toContain("No referenced issues in the recent release window");
+    expect(html).not.toContain("master@");
+    expect(html).not.toMatch(/name="pair"/);
   });
 
   // #59: once every referenced issue in a repo card is closed, the
@@ -847,9 +849,11 @@ describe("GET /releases", () => {
     expect(html).toContain("No releases with referenced issues");
   });
 
-  it("does not turn an unallowlisted tag-less repo into a synthetic block", async () => {
+  it("shows an unallowlisted tag-less repo as an empty card but never as a synthetic block", async () => {
     // Guard against the auto-merge regression the user called out: a PR repo
-    // briefly without tags must NOT show its main-branch commits here.
+    // briefly without tags must NOT show its main-branch commits as a release.
+    // Post-#224 the repo still appears as an empty card (full roster), but the
+    // synthetic path (/commits fetch + "direct push" marker) must stay unentered.
     vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
       const url = typeof req === "string" ? req : (req as Request).url;
 
@@ -881,7 +885,12 @@ describe("GET /releases", () => {
 
     expect(res.status).toBe(200);
     const html = await res.text();
-    expect(html).toContain("No releases with referenced issues");
+    // Empty card shown (full roster)...
+    expect(html).toContain("ippoan/some-pr-repo");
+    expect(html).toContain("No referenced issues in the recent release window");
+    // ...but never promoted to a synthetic block (no marker; /commits not hit,
+    // enforced by the throw in the stub above).
     expect(html).not.toContain("direct push");
+    expect(html).not.toMatch(/name="pair"/);
   });
 });


### PR DESCRIPTION
## 背景

`/releases` landing page が、直近のリリースレンジに `Refs #N` 参照 issue が無い repo を `populated` フィルタで丸ごと落としていた。さらに synthetic (direct-push / TAGLESS) block は **open issue のみ**残すため、参照 issue が全部 close 済みの repo もカードごと消えていた。watched(Hub status ∪ direct-push allowlist ∪ `TAGLESS_REPOS`)に十数 repo 入っていても表示は数件だけ、という状態。

## 変更

operator が「リリース対象 repo の全ロスター」を常に見られるようにする:

- **`renderIndex`**: `populated` フィルタを撤廃。null でない全 view をカード化。bottom の empty-state copy は watched が完全に空(`views.length === 0`)のときだけ出す。
- **`renderIndexRepo`**: 表示すべき tag section が無い repo に passive な `No referenced issues in the recent release window` note を出す(カードは残す)。
- **`loadSyntheticBlock`**: open-only 制約を外し close 済み issue も含める。`renderTagBlock` が close 行を既存の `<details>` に畳むので低ノイズのまま。
- `.no-refs` の軽量 CSS を追加。

## 不変条件 (回帰防止)

- archived repo は引き続き一覧から除外 (#155)
- tag fetch 失敗の repo は null で drop
- **allowlist / TAGLESS に居ない tag-less repo を synthetic block に昇格させない**(auto-merge PR repo の main 直 commit をリリース扱いしない)。空カードは出るが `direct push` マーカーは付かず `/commits` も叩かない

## テスト

- `npm run typecheck` ✓
- `npx vitest run` → 39 files / **647 passed** ✓
- 挙動が変わる 2 テスト(`omits a synthetic block when no Refs` / `unallowlisted tag-less repo`)を新挙動(空カード表示 + synthetic 非昇格の担保)に更新

Refs #224


---
_Generated by [Claude Code](https://claude.ai/code/session_01AdxDxx9t2z1C9TdeysjipB)_