### PR TITLE
feat(release-wave): enable no-wave retest from global compatibility graph

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import {
   handleReleaseWaveRollback,
   handleReleaseWaveAbort,
   handleReleaseWaveRetest,
+  handleReleaseWaveRetestConsumer,
   handleReleaseWavePendingReleaseFlip,
   handleReleaseWaveTrafficRollback,
   handleReleaseWaveBackendRollback,
@@ -288,6 +289,15 @@ app.post("/api/release-wave/:wave_id/abort", (c) =>
 // (Refs #157 Phase B)。form field `frontend` で 1 件指定可、無ければ全 red。
 app.post("/api/release-wave/:wave_id/retest", (c) =>
   handleReleaseWaveRetest(c.req.raw, c.env, c.req.param("wave_id")),
+);
+// wave 非依存の単発 retest (Refs #157 / #137)。global Compatibility グラフの
+// 「no wave」backend consumer から retest できるよう、wave_id を取らず
+// form field `backend_repo` + `frontend` (+ 任意 `backend_image`) で
+// release-wave-retest を 1 件 dispatch する。
+// 静的セグメント `retest-consumer` は上の `:wave_id/retest` (2 セグメント) と
+// セグメント数が違うため衝突しない。
+app.post("/api/release-wave/retest-consumer", (c) =>
+  handleReleaseWaveRetestConsumer(c.req.raw, c.env),
 );
 // 単独 v* リリースの no-traffic version を 100% へ flip (Refs #181 / #174)。
 // wave を起こさず form field `repo` の pending-release record を promote する。

--- a/src/release-wave/api.ts
+++ b/src/release-wave/api.ts
@@ -12,7 +12,11 @@
 import type { Env } from "../index";
 import type { ReleaseWaveHub, RpcResult } from "./do";
 import type { WaveState } from "./types";
-import { computeWaveCompatibility, getBackendCurrent } from "./compat";
+import {
+  computeWaveCompatibility,
+  computeCompatibility,
+  getBackendCurrent,
+} from "./compat";
 import { decideRetestDispatches, dispatchAll, type Dispatch } from "./dispatch";
 import { getPendingRelease, clearPendingRelease } from "./pending-release";
 import { getTraffic } from "./traffic";
@@ -211,6 +215,117 @@ export async function handleReleaseWaveRetest(
     }
   }
   return redirectToDetail(wave_id);
+}
+
+// ----------------------------------------------------------------------------
+// POST /api/release-wave/retest-consumer  (Refs #157 / #137)
+// ----------------------------------------------------------------------------
+
+/**
+ * wave **非依存**で 1 consumer (frontend) の integration retest を起こす。
+ *
+ * global「Compatibility (all consumers)」グラフの retest ボタンは、backend が
+ * 単独 deploy (= `backend::<repo>.wave_id` が null) だと wave-bound な
+ * `/api/release-wave/<wave_id>/retest` を呼べず、これまで disabled だった。
+ * 本 endpoint はその制約を外し、wave が無くても retest できるようにする。
+ *
+ * `release-wave-retest` dispatch を frontend repo に送る点・client_payload の
+ * shape (`backend_repo` / `backend_image` / `prod_version`) は wave 版と同一で、
+ * 違いは `wave_id` を載せない (= null 相当) ことだけ。consumer 側の retest 受け
+ * (frontend-ci の `compat_backend_image` 経路 / `report-frontend-compat` action)
+ * は `wave_id` を一切参照しないため、無くても動く。
+ *
+ * form fields:
+ *   - `backend_repo` ("owner/name") 必須。`backend::<repo>` record を引く起点。
+ *   - `frontend`     ("owner/name") 必須。dispatch 先 consumer repo。
+ *   - `backend_image` 任意。未指定なら `backend::<repo>.current_image` を採用
+ *     (= グラフが指す「現 prod image」と一致させる)。指定時は値の検証として
+ *     現 image との一致を要求しない (= 過去 image での retest も許す)。
+ *
+ * 検証:
+ *   - backend record が無ければ 404。
+ *   - 指定 frontend が当該 backend の consumer (= その backend_repo を test した
+ *     履歴を持つ) でなければ 404 (= グラフに無い edge への誤射出を防ぐ)。
+ * dispatch は best-effort。完了後は一覧ページに 303 redirect する。
+ */
+export async function handleReleaseWaveRetestConsumer(
+  req: Request,
+  env: Env,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return jsonResponse(405, { code: "METHOD_NOT_ALLOWED", error: "use POST" });
+  }
+  if (!env.COMPAT_KV) {
+    return jsonResponse(500, {
+      code: "KV_NOT_CONFIGURED",
+      error: "COMPAT_KV is not bound",
+    });
+  }
+
+  let backendRepo = "";
+  let frontend = "";
+  let backendImage = "";
+  try {
+    const form = await req.formData();
+    backendRepo = String(form.get("backend_repo") ?? "").trim();
+    frontend = String(form.get("frontend") ?? "").trim();
+    backendImage = String(form.get("backend_image") ?? "").trim();
+  } catch {
+    // form-data 以外は下で 400
+  }
+  if (!backendRepo || !frontend) {
+    return jsonResponse(400, {
+      code: "BAD_REQUEST",
+      error: "form fields 'backend_repo' and 'frontend' are required",
+    });
+  }
+
+  const backend = await getBackendCurrent(env.COMPAT_KV, backendRepo);
+  if (!backend) {
+    return jsonResponse(404, {
+      code: "NOT_FOUND",
+      error: `no backend deploy record for ${backendRepo}`,
+    });
+  }
+  const image = backendImage || backend.current_image;
+
+  // frontend が当該 backend の consumer であることを確認しつつ、その
+  // prod_version を取り出す (= report 経路で frontend::<repo> を引く際の version)。
+  const compat = await computeCompatibility(
+    env.COMPAT_KV,
+    backendRepo,
+    backend.current_image,
+  );
+  const edge = compat.matrix.find((m) => m.frontend === frontend);
+  if (!edge) {
+    return jsonResponse(404, {
+      code: "FRONTEND_NOT_CONSUMER",
+      error: `${frontend} has no test history against ${backendRepo}`,
+    });
+  }
+
+  const dispatch: Dispatch = {
+    repo: frontend,
+    event_type: "release-wave-retest",
+    client_payload: {
+      // wave 非依存。consumer 側 retest 受けは wave_id を参照しないので省略する
+      // (= 既存 wave 版 dispatch との唯一の差分)。
+      backend_repo: backendRepo,
+      backend_image: image,
+      ...(edge.prod_version ? { prod_version: edge.prod_version } : {}),
+    },
+  };
+
+  const results = await dispatchAll(env, [dispatch]);
+  if (!(results.length > 0 && results[0]!.ok)) {
+    const err =
+      results.length > 0 && !results[0]!.ok ? results[0]!.error : "dispatch failed";
+    return jsonResponse(502, {
+      code: "DISPATCH_FAILED",
+      error: `failed to dispatch retest for ${frontend}: ${err}`,
+    });
+  }
+  return redirectToList();
 }
 
 // ----------------------------------------------------------------------------

--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -647,11 +647,12 @@ function renderGlobalCompatibilitySection(
  * global (wave 非依存) Compatibility グラフの直下に、untested edge
  * (backend × frontend) ごとの "Re-test" ボタングリッドを描画する (Refs #157)。
  *
- * 各 backend の `wave_id` を使って既存 `/api/release-wave/<wave_id>/retest` に
- * `frontend` を POST する (= 新 endpoint を作らず wave 詳細ページと同じ
- * handler / dispatch 経路を流用する)。`wave_id` を持たない backend
- * (= 単独 deploy で wave 未紐付け) の edge は disabled ボタンにし、
- * tooltip で理由を示す。
+ * global グラフ自体が wave 非依存なので、retest も wave 非依存の
+ * `/api/release-wave/retest-consumer` に統一して POST する。これにより backend
+ * が単独 deploy (wave 未紐付け = `wave_id` null) でも retest できる
+ * (旧実装は wave-bound endpoint しか無く no-wave backend のボタンを disabled に
+ * していた。Refs #137 (A))。`backend_repo` + `frontend` を hidden field で渡し、
+ * backend image は handler 側が `backend::<repo>.current_image` を採用する。
  *
  * JS 不使用 (form POST のみ) なので strict CSP `default-src 'none'` のまま動く。
  */
@@ -662,18 +663,14 @@ function renderGlobalRetestButtons(compat: WaveCompatibility): string {
     if (reds.length === 0) continue;
     const buttons = reds
       .map((m) => {
-        if (!b.wave_id) {
-          // wave 未紐付けの backend は既存 retest endpoint を呼べない。
-          return `<button type="button" class="warn" disabled
-              title="${escapeHtml(b.backend_repo)} は wave に紐付いていないため (単独 deploy)、ここからの retest 不可。該当 wave で再実行するか backend を wave 経由で deploy してください。">
-              Re-test ${escapeHtml(m.frontend)}
-            </button>`;
-        }
-        const action = encodeURIComponent(b.wave_id);
-        return `<form method="post" action="/api/release-wave/${action}/retest" style="display:inline; margin:0">
+        const waveNote = b.wave_id
+          ? ` (wave ${escapeHtml(b.wave_id)})`
+          : " (no wave)";
+        return `<form method="post" action="/api/release-wave/retest-consumer" style="display:inline; margin:0">
+            <input type="hidden" name="backend_repo" value="${escapeHtml(b.backend_repo)}">
             <input type="hidden" name="frontend" value="${escapeHtml(m.frontend)}">
             <button type="submit" class="warn"
-              title="Re-test ${escapeHtml(m.frontend)} against ${escapeHtml(b.backend_repo)} の現 image (wave ${escapeHtml(b.wave_id)})">
+              title="Re-test ${escapeHtml(m.frontend)} against ${escapeHtml(b.backend_repo)} の現 image${waveNote}">
               Re-test ${escapeHtml(m.frontend)}
             </button>
           </form>`;

--- a/test/release-wave/api.test.ts
+++ b/test/release-wave/api.test.ts
@@ -4,6 +4,7 @@ import {
   handleReleaseWaveRollback,
   handleReleaseWaveAbort,
   handleReleaseWaveRetest,
+  handleReleaseWaveRetestConsumer,
   handleReleaseWavePendingReleaseFlip,
   handleReleaseWaveTrafficRollback,
   handleReleaseWaveBackendRollback,
@@ -446,6 +447,150 @@ describe("handleReleaseWaveRetest", () => {
       String(c[0]).includes("/dispatches"),
     );
     expect(dispatchCall).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// /api/release-wave/retest-consumer  (Refs #157 / #137 — wave 非依存)
+// ============================================================================
+
+/** retest-consumer 用の env (hub は不要、COMPAT_KV のみ)。 */
+function retestConsumerEnv(compatKv?: KVNamespace): Env {
+  return {
+    RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({}) },
+    COMPAT_KV: compatKv,
+    CI_STATUS: memKv({ "auth-client-worker:gh-token": FRESH_TOKEN }),
+    INTERNAL_SHARED_SECRET: { get: async () => "secret" },
+  } as unknown as Env;
+}
+
+describe("handleReleaseWaveRetestConsumer", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns 405 on GET", async () => {
+    const env = retestConsumerEnv(redCompatKv());
+    const req = new Request(
+      "https://ci-dashboard.ippoan.org/api/release-wave/retest-consumer",
+      { method: "GET" },
+    );
+    const resp = await handleReleaseWaveRetestConsumer(req, env);
+    expect(resp.status).toBe(405);
+  });
+
+  it("returns 500 when COMPAT_KV unbound", async () => {
+    const env = retestConsumerEnv(undefined);
+    const resp = await handleReleaseWaveRetestConsumer(
+      postRequest("/api/release-wave/retest-consumer", {
+        formBody: { backend_repo: "ippoan/rust-alc-api", frontend: "ippoan/alc-app" },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(500);
+  });
+
+  it("returns 400 when backend_repo / frontend missing", async () => {
+    const env = retestConsumerEnv(redCompatKv());
+    const resp = await handleReleaseWaveRetestConsumer(
+      postRequest("/api/release-wave/retest-consumer", {
+        formBody: { backend_repo: "ippoan/rust-alc-api" },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(400);
+  });
+
+  it("returns 404 when backend has no deploy record", async () => {
+    const env = retestConsumerEnv(memKv());
+    const resp = await handleReleaseWaveRetestConsumer(
+      postRequest("/api/release-wave/retest-consumer", {
+        formBody: { backend_repo: "ippoan/ghost", frontend: "ippoan/alc-app" },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(404);
+  });
+
+  it("returns 404 when frontend is not a consumer of the backend", async () => {
+    const env = retestConsumerEnv(redCompatKv());
+    const resp = await handleReleaseWaveRetestConsumer(
+      postRequest("/api/release-wave/retest-consumer", {
+        formBody: { backend_repo: "ippoan/rust-alc-api", frontend: "ippoan/not-a-consumer" },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(404);
+  });
+
+  it("dispatches release-wave-retest WITHOUT wave_id for a no-wave backend and redirects to list", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    // redCompatKv() の backend record は wave_id: null (= 単独 deploy)。
+    const env = retestConsumerEnv(redCompatKv());
+    const resp = await handleReleaseWaveRetestConsumer(
+      postRequest("/api/release-wave/retest-consumer", {
+        formBody: { backend_repo: "ippoan/rust-alc-api", frontend: "ippoan/alc-app" },
+      }),
+      env,
+    );
+    // 完了後は一覧へ 303
+    expect(resp.status).toBe(303);
+    expect(resp.headers.get("Location")).toBe("/release-wave");
+    const dispatchCall = fetchSpy.mock.calls.find((c) =>
+      String(c[0]).includes("/repos/ippoan/alc-app/dispatches"),
+    );
+    expect(dispatchCall).toBeDefined();
+    const body = JSON.parse(dispatchCall![1].body);
+    expect(body.event_type).toBe("release-wave-retest");
+    // wave_id は載らない (= 唯一の差分)。
+    expect(body.client_payload.wave_id).toBeUndefined();
+    expect(body.client_payload).toMatchObject({
+      backend_repo: "ippoan/rust-alc-api",
+      backend_image: "cur-img",
+      prod_version: "v1.2.10",
+    });
+  });
+
+  it("uses the explicit backend_image form field when provided", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    const env = retestConsumerEnv(redCompatKv());
+    const resp = await handleReleaseWaveRetestConsumer(
+      postRequest("/api/release-wave/retest-consumer", {
+        formBody: {
+          backend_repo: "ippoan/rust-alc-api",
+          frontend: "ippoan/alc-app",
+          backend_image: "explicit-img",
+        },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(303);
+    const dispatchCall = fetchSpy.mock.calls.find((c) =>
+      String(c[0]).includes("/dispatches"),
+    );
+    const body = JSON.parse(dispatchCall![1].body);
+    expect(body.client_payload.backend_image).toBe("explicit-img");
+  });
+
+  it("returns 502 when the dispatch fails", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(new Response("boom", { status: 500 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    const env = retestConsumerEnv(redCompatKv());
+    const resp = await handleReleaseWaveRetestConsumer(
+      postRequest("/api/release-wave/retest-consumer", {
+        formBody: { backend_repo: "ippoan/rust-alc-api", frontend: "ippoan/alc-app" },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(502);
   });
 });
 

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -1068,7 +1068,7 @@ describe("handleReleaseWaveListPage global compat overlay", () => {
     expect(html.slice(Math.max(0, idx - 120), idx)).toContain("disabled");
   });
 
-  it("renders a per-untested-consumer Re-test button posting to the backend's wave retest endpoint", async () => {
+  it("renders a per-untested-consumer Re-test button posting to the wave-independent retest-consumer endpoint", async () => {
     const env = fakeEnv({
       listReturn: [],
       compatKv: memKv({
@@ -1097,13 +1097,14 @@ describe("handleReleaseWaveListPage global compat overlay", () => {
     });
     const html = await (await handleReleaseWaveListPage(env)).text();
     expect(html).toContain("Re-test untested consumers");
-    // backend record の wave_id を流用して既存 retest endpoint へ POST する
-    expect(html).toContain('action="/api/release-wave/w-backend/retest"');
+    // global グラフは wave 非依存なので retest-consumer へ POST する
+    expect(html).toContain('action="/api/release-wave/retest-consumer"');
+    expect(html).toContain('name="backend_repo" value="ippoan/rust-alc-api"');
     expect(html).toContain('name="frontend" value="ippoan/alc-app"');
     expect(html).toContain("Re-test ippoan/alc-app");
   });
 
-  it("disables the Re-test button when the backend has no wave_id (single deploy)", async () => {
+  it("renders an enabled Re-test button even when the backend has no wave_id (single deploy)", async () => {
     const env = fakeEnv({
       listReturn: [],
       compatKv: memKv({
@@ -1132,11 +1133,12 @@ describe("handleReleaseWaveListPage global compat overlay", () => {
     });
     const html = await (await handleReleaseWaveListPage(env)).text();
     expect(html).toContain("Re-test untested consumers");
-    // wave 未紐付けなので POST 先 form は出ず、disabled ボタンになる
-    expect(html).not.toContain("/retest");
+    // wave 未紐付けでも wave 非依存 endpoint へ POST できる (disabled にしない)
+    expect(html).toContain('action="/api/release-wave/retest-consumer"');
+    expect(html).toContain('name="backend_repo" value="ippoan/rust-alc-api"');
     const idx = html.indexOf("Re-test ippoan/alc-app");
     expect(idx).toBeGreaterThan(-1);
-    expect(html.slice(Math.max(0, idx - 250), idx)).toContain("disabled");
+    expect(html.slice(Math.max(0, idx - 250), idx)).not.toContain("disabled");
   });
 
   it("does not render the Re-test grid when all consumers are tested", async () => {


### PR DESCRIPTION
## 改善A: no-wave でも retest 可能に

`/release-wave` の global「Compatibility (all consumers)」グラフの retest ボタンは、backend が単独 deploy (= `backend::<repo>.wave_id` が null) だと wave-bound な `/api/release-wave/<wave_id>/retest` を呼べず disabled だった (PR #233 のフォールバック)。wave が無くても retest できるようにする。

### 実装

- **新 endpoint `POST /api/release-wave/retest-consumer`** (wave 非依存) を `src/release-wave/api.ts` に追加。
  - form field `backend_repo` + `frontend` (+ 任意 `backend_image`) を受ける。
  - `backend::<repo>` record を引き、`computeCompatibility` で consumer edge を検証 (グラフに無い edge への誤射出を防ぐ)。
  - frontend repo へ `release-wave-retest` を 1 件 `dispatchAll` で dispatch。client_payload は `{ backend_repo, backend_image, prod_version }` で、wave 版と同一 shape。**唯一の差分は `wave_id` を載せないこと**。
  - 404 (backend record 無し / frontend が consumer でない) / 400 (field 欠落) / 500 (KV unbound) / 502 (dispatch 失敗) を返す。成功時は `/release-wave` 一覧へ 303。
- **global グラフのボタンを全て新 endpoint に統一** (`src/release-wave/page.ts` `renderGlobalRetestButtons`)。global グラフ自体が wave 非依存なので、wave あり/なしで分岐せず `retest-consumer` に POST する。no-wave backend のボタンを disabled にする旧分岐を撤去 (= 押せるようになる)。
- routing を `src/index.ts` に追加。`retest-consumer` は静的 1 セグメントなので `:wave_id/retest` (2 セグメント) と衝突しない。

### consumer / ci-workflows 側の受け取り確認

`ippoan/ci-workflows` を調査した結果、**ci-workflows 側の修正は不要**:

- `release-wave-handler.yml` の event allowlist は stage/flip/rollback/traffic-rollback/backend-rollback のみで、**`release-wave-retest` を処理しない**。retest event は consumer repo 側の別 workflow が受ける設計 (frontend-ci を `compat_backend_image` 付きで呼ぶ) で、現状どの consumer repo にもその受け口は未配線 (= `release-wave-retest` は今のところ全 repo で未消費)。
- frontend-ci の retest 経路 (`compat_backend_image` input) と `report-frontend-compat` action は **`wave_id` を一切参照しない** (`backend_repo` / `backend_image` / `prod_version` のみ使う)。
- したがって wave_id を省いても既存 (wave 版) dispatch と等価に消費可能。no-wave 用の optional 化は ci-workflows 側に不要。

## 改善B: Start wave ボタン

改善A を確実に仕上げることを優先し、改善B は本 PR では見送り。理由と提案は本文末尾の「改善B について」を参照。

### 改善B について

`release_wave_start` 相当のロジックは `ReleaseWaveHub` DO (`src/release-wave/do.ts` の `createWave`) にあり、MCP tool `release_wave_start` から叩かれている。global グラフから「backend + untested consumers を一括 wave 化」する Start wave フォームを足すには:

- 各参加 repo の最新 `target_tag` / `head_sha` を GitHub から解決 (or フォーム入力) する route を `api.ts` に追加し `createWave` を呼ぶ。
- どの repo を wave に含めるか (= backend + どの consumer) の選定 UI と、`release-wave-targets.yaml` 参加 repo との整合が設計判断を要する。

スコープと設計判断の大きさから別 issue / 別 PR が妥当。改善A だけで「retest できない」課題は解消する。

## テスト

- `test/release-wave/api.test.ts`: `handleReleaseWaveRetestConsumer` の 8 ケース (405 / 500 / 400 / 404×2 / no-wave dispatch (wave_id 非載) / explicit backend_image / 502) を追加。実 dispatch は `fetch` を stub。
- `test/release-wave/page.test.ts`: global retest ボタンが `retest-consumer` へ POST し、no-wave backend でも disabled にならないことを検証するよう既存 2 ケースを更新。

ローカルは `@ippoan/auth-client-worker` (GitHub Packages, token 必須) が install できないため typecheck/test は CI に委譲。

Refs #137
Refs #157

---
_Generated by [Claude Code](https://claude.ai/code/session_012zLhVkMuDnAyBWZNLnuorh)_