### PR TITLE
feat(release-wave): add per-consumer retest buttons to global compatibility view

### DIFF
--- a/src/release-wave/compat.ts
+++ b/src/release-wave/compat.ts
@@ -356,6 +356,13 @@ export async function computeCompatibility(
 /** wave 内の 1 backend repo についての突合結果。 */
 export interface WaveBackendCompat {
   backend_repo: string;
+  /**
+   * 当該 backend を deploy した wave の id (`backend::<repo>.wave_id`)。
+   * 単独 deploy (wave 経由でない) なら null。global (wave 非依存) ビューの
+   * retest ボタンが既存 `/api/release-wave/<wave_id>/retest` を流用するために使う。
+   * Refs #157。
+   */
+  wave_id: string | null;
   /** `backend::<repo>` に記録された現 production image (record 無しなら null)。 */
   current_image: string | null;
   /** current_image に対応する git release tag (v2 record のみ、無ければ null)。Refs #197。 */
@@ -398,6 +405,7 @@ export async function computeWaveCompatibility(
     const compat = await computeCompatibility(kv, repo, rec.current_image);
     backends.push({
       backend_repo: repo,
+      wave_id: rec.wave_id ?? null,
       current_image: rec.current_image,
       current_tag: rec.current_tag ?? null,
       deploy_history: Array.isArray(rec.deploy_history) ? rec.deploy_history : [],

--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -635,10 +635,62 @@ function renderGlobalCompatibilitySection(
       <h2>Compatibility (all consumers) — ${verdict}</h2>
       <p class="meta">全 backend の<strong>現 production image</strong>を既 deploy
         frontend が integration test 済みか (wave 横断)。緑 = tested / 赤 = untested。
-        個別 wave の retest 操作は各 wave 詳細ページで。
+        赤 (untested) の consumer は下のボタンから直接 retest できる。
         Refs <a href="https://github.com/ippoan/ci-dashboard/issues/157">#157</a>.</p>
       ${body}
+      ${renderGlobalRetestButtons(compat)}
       ${renderActiveWaveOverlay(active)}
+    </div>`;
+}
+
+/**
+ * global (wave 非依存) Compatibility グラフの直下に、untested edge
+ * (backend × frontend) ごとの "Re-test" ボタングリッドを描画する (Refs #157)。
+ *
+ * 各 backend の `wave_id` を使って既存 `/api/release-wave/<wave_id>/retest` に
+ * `frontend` を POST する (= 新 endpoint を作らず wave 詳細ページと同じ
+ * handler / dispatch 経路を流用する)。`wave_id` を持たない backend
+ * (= 単独 deploy で wave 未紐付け) の edge は disabled ボタンにし、
+ * tooltip で理由を示す。
+ *
+ * JS 不使用 (form POST のみ) なので strict CSP `default-src 'none'` のまま動く。
+ */
+function renderGlobalRetestButtons(compat: WaveCompatibility): string {
+  const groups: string[] = [];
+  for (const b of compat.backends) {
+    const reds = b.matrix.filter((m) => !m.tested_against_target);
+    if (reds.length === 0) continue;
+    const buttons = reds
+      .map((m) => {
+        if (!b.wave_id) {
+          // wave 未紐付けの backend は既存 retest endpoint を呼べない。
+          return `<button type="button" class="warn" disabled
+              title="${escapeHtml(b.backend_repo)} は wave に紐付いていないため (単独 deploy)、ここからの retest 不可。該当 wave で再実行するか backend を wave 経由で deploy してください。">
+              Re-test ${escapeHtml(m.frontend)}
+            </button>`;
+        }
+        const action = encodeURIComponent(b.wave_id);
+        return `<form method="post" action="/api/release-wave/${action}/retest" style="display:inline; margin:0">
+            <input type="hidden" name="frontend" value="${escapeHtml(m.frontend)}">
+            <button type="submit" class="warn"
+              title="Re-test ${escapeHtml(m.frontend)} against ${escapeHtml(b.backend_repo)} の現 image (wave ${escapeHtml(b.wave_id)})">
+              Re-test ${escapeHtml(m.frontend)}
+            </button>
+          </form>`;
+      })
+      .join(" ");
+    groups.push(`
+      <div style="margin-top:8px">
+        <strong class="meta">${escapeHtml(b.backend_repo)}
+          ${b.wave_id ? `<span class="meta">(wave ${escapeHtml(b.wave_id)})</span>` : `<span class="meta">(no wave)</span>`}</strong>
+        <div class="actions" style="margin-top:4px">${buttons}</div>
+      </div>`);
+  }
+  if (groups.length === 0) return "";
+  return `
+    <div style="margin-top:10px">
+      <strong class="meta">Re-test untested consumers</strong>
+      ${groups.join("")}
     </div>`;
 }
 

--- a/test/release-wave/compat.test.ts
+++ b/test/release-wave/compat.test.ts
@@ -472,6 +472,31 @@ describe("computeWaveCompatibility", () => {
     expect(res.checked).toBe(false);
     expect(res.verified).toBe(true);
   });
+
+  it("propagates the backend record's wave_id (and null for single deploys)", async () => {
+    const store = kv();
+    await recordBackendDeploy(store, {
+      repo: "ippoan/rust-alc-api",
+      current_image: "cur",
+      deployed_by: "x",
+      wave_id: "w-42",
+      now: daysAgo(1),
+    });
+    await recordBackendDeploy(store, {
+      repo: "ippoan/cc-relay",
+      current_image: "cur2",
+      deployed_by: "x",
+      now: daysAgo(1),
+    });
+    const res = await computeWaveCompatibility(store, [
+      "ippoan/rust-alc-api",
+      "ippoan/cc-relay",
+    ]);
+    const rust = res.backends.find((b) => b.backend_repo === "ippoan/rust-alc-api")!;
+    const relay = res.backends.find((b) => b.backend_repo === "ippoan/cc-relay")!;
+    expect(rust.wave_id).toBe("w-42");
+    expect(relay.wave_id).toBeNull();
+  });
 });
 
 describe("computeGlobalCompatibility", () => {

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -1067,4 +1067,85 @@ describe("handleReleaseWaveListPage global compat overlay", () => {
     expect(idx).toBeGreaterThan(-1);
     expect(html.slice(Math.max(0, idx - 120), idx)).toContain("disabled");
   });
+
+  it("renders a per-untested-consumer Re-test button posting to the backend's wave retest endpoint", async () => {
+    const env = fakeEnv({
+      listReturn: [],
+      compatKv: memKv({
+        "backend::ippoan/rust-alc-api": {
+          schema_version: 1,
+          repo: "ippoan/rust-alc-api",
+          current_image: "cur-img",
+          deployed_at: "2026-05-27T00:00:00Z",
+          deployed_by: "x",
+          wave_id: "w-backend",
+        },
+        "frontend::ippoan/alc-app": {
+          schema_version: 1,
+          repo: "ippoan/alc-app",
+          prod_version: "v1.2.10",
+          prod_deployed_at: "2026-05-27T00:00:00Z",
+          tested_against: [
+            {
+              backend_repo: "ippoan/rust-alc-api",
+              backend_image: "stale-img",
+              tested_at: "2026-05-27T00:00:00Z",
+            },
+          ],
+        },
+      }),
+    });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    expect(html).toContain("Re-test untested consumers");
+    // backend record の wave_id を流用して既存 retest endpoint へ POST する
+    expect(html).toContain('action="/api/release-wave/w-backend/retest"');
+    expect(html).toContain('name="frontend" value="ippoan/alc-app"');
+    expect(html).toContain("Re-test ippoan/alc-app");
+  });
+
+  it("disables the Re-test button when the backend has no wave_id (single deploy)", async () => {
+    const env = fakeEnv({
+      listReturn: [],
+      compatKv: memKv({
+        "backend::ippoan/rust-alc-api": {
+          schema_version: 1,
+          repo: "ippoan/rust-alc-api",
+          current_image: "cur-img",
+          deployed_at: "2026-05-27T00:00:00Z",
+          deployed_by: "x",
+          wave_id: null,
+        },
+        "frontend::ippoan/alc-app": {
+          schema_version: 1,
+          repo: "ippoan/alc-app",
+          prod_version: "v1.2.10",
+          prod_deployed_at: "2026-05-27T00:00:00Z",
+          tested_against: [
+            {
+              backend_repo: "ippoan/rust-alc-api",
+              backend_image: "stale-img",
+              tested_at: "2026-05-27T00:00:00Z",
+            },
+          ],
+        },
+      }),
+    });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    expect(html).toContain("Re-test untested consumers");
+    // wave 未紐付けなので POST 先 form は出ず、disabled ボタンになる
+    expect(html).not.toContain("/retest");
+    const idx = html.indexOf("Re-test ippoan/alc-app");
+    expect(idx).toBeGreaterThan(-1);
+    expect(html.slice(Math.max(0, idx - 250), idx)).toContain("disabled");
+  });
+
+  it("does not render the Re-test grid when all consumers are tested", async () => {
+    const env = fakeEnv({
+      listReturn: [],
+      compatKv: memKv(compatSeed),
+    });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    expect(html).toContain("all consumers tested");
+    expect(html).not.toContain("Re-test untested consumers");
+  });
 });


### PR DESCRIPTION
## 概要

`/release-wave` list ページの **Compatibility (all consumers)** global グラフ (wave 非依存) に、untested(赤) consumer ごとの **「Re-test」ボタン**を追加する。

これまで retest ボタンは wave 詳細ページの compatibility section にしか無かった。global グラフからも untested consumer の integration test を直接再実行したい、という要望に対応する。

## 設計 — 新 endpoint を作らず既存経路を流用

global グラフの untested edge は `(backend_repo, frontend)` のペア。その backend の `backend::<repo>` KV record には、それを deploy した wave の `wave_id` が紐づいている。よって各 retest ボタンは、その backend の `wave_id` を使って**既存** `/api/release-wave/{wave_id}/retest` に `frontend` を POST すればよい (= wave 詳細ページと同じ handler / dispatch 経路を共用)。**新 route / handler 変更は不要。**

## 変更点

- **`src/release-wave/compat.ts`**: `WaveBackendCompat` に `wave_id: string | null` を追加し、`computeWaveCompatibility` が `backend::<repo>` record の `wave_id` を伝播するようにした (単独 deploy は null)。
- **`src/release-wave/page.ts`**: `renderGlobalCompatibilitySection` の SVG 直下に、新ヘルパ `renderGlobalRetestButtons()` で untested edge ごとの「Re-test {frontend}」ボタングリッドを描画。各ボタンは backend の `wave_id` を使って既存 retest endpoint に `frontend` を hidden field で POST する。
- **フォールバック**: `wave_id` を持たない backend (単独 deploy で wave 未紐付け) の edge は **disabled ボタン**にし、tooltip で「wave 未紐付けのため retest 不可」を示す。
- JS 不使用 (form POST のみ)。strict CSP `default-src 'none'` のまま動く。属性は全て `escapeHtml` でエスケープ。
- wave 詳細ページの既存 retest ボタンは未変更 (同じ route/handler を共用)。

## テスト

- `compat.test.ts`: `computeWaveCompatibility` が backend record の `wave_id` を伝播する (および単独 deploy で null になる) ことを検証。
- `page.test.ts`: 
  - untested consumer に `/api/release-wave/{wave_id}/retest` へ POST する form ボタンが出ること
  - `wave_id` が null の backend では disabled ボタンになり POST form が出ないこと
  - 全 consumer が tested なら retest グリッド自体が出ないこと

> ローカルは `@ippoan/auth-client-worker` (GitHub Packages) の token が無く `npm install` できないため、`typecheck` / `test` は CI に委譲。

Refs #137
Refs #157

---
_Generated by [Claude Code](https://claude.ai/code/session_012zLhVkMuDnAyBWZNLnuorh)_