### PR TITLE
feat(releases): PR merge / default-branch push で compare cache を invalidate(merge 単位の即時反映)

### DIFF
--- a/src/release-cache.ts
+++ b/src/release-cache.ts
@@ -243,6 +243,19 @@ export async function invalidateRepoCommits(
   await invalidateRepoPrefix(kv, `${PREFIX}commits:${owner}/${name}:`);
 }
 
+/** 該当 repo の compare cache (`cmp:owner/name:<prev>..<curr>`) を全 flush。
+ *  PR merge / default branch への push 時に呼ぶ。"Unreleased" ゾーンの
+ *  `<latest tag>...<defaultBranch>` compare は HEAD が動くと内容が変わるので、
+ *  merge の瞬間に消して即時 refetch させる (60s TTL を待たない)。Refs #231。
+ *  immutable な `tag...tag` compare も一緒に消えるが re-fetch は冪等。 */
+export async function invalidateRepoCompare(
+  kv: KVNamespace | undefined,
+  owner: string,
+  name: string,
+): Promise<void> {
+  await invalidateRepoPrefix(kv, `${PREFIX}cmp:${owner}/${name}:`);
+}
+
 /** 該当 repo の repo-meta (default_branch 等) cache を flush。
  *  `repository` event (rename / default_branch 変更) で呼ぶ想定。
  *  現状の webhook handler では未使用だが API 表面として用意しておく。 */

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -17,6 +17,7 @@ import {
   invalidateIssue as invalidateReleaseCacheIssue,
   invalidateRepoTags,
   invalidateRepoCommits,
+  invalidateRepoCompare,
 } from "./release-cache";
 
 interface ReleaseWebhookPayload {
@@ -207,16 +208,27 @@ export async function handleWebhook(
       payload.action === "closed" &&
       payload.pull_request.merged === true &&
       payload.pull_request.base.ref === payload.repository.default_branch;
-    if (isMergeToDefault && parseTaglessRepos(env.TAGLESS_REPOS).has(repo)) {
-      await hub.fetch(new Request("http://hub/release-alert-detect-pr", {
-        method: "POST",
-        body: JSON.stringify({
-          repo,
-          prNumber: payload.pull_request.number,
-          mergeSha: payload.pull_request.merge_commit_sha,
-          defaultBranch: payload.repository.default_branch,
-        }),
-      }));
+    if (isMergeToDefault) {
+      // /releases の "Unreleased" ゾーンを即時更新。merge で main HEAD が動き、
+      // `<tag>...<defaultBranch>` の compare 内容 (= 直近 merge が参照した
+      // open issue) が変わるので、compare + commits cache を flush して 60s
+      // TTL を待たずに次ロードで refetch させる。Refs #231。
+      const [owner, name] = repo.split("/");
+      if (owner && name) {
+        await invalidateRepoCompare(env.CI_STATUS, owner, name);
+        await invalidateRepoCommits(env.CI_STATUS, owner, name);
+      }
+      if (parseTaglessRepos(env.TAGLESS_REPOS).has(repo)) {
+        await hub.fetch(new Request("http://hub/release-alert-detect-pr", {
+          method: "POST",
+          body: JSON.stringify({
+            repo,
+            prNumber: payload.pull_request.number,
+            mergeSha: payload.pull_request.merge_commit_sha,
+            defaultBranch: payload.repository.default_branch,
+          }),
+        }));
+      }
     }
     return new Response("OK", { status: 200 });
   }
@@ -293,6 +305,10 @@ export async function handleWebhook(
           await invalidateRepoTags(env.CI_STATUS, owner, name);
         } else if (defaultBranch && ref === `refs/heads/${defaultBranch}`) {
           await invalidateRepoCommits(env.CI_STATUS, owner, name);
+          // "Unreleased" ゾーンの `<tag>...<defaultBranch>` compare も flush。
+          // squash merge は default branch への push として届くので、これで
+          // merge 単位の即時反映になる (60s TTL を待たない)。Refs #231。
+          await invalidateRepoCompare(env.CI_STATUS, owner, name);
         }
       }
     }

--- a/test/release-cache.test.ts
+++ b/test/release-cache.test.ts
@@ -8,6 +8,7 @@ import {
   invalidateIssue,
   invalidateRepoTags,
   invalidateRepoCommits,
+  invalidateRepoCompare,
   invalidateRepoMeta,
   clearReleaseCache,
   TTL_MOVING_COMPARE,
@@ -153,6 +154,29 @@ describe("release-cache", () => {
     expect(calls).toBe(3); // 該当 repo 再 fetch
     await cachedCommits("tok", env.CI_STATUS, "ippoan", "other", "main", 50);
     expect(calls).toBe(3); // 別 repo は hit
+  });
+
+  it("invalidateRepoCompare: 該当 repo の全 compare range を flush する (#231)", async () => {
+    let calls = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      calls++;
+      return Response.json({ commits: [] });
+    });
+    // immutable tag...tag と moving tag...main の両方を populate
+    await cachedCompare("tok", env.CI_STATUS, "ippoan", "ci-dashboard", "v1.0.0", "v1.1.0");
+    await cachedCompare("tok", env.CI_STATUS, "ippoan", "ci-dashboard", "v1.1.0", "main", TTL_MOVING_COMPARE);
+    await cachedCompare("tok", env.CI_STATUS, "ippoan", "other", "v1.0.0", "main", TTL_MOVING_COMPARE);
+    expect(calls).toBe(3);
+
+    await invalidateRepoCompare(env.CI_STATUS, "ippoan", "ci-dashboard");
+
+    // 該当 repo の compare は全部 (tag...tag も tag...main も) 再 fetch
+    await cachedCompare("tok", env.CI_STATUS, "ippoan", "ci-dashboard", "v1.0.0", "v1.1.0");
+    await cachedCompare("tok", env.CI_STATUS, "ippoan", "ci-dashboard", "v1.1.0", "main", TTL_MOVING_COMPARE);
+    expect(calls).toBe(5);
+    // 別 repo は hit のまま
+    await cachedCompare("tok", env.CI_STATUS, "ippoan", "other", "v1.0.0", "main", TTL_MOVING_COMPARE);
+    expect(calls).toBe(5);
   });
 
   it("invalidateRepoMeta: 該当 repo の repo-meta key だけ消す", async () => {

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -624,6 +624,52 @@ describe("POST /webhook", () => {
     expect(hubCalls.filter((c) => c.path === "/release-alert-detect-pr")).toHaveLength(0);
   });
 
+  // #231: a PR merged into the default branch flushes the repo's compare +
+  // commits cache so /releases' "Unreleased" zone reflects the just-merged
+  // Refs immediately (not after the 60s TTL). Ungated by TAGLESS so any
+  // watched repo benefits.
+  it("merged PR into default branch flushes compare + commits cache", async () => {
+    await env.CI_STATUS.put("rcache:v1:cmp:ippoan/foo:v1.0.0..main", "{}", { expirationTtl: 60 });
+    await env.CI_STATUS.put("rcache:v1:commits:ippoan/foo:main:100", "[]", { expirationTtl: 60 });
+    const body = JSON.stringify({
+      action: "closed",
+      pull_request: { number: 12, merged: true, merge_commit_sha: "cafef00d", base: { ref: "main" } },
+      repository: { full_name: "ippoan/foo", default_branch: "main" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST", body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "pull_request" },
+      }),
+      testEnv(), ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(await env.CI_STATUS.get("rcache:v1:cmp:ippoan/foo:v1.0.0..main")).toBeNull();
+    expect(await env.CI_STATUS.get("rcache:v1:commits:ippoan/foo:main:100")).toBeNull();
+  });
+
+  it("PR merged into a non-default branch does NOT flush compare cache", async () => {
+    await env.CI_STATUS.put("rcache:v1:cmp:ippoan/foo:v1.0.0..main", "{}", { expirationTtl: 60 });
+    const body = JSON.stringify({
+      action: "closed",
+      pull_request: { number: 13, merged: true, merge_commit_sha: "abc", base: { ref: "develop" } },
+      repository: { full_name: "ippoan/foo", default_branch: "main" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST", body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "pull_request" },
+      }),
+      testEnv(), ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(await env.CI_STATUS.get("rcache:v1:cmp:ippoan/foo:v1.0.0..main")).toBe("{}");
+  });
+
   // Regression guard for issue #51: Tag Release directly must NOT fire — the
   // Hub it would reach is still on the previous version's deploy.
   it("does NOT trigger release-alert-detect on a Tag Release workflow completion", async () => {
@@ -705,9 +751,11 @@ describe("POST /webhook", () => {
     expect(await env.CI_STATUS.get("rcache:v1:tags:ippoan/foo:10")).toBeNull();
   });
 
-  it("push to default branch flushes commits cache (not tags)", async () => {
+  it("push to default branch flushes commits + compare cache (not tags)", async () => {
     await env.CI_STATUS.put("rcache:v1:tags:ippoan/foo:10", "[]", { expirationTtl: 300 });
     await env.CI_STATUS.put("rcache:v1:commits:ippoan/foo:main:50", "[]", { expirationTtl: 60 });
+    // "Unreleased" ゾーンの tag...main compare key (Refs #231)
+    await env.CI_STATUS.put("rcache:v1:cmp:ippoan/foo:v1.0.0..main", "{}", { expirationTtl: 60 });
     const body = JSON.stringify({
       ref: "refs/heads/main",
       repository: { full_name: "ippoan/foo", default_branch: "main" },
@@ -725,12 +773,15 @@ describe("POST /webhook", () => {
     );
     await waitOnExecutionContext(ctx);
     expect(await env.CI_STATUS.get("rcache:v1:commits:ippoan/foo:main:50")).toBeNull();
+    // merge で main HEAD が動くと compare 内容が変わるので flush される (#231)
+    expect(await env.CI_STATUS.get("rcache:v1:cmp:ippoan/foo:v1.0.0..main")).toBeNull();
     // tags cache は触らない (push が tag じゃないので)
     expect(await env.CI_STATUS.get("rcache:v1:tags:ippoan/foo:10")).toBe("[]");
   });
 
   it("push to feature branch is noop for release-cache", async () => {
     await env.CI_STATUS.put("rcache:v1:commits:ippoan/foo:main:50", "[]", { expirationTtl: 60 });
+    await env.CI_STATUS.put("rcache:v1:cmp:ippoan/foo:v1.0.0..main", "{}", { expirationTtl: 60 });
     const body = JSON.stringify({
       ref: "refs/heads/feature-x",
       repository: { full_name: "ippoan/foo", default_branch: "main" },
@@ -749,6 +800,7 @@ describe("POST /webhook", () => {
     await waitOnExecutionContext(ctx);
     // 触らない
     expect(await env.CI_STATUS.get("rcache:v1:commits:ippoan/foo:main:50")).toBe("[]");
+    expect(await env.CI_STATUS.get("rcache:v1:cmp:ippoan/foo:v1.0.0..main")).toBe("{}");
   });
 
   it("issues event also invalidates release-cache issue key (close immediately reflects on /releases)", async () => {


### PR DESCRIPTION
## 背景

#229 で Unreleased ゾーンの `tag...main` compare を 60s TTL に縮めたが、merge 直後に最大 60s 待つ。release は **merge / PR 単位**で起きるので、その瞬間に webhook で対象 repo の release cache を flush して即時反映する。

## 現状の gap

webhook(`src/webhook.ts`)は `push`(default branch)で **`commits` cache しか flush していなかった**。Unreleased ゾーンが使う `cmp:owner/name:<tag>..<branch>`(compare)cache は触らず、TTL 頼みだった。→ PR merge で新しく参照された open issue が最大 60s 出ない。

## 変更

1. `release-cache.ts`: `invalidateRepoCompare(kv, owner, name)` を追加(`cmp:owner/name:*` を prefix delete)
2. `webhook.ts`:
   - `push`(default branch): `invalidateRepoCommits` の隣に `invalidateRepoCompare` を追加(squash merge は default-branch push として届く)
   - `pull_request`(merged → default branch): `invalidateRepoCompare` + `invalidateRepoCommits` を追加(PR 単位の保険、TAGLESS 限定でなく全 watched repo)

これで **merge → webhook 到達の瞬間に compare cache が消え、次の /releases ロードで GitHub から取り直す** = 直近 merge の open 参照 issue が即出る。immutable な `tag...tag` compare も一緒に消えるが re-fetch は冪等。

## テスト

- `npm run typecheck` ✓
- `npx vitest run` → 39 files / **651 passed**(+4: push が compare flush / feature-branch は noop / PR merge が compare+commits flush / 非 default branch merge は noop / `invalidateRepoCompare` unit)✓

Refs #231


---
_Generated by [Claude Code](https://claude.ai/code/session_01AdxDxx9t2z1C9TdeysjipB)_