### PR TITLE
fix(releases): Unreleased ゾーンの tag...main compare を短 TTL にして直近 merge の open issue を出す

### DIFF
--- a/src/release-cache.ts
+++ b/src/release-cache.ts
@@ -34,6 +34,12 @@ const TTL_REPO_META = 3600;
 const TTL_PR = 86400;
 const TTL_ISSUE = 60;
 
+// Short TTL for compares whose HEAD is a moving ref (e.g. the "Unreleased"
+// zone's `tag...<defaultBranch>`). Just-merged Refs must surface promptly, so
+// we cap freshness at the KV minimum rather than the 24h immutable-range TTL.
+// Refs #228.
+export const TTL_MOVING_COMPARE = 60;
+
 // Minimum KV expirationTtl is 60s; everything above respects that.
 
 interface TagListItem { name: string; commit: { sha: string } }
@@ -98,9 +104,15 @@ export async function cachedCompare(
   name: string,
   prev: string,
   curr: string,
+  // TTL override. The default (TTL_COMPARE = 24h) is only safe when BOTH ends
+  // are immutable refs (tag...tag) — that range never changes. The "Unreleased"
+  // zone compares `tag...<defaultBranch>`, whose HEAD moves on every merge, so
+  // a 24h cache would hide just-merged Refs for up to a day (Refs #228). Such
+  // callers must pass a short TTL (e.g. TTL_MOVING_COMPARE).
+  ttlSec: number = TTL_COMPARE,
 ): Promise<CompareResponse> {
   const key = `${PREFIX}cmp:${owner}/${name}:${prev}..${curr}`;
-  return kvCached(kv, key, TTL_COMPARE, () =>
+  return kvCached(kv, key, ttlSec, () =>
     githubApi<CompareResponse>(
       token, "GET", `/repos/${owner}/${name}/compare/${prev}...${curr}`,
     ),

--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -17,6 +17,7 @@ import {
   cachedCommits,
   cachedRepoMeta,
   cachedIssue,
+  TTL_MOVING_COMPARE,
 } from "./release-cache";
 import { loadDirectPushAllowlist } from "./direct-push-allowlist";
 import { parseTaglessRepos } from "./tagless-repos";
@@ -371,7 +372,13 @@ async function loadSyntheticBlock(
   let commits: RawCommit[] = [];
   try {
     if (sinceTag) {
-      const cmp = await cachedCompare(token, kv, owner, name, sinceTag, defaultBranch);
+      // `sinceTag...defaultBranch` is a moving range — HEAD advances on every
+      // merge — so cap the compare cache at the short moving-head TTL. The
+      // default 24h would hide just-merged Refs (e.g. open issues referenced by
+      // a PR merged minutes ago), making the repo look "all closed". Refs #228.
+      const cmp = await cachedCompare(
+        token, kv, owner, name, sinceTag, defaultBranch, TTL_MOVING_COMPARE,
+      );
       commits = cmp.commits;
     } else {
       commits = await cachedCommits(token, kv, owner, name, defaultBranch, SYNTHETIC_COMMIT_WINDOW);

--- a/test/release-cache.test.ts
+++ b/test/release-cache.test.ts
@@ -10,6 +10,7 @@ import {
   invalidateRepoCommits,
   invalidateRepoMeta,
   clearReleaseCache,
+  TTL_MOVING_COMPARE,
 } from "../src/release-cache";
 
 // The cache layer is meant to be transparent: first call hits GitHub, second
@@ -66,6 +67,32 @@ describe("release-cache", () => {
     await cachedCompare("tok", env.CI_STATUS, "ippoan", "x", "v1.0.0", "v1.1.0");
     await cachedCompare("tok", env.CI_STATUS, "ippoan", "x", "v1.1.0", "v1.2.0");
     expect(calls).toBe(2);
+  });
+
+  // #228: the "Unreleased" zone compares `tag...<defaultBranch>`, a moving
+  // range, so it must NOT inherit the 24h immutable-range TTL — otherwise a
+  // just-merged Ref stays hidden for up to a day. An explicit ttlSec override
+  // (TTL_MOVING_COMPARE) caps the KV entry at 60s; the default stays 24h.
+  it("cachedCompare: honors an explicit short ttl for moving-HEAD ranges", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({ commits: [] }),
+    );
+    const putSpy = vi.spyOn(env.CI_STATUS, "put");
+
+    // Immutable tag...tag — default 24h.
+    await cachedCompare("tok", env.CI_STATUS, "ippoan", "y", "v1.0.0", "v1.1.0");
+    // Moving tag...main — short TTL via override.
+    await cachedCompare(
+      "tok", env.CI_STATUS, "ippoan", "y", "v1.0.0", "main", TTL_MOVING_COMPARE,
+    );
+
+    const ttlFor = (frag: string): number | undefined => {
+      const call = putSpy.mock.calls.find(([k]) => String(k).includes(frag));
+      return (call?.[2] as { expirationTtl?: number } | undefined)?.expirationTtl;
+    };
+    expect(ttlFor("v1.0.0..v1.1.0")).toBe(86400);
+    expect(ttlFor("v1.0.0..main")).toBe(TTL_MOVING_COMPARE);
+    expect(TTL_MOVING_COMPARE).toBe(60);
   });
 
   it("falls through to the loader when kv is undefined (no caching)", async () => {


### PR DESCRIPTION
## 症状(ユーザー報告)

`/releases` で多数の repo が「✅ N closed issues (released)」と出るのに、`/issues` では同じ repo に open issue が複数ある。例: ci-dashboard は #226 #224 #221 が open で、いずれも直近 merge commit に `Refs #N` がある。一見矛盾。

## 根本原因

`loadSyntheticBlock` の "Unreleased" ゾーンは `cachedCompare(<latest tag>, defaultBranch)` = `tag...main` を使う。これは **HEAD が動く range** なのに、`cachedCompare` の default TTL = `TTL_COMPARE = 86400`(24h、immutable な `tag...tag` 用)が適用されていた。

→ PR を merge して新しい `Refs #N` が main に入っても最大 24h は古い compare がキャッシュされ、**直近 merge で参照された open issue が Unreleased ゾーンに surface しない**。残るのは古い closed 参照だけ → repo が「全 closed」= #226 のコンパクト 1 行に見えていた。

## 修正

- `cachedCompare` に optional な `ttlSec` override を追加(default は従来の `TTL_COMPARE` = 24h、後方互換)
- moving-HEAD 用 `TTL_MOVING_COMPARE = 60`(KV 最小)を新設
- `loadSyntheticBlock` の `sinceTag`(= Unreleased)経路だけ `TTL_MOVING_COMPARE` を渡す

immutable な `tag...tag` compare は 24h のまま。直近 merge の open `Refs` は ≤60s で surface する。

## 補足(矛盾ではない部分)

`/issues` の open のうち merged PR を持たない planning/tracking issue(#182/#173/#172/#152 等)は、どの release commit にも参照されないため /releases には出ない。これは設計どおり(/releases =「release range の commit が触れた issue」のレンズ)。本修正は「参照されているのに stale cache で出ていなかった」分のみを直す。

## テスト

- `npm run typecheck` ✓
- `npx vitest run` → 39 files / **648 passed**(TTL 回帰テスト +1: moving-HEAD は 60s、immutable は 24h を `kv.put` の `expirationTtl` で assert)✓

Refs #228


---
_Generated by [Claude Code](https://claude.ai/code/session_01AdxDxx9t2z1C9TdeysjipB)_