### PR TITLE
feat(releases): closed しか無い repo を 1 行コンパクトカードに畳む

### DIFF
--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -788,21 +788,35 @@ ${PWA_REGISTER_SCRIPT}
 }
 
 function renderIndexRepo(view: RepoView): string {
-  const tagSections = view.tagBlocks
-    .filter((b) => b.issues.length > 0)
-    .map((b) => renderTagBlock(view.repo, b))
-    .join("\n");
-
-  // When every referenced issue across the visible tag blocks is already
-  // closed, the form has nothing to actually do — clicking the button would
-  // just round-trip with an empty selection. Drop the actions row so the
-  // historical `<details>` blocks remain as audit context without inviting a
-  // no-op click (#59). The `<form>` itself stays so future closes (e.g. if
-  // an issue is reopened) still have a working submit path; the operator
-  // would just need a tick + a manual page refresh to re-render the button.
-  const hasVisibleCandidate = view.tagBlocks.some((b) =>
+  // Only tag blocks with at least one OPEN (actionable) issue get the full
+  // table+form treatment. Closed-only blocks are pure noise on the landing
+  // page — the operator already released them. Refs #226.
+  const openBlocks = view.tagBlocks.filter((b) =>
     b.issues.some((i) => i.state !== "closed"),
   );
+
+  // When nothing in the repo is open, collapse the whole card to a single
+  // compact line instead of a tall stack of expandable "N closed issues"
+  // <details>. The repo stays on the roster (#224) but reads as one row:
+  // either a deduped closed-issue count ("released") or a no-refs note.
+  // No <form> / table / older-tags strip — the point is one line. Refs #226.
+  if (openBlocks.length === 0) {
+    const closed = new Set<number>();
+    for (const b of view.tagBlocks) {
+      for (const i of b.issues) if (i.state === "closed") closed.add(i.number);
+    }
+    const summary = closed.size > 0
+      ? `<span class="closed-summary">✅ ${closed.size} closed issue${closed.size === 1 ? "" : "s"} (released)</span>`
+      : `<span class="no-refs">No referenced issues in the recent release window.</span>`;
+    return `<section class="repo-card repo-card-compact">
+      <a class="repo-link" href="https://github.com/${escapeHtml(view.repo)}/releases" target="_blank" rel="noopener">${escapeHtml(view.repo)}</a>
+      ${summary}
+    </section>`;
+  }
+
+  const tagSections = openBlocks
+    .map((b) => renderTagBlock(view.repo, b))
+    .join("\n");
 
   const olderHtml = view.olderTags.length === 0
     ? ""
@@ -812,20 +826,12 @@ function renderIndexRepo(view: RepoView): string {
         )
         .join(" · ")}</div>`;
 
-  const actions = hasVisibleCandidate
-    ? `<div class="actions">
+  // Every kept block has ≥1 open issue, so the close button always has
+  // something to act on here.
+  const actions = `<div class="actions">
         <button type="submit">✅ Close selected as released</button>
         <span class="hint">⚠️ rows start unchecked.</span>
-      </div>`
-    : "";
-
-  // No tag block carried a referenced issue (no semver tags, no Refs in the
-  // recent range, or the synthetic path found nothing). The repo is still
-  // shown — operator wants the full roster (Refs #224) — with a passive note
-  // standing in for the table/actions so an empty card doesn't read as broken.
-  const noRefsNote = tagSections === ""
-    ? `<div class="no-refs">No referenced issues in the recent release window.</div>`
-    : "";
+      </div>`;
 
   // Whole repo card is one form so the operator can tick across tags and
   // close them in one shot; the POST handler groups by tag for comment
@@ -835,7 +841,6 @@ function renderIndexRepo(view: RepoView): string {
     <form method="POST" action="/api/release-close-batch" class="batch-close-form">
       <input type="hidden" name="repo" value="${escapeHtml(view.repo)}">
       ${tagSections}
-      ${noRefsNote}
       ${actions}
     </form>
     ${olderHtml}
@@ -1019,6 +1024,16 @@ const STYLES = `
     font-size: 12px; color: #8b949e;
     padding: 4px 0 2px 0;
   }
+  /* Closed-only / no-ref repos collapse to a single compact row (#226). */
+  .repo-card-compact {
+    display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap;
+    padding: 10px 16px;
+  }
+  .repo-card-compact .repo-link {
+    font-size: 14px; font-weight: 600; color: #c9d1d9; text-decoration: none;
+  }
+  .repo-card-compact .repo-link:hover { color: #58a6ff; }
+  .repo-card-compact .closed-summary { font-size: 12px; color: #8b949e; }
   .tag-block { margin-bottom: 14px; }
   .tag-block-header {
     display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap;

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -585,11 +585,11 @@ describe("GET /releases", () => {
     expect(html).not.toMatch(/name="pair"/);
   });
 
-  // #59: once every referenced issue in a repo card is closed, the
-  // "✅ Close selected as released" button has nothing to act on and
-  // round-trips empty. Hide it; keep the closed-history <details> as
-  // audit context.
-  it("hides the close button when all visible candidates are already closed", async () => {
+  // #226: when every referenced issue in a repo is already closed, the whole
+  // card collapses to a single compact line ("✅ N closed (released)") instead
+  // of a tall stack of expandable "N closed issues" <details>. No close button,
+  // no <details>, no checkbox form — just the one-liner.
+  it("collapses an all-closed repo to a single compact line", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
       const url = typeof req === "string" ? req : (req as Request).url;
       if (url.includes("/repos/ippoan/ci-dashboard/tags")) {
@@ -603,8 +603,8 @@ describe("GET /releases", () => {
           commits: [{ sha: "x", commit: { message: "feat\n\nRefs #1" } }],
         });
       }
-      // The referenced issue is already closed → block.issues is non-empty
-      // (so the tag block renders) but hasVisibleCandidate is false.
+      // The only referenced issue is already closed → no open block → the
+      // repo card collapses to the compact closed-summary line.
       if (url.endsWith("/repos/ippoan/ci-dashboard/issues/1")) {
         return Response.json({
           number: 1, title: "old work", state: "closed",
@@ -624,10 +624,13 @@ describe("GET /releases", () => {
 
     expect(res.status).toBe(200);
     const html = await res.text();
-    // Card itself still renders so the closed-history <details> stays visible.
+    // Compact one-liner: repo link + deduped closed count, no expandable list.
     expect(html).toContain("ippoan/ci-dashboard");
-    expect(html).toContain("1 closed issue");
-    // But the actions row (and its button) is gone.
+    expect(html).toContain("repo-card-compact");
+    expect(html).toContain("1 closed issue (released)");
+    // No expandable closed <details>, no checkbox form, no close button.
+    expect(html).not.toContain('<details class="closed-details">');
+    expect(html).not.toMatch(/name="pair"/);
     expect(html).not.toContain("Close selected as released");
   });
 


### PR DESCRIPTION
## 背景

#224 / #225 で watched repo を全件カード表示するようにしたが、参照 issue が全部 close 済みの repo が「`▶ N closed issues`」の `<details>` を縦に積んだ背の高いカードになり、`/releases` がノイジーになっていた(例: ci-dashboard の Unreleased 30 closed + v0.0.68〜72 各 1 closed、ref-files-worker の main@... 7 closed)。

## 変更

`renderIndexRepo`:

- **open issue を含むタグブロックだけ**フル描画(closed-only ブロックは drop)
- repo に open 参照 issue が 1 件も無い場合、カードを **1 行に畳む**:
  - closed 参照 issue があれば `✅ N closed issue(s) (released)`(issue 番号で dedup)
  - 参照 issue 自体が無ければ `No referenced issues in the recent release window.`
  - `<form>` / table / `<details>` / older-tags strip は出さない(真に 1 行)
- open ブロックがある repo は従来どおりフルカード。open が必ずあるので close ボタンは常に actionable
- `.repo-card-compact` の軽量 CSS を追加

mixed ブロック(open + closed)は従来どおり open table + closed `<details>` を維持。#224 の roster 趣旨(closed-only repo も一覧に残す)は維持し、表現だけ 1 行に圧縮。

## テスト

- `npm run typecheck` ✓
- `npx vitest run` → 39 files / **647 passed** ✓
- 旧 #59 テスト(all-closed で button 非表示 + `<details>` 維持)を新挙動(コンパクト 1 行)に更新

Refs #226


---
_Generated by [Claude Code](https://claude.ai/code/session_01AdxDxx9t2z1C9TdeysjipB)_