### PR TITLE
feat(release-wave): add Start wave UI to /release-wave

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ import {
   handleReleaseWaveTrafficRollback,
   handleReleaseWaveBackendRollback,
 } from "./release-wave/api";
+import { handleReleaseWaveStart } from "./release-wave/start";
 import {
   handlePwaManifest,
   handlePwaServiceWorker,
@@ -273,6 +274,15 @@ app.get("/backend-current-image", (c) =>
 app.get("/release-wave", (c) => handleReleaseWaveListPageWithRepoStatus(c.env));
 app.get("/release-wave/:wave_id", (c) =>
   handleReleaseWaveDetailPage(c.env, c.req.param("wave_id")),
+);
+// Start wave (Refs #137 / #157 改善B)。/release-wave の Start wave フォームが
+// 叩く。form field `wave_id` / `flip_policy` / `note` / `include` (複数) /
+// `target_tag__<repo>` / `require_compatibility` (複数)。各 repo の head_sha は
+// default branch HEAD を server 側で取得して createWave を起こす。
+// 静的セグメント `start` は下の `:wave_id/<action>` (2 セグメント) と
+// セグメント数が違うため衝突しない。
+app.post("/api/release-wave/start", (c) =>
+  handleReleaseWaveStart(c.req.raw, c.env),
 );
 // Action buttons (state 遷移を起こす side-effectful POST)。完了後は
 // 303 で詳細ページに redirect する。

--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -24,6 +24,7 @@ import {
 } from "./repo-release-status";
 import { computeGlobalCompatibility, type WaveCompatibility } from "./compat";
 import { parseTaglessRepos } from "../tagless-repos";
+import { renderStartWaveSection, injectStartWaveSection } from "./start";
 import {
   getTrafficForRepos,
   type TrafficRecord,
@@ -524,6 +525,10 @@ export async function handleReleaseWaveListPageWithRepoStatus(
   const section = renderRepoReleaseStatusSection(statuses);
   let html = await res.text();
   html = injectRepoStatusSection(html, section);
+
+  // Start wave フォーム (Refs #137 / #157 改善B)。tagless でない監視対象 repo を
+  // 候補に出し、画面から wave を start できるようにする。h1 直下に注入。
+  html = injectStartWaveSection(html, renderStartWaveSection(statuses));
 
   // Compatibility (all consumers) グラフ内 repo に Tag Release ボタンを足す。
   if (env.COMPAT_KV) {

--- a/src/release-wave/start.ts
+++ b/src/release-wave/start.ts
@@ -1,0 +1,335 @@
+/**
+ * /release-wave の「Start wave」UI と POST endpoint。
+ *
+ * backend (rust-alc-api) + consumer frontend を 1 wave にまとめて開始し、
+ * 同時 flip できるようにする画面側の入口 (Refs #137 / #157 改善B)。
+ * これまで wave は `release_wave_start` MCP tool でしか開始できず、
+ * 画面から start する導線が無かった。
+ *
+ * 設計:
+ *   - 参加候補 repo は `getRepoReleaseStatuses` が discover する監視対象 repo
+ *     (Hub status / direct-push allowlist / TAGLESS_REPOS / compat グラフ) を
+ *     流用する。archived / tagless は除外。
+ *   - 各候補をチェックボックスで選択し、repo ごとに target_tag をフォーム入力する。
+ *     target_tag は妥協入力 (= 自動採番せず operator が打つ tag を手で書く)。
+ *   - 各 repo の head_sha は POST 受信時に default branch HEAD を GitHub から
+ *     取得する (= フォームには出さない)。
+ *   - flip_policy は安全側の `manual-approval` を default にする (= stage 後に
+ *     approve を要求)。`auto` も選べる。
+ *   - 認証は CF Access edge に委譲 (= 他の action と同じトラストモデル)。
+ *
+ * CSP は page.ts の strict 設定 (`script-src 'none'`, `form-action 'self'`) なので、
+ * 素の <form method="post"> + inline style のみで構成する (JS 無し)。
+ */
+
+import type { Env } from "../index";
+import type { ReleaseWaveHub, RpcResult } from "./do";
+import type { FlipPolicy, WaveState } from "./types";
+import { parseRepo, tokenForOrg, githubApi } from "../github-api";
+import { cachedRepoMeta } from "../release-cache";
+import {
+  getRepoReleaseStatuses,
+  type RepoReleaseStatus,
+} from "./repo-release-status";
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+function hubStub(env: Env): DurableObjectStub<ReleaseWaveHub> {
+  const id = env.RELEASE_WAVE_HUB.idFromName("singleton");
+  return env.RELEASE_WAVE_HUB.get(id) as DurableObjectStub<ReleaseWaveHub>;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body, null, 2), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** wave start 後は詳細ページに 303 redirect。 */
+function redirectToDetail(wave_id: string): Response {
+  return new Response(null, {
+    status: 303,
+    headers: { Location: `/release-wave/${encodeURIComponent(wave_id)}` },
+  });
+}
+
+// ----------------------------------------------------------------------------
+// SSR: Start wave フォーム section
+// ----------------------------------------------------------------------------
+
+/** default wave_id 候補 (操作者が上書き可)。`wave_YYYY_MM_DD_HHMM` (UTC)。 */
+export function defaultWaveId(now: Date = new Date()): string {
+  const p = (n: number) => String(n).padStart(2, "0");
+  return (
+    `wave_${now.getUTCFullYear()}_${p(now.getUTCMonth() + 1)}_${p(now.getUTCDate())}` +
+    `_${p(now.getUTCHours())}${p(now.getUTCMinutes())}`
+  );
+}
+
+/**
+ * Start wave フォームを HTML で返す。
+ *
+ * 候補 repo = tagless でない監視対象 repo (= getRepoReleaseStatuses の結果)。
+ * tagless はそもそも tag を打たない方針なので wave に乗せられない。
+ * 候補が 0 件 (= CI_STATUS 未 bind / 取得失敗) なら "" を返し、呼び出し側で
+ * section を落とす。
+ */
+export function renderStartWaveSection(
+  statuses: RepoReleaseStatus[],
+  now: Date = new Date(),
+): string {
+  const candidates = statuses.filter((s) => !s.tagless && s.behind >= 0);
+  if (candidates.length === 0) return "";
+
+  const rows = candidates
+    .map((s) => {
+      // target_tag の placeholder は最新 tag。未tag は v0.1.0 を例示。
+      const placeholder = s.latestTag ?? "v0.1.0";
+      const id = `repo_${s.repo.replace(/[^a-zA-Z0-9]/g, "_")}`;
+      const tagHint = s.hasTag
+        ? `<span class="meta">latest: ${escapeHtml(s.latestTag ?? "")}</span>`
+        : `<span class="meta">未tag</span>`;
+      return `
+        <tr>
+          <td>
+            <input type="checkbox" name="include" value="${escapeHtml(s.repo)}" id="${escapeHtml(id)}">
+            <label for="${escapeHtml(id)}">${escapeHtml(s.repo)}</label>
+          </td>
+          <td>${tagHint}</td>
+          <td>
+            <input type="text" name="target_tag__${escapeHtml(s.repo)}"
+              placeholder="${escapeHtml(placeholder)}"
+              style="width:140px">
+          </td>
+          <td>
+            <input type="checkbox" name="require_compatibility" value="${escapeHtml(s.repo)}"
+              title="backend repo の場合: consuming frontend が未 test なら approve を拒否する">
+          </td>
+        </tr>`;
+    })
+    .join("");
+
+  return `
+    <div class="section">
+      <h2>Start wave</h2>
+      <p class="meta">backend と consumer frontend をまとめて 1 wave にして同時 flip する。
+        参加 repo をチェックし、各 repo に cut する target tag を入力する。
+        head_sha は start 時に default branch HEAD を自動取得する。
+        flip_policy は安全側の <strong>manual-approval</strong> が default
+        (= stage 後に approve が必要)。</p>
+      <form method="post" action="/api/release-wave/start">
+        <div style="margin:8px 0">
+          <label for="wave_id">Wave ID</label>
+          <input type="text" name="wave_id" id="wave_id"
+            value="${escapeHtml(defaultWaveId(now))}" style="width:260px" required>
+          &nbsp;&nbsp;
+          <label for="flip_policy">Flip policy</label>
+          <select name="flip_policy" id="flip_policy">
+            <option value="manual-approval" selected>manual-approval</option>
+            <option value="auto">auto</option>
+          </select>
+        </div>
+        <div style="margin:8px 0">
+          <label for="note">Note</label>
+          <input type="text" name="note" id="note" placeholder="release theme (optional)"
+            style="width:420px">
+        </div>
+        <table>
+          <thead>
+            <tr>
+              <th>Repo (include)</th>
+              <th>Tag</th>
+              <th>Target tag</th>
+              <th title="backend repo: consuming frontend 未 test 時に approve を拒否">require_compat</th>
+            </tr>
+          </thead>
+          <tbody>${rows}</tbody>
+        </table>
+        <div style="margin:10px 0">
+          <button type="submit">Start wave</button>
+        </div>
+      </form>
+    </div>`;
+}
+
+/**
+ * レンダリング済み一覧 HTML に Start wave section を注入する。
+ *
+ * 配置: 既存 wave 一覧テーブル (`<h1>Release Waves</h1>` 直下に Compatibility /
+ * Pending releases / Repo リリース状況 section が続く) の **末尾**、wave 一覧
+ * テーブルの直前に入れたいが、テーブルは marker が無いので簡便に h1 直後に置く。
+ * → start フォームを一番上 (h1 直後) に出し、その下に既存 section が続く。
+ */
+export function injectStartWaveSection(html: string, section: string): string {
+  if (!section) return html;
+  const h1Marker = "<h1>Release Waves</h1>";
+  const h1 = html.indexOf(h1Marker);
+  if (h1 !== -1) {
+    // h1 の直後に続く <p class="meta"> 説明文の終わりまで読み飛ばして入れる。
+    const at = h1 + h1Marker.length;
+    return html.slice(0, at) + "\n    " + section + html.slice(at);
+  }
+  return html.replace("</body>", `${section}\n</body>`);
+}
+
+// ----------------------------------------------------------------------------
+// POST /api/release-wave/start
+// ----------------------------------------------------------------------------
+
+/**
+ * default branch HEAD の commit sha を取得する。失敗時は null。
+ *
+ * `GET /repos/{owner}/{name}` で default_branch を引き (cachedRepoMeta、KV cache)、
+ * `GET /repos/{owner}/{name}/commits/{branch}` で HEAD commit の sha を取る。
+ */
+async function fetchHeadSha(
+  env: Env,
+  repo: string,
+): Promise<string | null> {
+  try {
+    const { owner, repo: name } = parseRepo(repo);
+    const token = await tokenForOrg(env, owner);
+    const meta = await cachedRepoMeta(token, env.CI_STATUS, owner, name);
+    const commit = await githubApi<{ sha: string }>(
+      token,
+      "GET",
+      `/repos/${owner}/${name}/commits/${encodeURIComponent(meta.default_branch)}`,
+    );
+    return commit.sha || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Start wave フォームの submit を受け、createWave を起こす。
+ *
+ * form fields:
+ *   - `wave_id`            必須。wave 識別子。
+ *   - `flip_policy`        `manual-approval` | `auto`。既定 manual-approval。
+ *   - `note`              任意。
+ *   - `include`           checkbox (複数)。参加させる repo の "owner/name"。
+ *   - `target_tag__<repo>` 各参加 repo に cut する tag。
+ *   - `require_compatibility` checkbox (複数)。compat gate を立てる backend repo。
+ *
+ * head_sha は各 repo の default branch HEAD を取得して埋める。取得失敗 repo は
+ * その旨を 400 で返す (= sha 無しで start すると flip dispatch の checkout ref が
+ * 壊れるため、ここで弾く)。
+ * 成功すると wave 詳細ページに 303 redirect。createWave が ALREADY_EXISTS /
+ * WAVE_IN_PROGRESS 等を返したら対応する HTTP status の JSON を返す。
+ */
+export async function handleReleaseWaveStart(
+  req: Request,
+  env: Env,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return jsonResponse(405, { code: "METHOD_NOT_ALLOWED", error: "use POST" });
+  }
+
+  let form: FormData;
+  try {
+    form = await req.formData();
+  } catch {
+    return jsonResponse(400, {
+      code: "BAD_REQUEST",
+      error: "expected form-encoded body",
+    });
+  }
+
+  const waveId = String(form.get("wave_id") ?? "").trim();
+  if (!waveId) {
+    return jsonResponse(400, {
+      code: "BAD_REQUEST",
+      error: "form field 'wave_id' is required",
+    });
+  }
+
+  const flipRaw = String(form.get("flip_policy") ?? "manual-approval").trim();
+  const flip_policy: FlipPolicy =
+    flipRaw === "auto" ? "auto" : "manual-approval";
+  const note = String(form.get("note") ?? "").trim();
+
+  const includes = form
+    .getAll("include")
+    .map((v) => String(v).trim())
+    .filter((v) => v.length > 0);
+  if (includes.length === 0) {
+    return jsonResponse(400, {
+      code: "BAD_REQUEST",
+      error: "select at least one repo (form field 'include')",
+    });
+  }
+
+  const requireCompat = new Set(
+    form.getAll("require_compatibility").map((v) => String(v).trim()),
+  );
+
+  // 各参加 repo の target_tag を引き、未入力なら 400。
+  const repos: Array<{
+    repo: string;
+    target_tag: string;
+    head_sha: string;
+    require_compatibility?: boolean;
+  }> = [];
+  const missingTag: string[] = [];
+  const missingSha: string[] = [];
+
+  for (const repo of includes) {
+    const tag = String(form.get(`target_tag__${repo}`) ?? "").trim();
+    if (!tag) {
+      missingTag.push(repo);
+      continue;
+    }
+    const head_sha = await fetchHeadSha(env, repo);
+    if (!head_sha) {
+      missingSha.push(repo);
+      continue;
+    }
+    repos.push({
+      repo,
+      target_tag: tag,
+      head_sha,
+      ...(requireCompat.has(repo) ? { require_compatibility: true } : {}),
+    });
+  }
+
+  if (missingTag.length > 0) {
+    return jsonResponse(400, {
+      code: "MISSING_TARGET_TAG",
+      error: `target_tag required for: ${missingTag.join(", ")}`,
+    });
+  }
+  if (missingSha.length > 0) {
+    return jsonResponse(502, {
+      code: "HEAD_SHA_FETCH_FAILED",
+      error: `failed to resolve default-branch HEAD sha for: ${missingSha.join(", ")}`,
+    });
+  }
+
+  const result = (await hubStub(env).start({
+    wave_id: waveId,
+    flip_policy,
+    note,
+    repos,
+  })) as RpcResult<WaveState>;
+
+  if (!result.ok) {
+    const status =
+      result.code === "ALREADY_EXISTS"
+        ? 409
+        : result.code === "WAVE_IN_PROGRESS"
+          ? 409
+          : 400;
+    return jsonResponse(status, { code: result.code, error: result.error });
+  }
+
+  return redirectToDetail(waveId);
+}

--- a/test/release-wave/start.test.ts
+++ b/test/release-wave/start.test.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  renderStartWaveSection,
+  injectStartWaveSection,
+  defaultWaveId,
+  handleReleaseWaveStart,
+} from "../../src/release-wave/start";
+import type { Env } from "../../src/index";
+import type { ReleaseWaveHub } from "../../src/release-wave/do";
+import type { RepoReleaseStatus } from "../../src/release-wave/repo-release-status";
+
+/** 簡易 in-memory KV (token cache / repo-meta cache 用)。 */
+function memKv(seed: Record<string, unknown> = {}): KVNamespace {
+  const store = new Map<string, string>(
+    Object.entries(seed).map(([k, v]) => [k, JSON.stringify(v)]),
+  );
+  return {
+    async get(key: string, type?: string) {
+      const raw = store.get(key);
+      if (raw === undefined) return null;
+      return type === "json" ? JSON.parse(raw) : raw;
+    },
+    async put(key: string, value: string) {
+      store.set(key, value);
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+    async list({ prefix = "" }: { prefix?: string } = {}) {
+      const keys = [...store.keys()]
+        .filter((k) => k.startsWith(prefix))
+        .map((name) => ({ name }));
+      return { keys, list_complete: true, cacheStatus: null };
+    },
+  } as unknown as KVNamespace;
+}
+
+const FRESH_TOKEN = {
+  token: "ghs_start_token",
+  expires_at_ms: Date.now() + 3600_000,
+};
+
+function status(
+  repo: string,
+  over: Partial<RepoReleaseStatus> = {},
+): RepoReleaseStatus {
+  return {
+    repo,
+    latestTag: "v1.0.0",
+    hasTag: true,
+    behind: 0,
+    tagless: false,
+    ...over,
+  };
+}
+
+/** start spy を持つ fake env。CI_STATUS に token + repo-meta cache を仕込む。 */
+function fakeEnv(opts: {
+  startReturn?: unknown;
+  ciStatusSeed?: Record<string, unknown>;
+} = {}): { env: Env; start: ReturnType<typeof vi.fn> } {
+  const start =
+    (opts.startReturn !== undefined
+      ? vi.fn().mockResolvedValue(opts.startReturn)
+      : vi.fn().mockResolvedValue({ ok: true, data: { wave_id: "w1" } }));
+  const hub = { start } as unknown as ReleaseWaveHub;
+  const env = {
+    RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => hub },
+    CI_STATUS: memKv({
+      "auth-client-worker:gh-token": FRESH_TOKEN,
+      ...(opts.ciStatusSeed ?? {}),
+    }),
+  } as unknown as Env;
+  return { env, start };
+}
+
+/**
+ * GitHub REST を URL で振り分ける fetch mock:
+ *   - `GET /repos/{o}/{n}`               → repo-meta { default_branch: "main" }
+ *   - `GET /repos/{o}/{n}/commits/{ref}` → { sha } (repo 名で sha を変える)
+ * `shaFor` で repo 名 → sha を制御。`commitsStatus` で commits 応答 status を上書き。
+ */
+function ghFetch(opts: {
+  shaFor?: (url: string) => string;
+  commitsStatus?: number;
+} = {}): ReturnType<typeof vi.fn> {
+  return vi.fn(async (url: string) => {
+    if (url.includes("/commits/")) {
+      const status = opts.commitsStatus ?? 200;
+      if (status !== 200) return new Response("err", { status });
+      const sha = opts.shaFor ? opts.shaFor(url) : "sha_head";
+      return new Response(JSON.stringify({ sha }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    // repo-meta
+    return new Response(JSON.stringify({ default_branch: "main" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+}
+
+function postRequest(formBody?: Record<string, string | string[]>): Request {
+  const params = new URLSearchParams();
+  if (formBody) {
+    for (const [k, v] of Object.entries(formBody)) {
+      if (Array.isArray(v)) for (const item of v) params.append(k, item);
+      else params.set(k, v);
+    }
+  }
+  return new Request("https://ci-dashboard.ippoan.org/api/release-wave/start", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params.toString(),
+  });
+}
+
+// ============================================================================
+// SSR helpers
+// ============================================================================
+
+describe("defaultWaveId", () => {
+  it("formats wave_YYYY_MM_DD_HHMM in UTC", () => {
+    const id = defaultWaveId(new Date("2026-06-03T04:05:00Z"));
+    expect(id).toBe("wave_2026_06_03_0405");
+  });
+});
+
+describe("renderStartWaveSection", () => {
+  it("renders a form with a row per non-tagless repo", () => {
+    const html = renderStartWaveSection([
+      status("ippoan/rust-alc-api"),
+      status("ippoan/alc-app", { hasTag: false, latestTag: null }),
+    ]);
+    expect(html).toContain('action="/api/release-wave/start"');
+    expect(html).toContain("ippoan/rust-alc-api");
+    expect(html).toContain("ippoan/alc-app");
+    // checkbox + target_tag input per repo
+    expect(html).toContain('name="include" value="ippoan/rust-alc-api"');
+    expect(html).toContain('name="target_tag__ippoan/rust-alc-api"');
+    // manual-approval is the default selected option
+    expect(html).toContain('value="manual-approval" selected');
+  });
+
+  it("excludes tagless repos and fetch-failed repos", () => {
+    const html = renderStartWaveSection([
+      status("ippoan/tagless-one", { tagless: true }),
+      status("ippoan/broken", { behind: -1 }),
+    ]);
+    // both candidates filtered out → empty section
+    expect(html).toBe("");
+  });
+
+  it("escapes repo names", () => {
+    const html = renderStartWaveSection([status('ippoan/x"y')]);
+    expect(html).not.toContain('value="ippoan/x"y"');
+    expect(html).toContain("&quot;");
+  });
+});
+
+describe("injectStartWaveSection", () => {
+  it("inserts after the h1 marker", () => {
+    const html = "<body><h1>Release Waves</h1><p>x</p></body>";
+    const out = injectStartWaveSection(html, "<div>START</div>");
+    expect(out.indexOf("START")).toBeGreaterThan(out.indexOf("Release Waves"));
+    expect(out.indexOf("START")).toBeLessThan(out.indexOf("<p>x</p>"));
+  });
+
+  it("falls back to before </body> when h1 missing", () => {
+    const out = injectStartWaveSection("<body>hi</body>", "<div>S</div>");
+    expect(out).toContain("<div>S</div>\n</body>");
+  });
+
+  it("is a no-op for empty section", () => {
+    const html = "<h1>Release Waves</h1>";
+    expect(injectStartWaveSection(html, "")).toBe(html);
+  });
+});
+
+// ============================================================================
+// POST /api/release-wave/start
+// ============================================================================
+
+describe("handleReleaseWaveStart", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns 405 on GET", async () => {
+    const { env } = fakeEnv();
+    const req = new Request(
+      "https://ci-dashboard.ippoan.org/api/release-wave/start",
+      { method: "GET" },
+    );
+    const resp = await handleReleaseWaveStart(req, env);
+    expect(resp.status).toBe(405);
+  });
+
+  it("400 when wave_id missing", async () => {
+    const { env, start } = fakeEnv();
+    const resp = await handleReleaseWaveStart(postRequest({}), env);
+    expect(resp.status).toBe(400);
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it("400 when no repo selected", async () => {
+    const { env, start } = fakeEnv();
+    const resp = await handleReleaseWaveStart(
+      postRequest({ wave_id: "w1" }),
+      env,
+    );
+    expect(resp.status).toBe(400);
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it("400 when a selected repo has no target_tag", async () => {
+    const { env, start } = fakeEnv();
+    const resp = await handleReleaseWaveStart(
+      postRequest({ wave_id: "w1", include: "ippoan/rust-alc-api" }),
+      env,
+    );
+    expect(resp.status).toBe(400);
+    const body = await resp.json<{ code: string }>();
+    expect(body.code).toBe("MISSING_TARGET_TAG");
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it("502 when HEAD sha fetch fails", async () => {
+    const { env, start } = fakeEnv();
+    vi.stubGlobal("fetch", ghFetch({ commitsStatus: 500 }));
+    const resp = await handleReleaseWaveStart(
+      postRequest({
+        wave_id: "w1",
+        include: "ippoan/rust-alc-api",
+        "target_tag__ippoan/rust-alc-api": "v1.2.0",
+      }),
+      env,
+    );
+    expect(resp.status).toBe(502);
+    const body = await resp.json<{ code: string }>();
+    expect(body.code).toBe("HEAD_SHA_FETCH_FAILED");
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it("calls hub.start with resolved head_sha and 303-redirects", async () => {
+    const { env, start } = fakeEnv();
+    vi.stubGlobal(
+      "fetch",
+      ghFetch({
+        shaFor: (url) =>
+          url.includes("alc-app") ? "sha_frontend" : "sha_backend",
+      }),
+    );
+
+    const resp = await handleReleaseWaveStart(
+      postRequest({
+        wave_id: "wave_x",
+        flip_policy: "manual-approval",
+        note: "theme",
+        include: ["ippoan/rust-alc-api", "ippoan/alc-app"],
+        "target_tag__ippoan/rust-alc-api": "v1.2.0",
+        "target_tag__ippoan/alc-app": "v3.0.0",
+        require_compatibility: "ippoan/rust-alc-api",
+      }),
+      env,
+    );
+
+    expect(resp.status).toBe(303);
+    expect(resp.headers.get("Location")).toBe("/release-wave/wave_x");
+    expect(start).toHaveBeenCalledTimes(1);
+    const arg = start.mock.calls[0]![0];
+    expect(arg.wave_id).toBe("wave_x");
+    expect(arg.flip_policy).toBe("manual-approval");
+    expect(arg.note).toBe("theme");
+    expect(arg.repos).toEqual([
+      {
+        repo: "ippoan/rust-alc-api",
+        target_tag: "v1.2.0",
+        head_sha: "sha_backend",
+        require_compatibility: true,
+      },
+      {
+        repo: "ippoan/alc-app",
+        target_tag: "v3.0.0",
+        head_sha: "sha_frontend",
+      },
+    ]);
+  });
+
+  it("defaults invalid flip_policy to manual-approval", async () => {
+    const { env, start } = fakeEnv();
+    vi.stubGlobal("fetch", ghFetch());
+    await handleReleaseWaveStart(
+      postRequest({
+        wave_id: "w1",
+        flip_policy: "garbage",
+        include: "ippoan/rust-alc-api",
+        "target_tag__ippoan/rust-alc-api": "v1.0.0",
+      }),
+      env,
+    );
+    expect(start.mock.calls[0]![0].flip_policy).toBe("manual-approval");
+  });
+
+  it("maps ALREADY_EXISTS to 409", async () => {
+    const { env } = fakeEnv({
+      startReturn: {
+        ok: false,
+        code: "ALREADY_EXISTS",
+        error: "exists",
+      },
+    });
+    vi.stubGlobal("fetch", ghFetch());
+    const resp = await handleReleaseWaveStart(
+      postRequest({
+        wave_id: "dup",
+        include: "ippoan/rust-alc-api",
+        "target_tag__ippoan/rust-alc-api": "v1.0.0",
+      }),
+      env,
+    );
+    expect(resp.status).toBe(409);
+  });
+
+  it("maps WAVE_IN_PROGRESS to 409", async () => {
+    const { env } = fakeEnv({
+      startReturn: {
+        ok: false,
+        code: "WAVE_IN_PROGRESS",
+        error: "busy",
+      },
+    });
+    vi.stubGlobal("fetch", ghFetch());
+    const resp = await handleReleaseWaveStart(
+      postRequest({
+        wave_id: "w2",
+        include: "ippoan/rust-alc-api",
+        "target_tag__ippoan/rust-alc-api": "v1.0.0",
+      }),
+      env,
+    );
+    expect(resp.status).toBe(409);
+  });
+});


### PR DESCRIPTION
## 概要

`/release-wave` ページに **Start wave** フォームを追加し、backend (rust-alc-api) と consumer frontend を 1 wave にまとめて開始 → 同時 flip できる画面導線を作る。これまで wave は `release_wave_start` MCP tool 経由でしか開始できず、画面から start する手段が無かった (PR #234 で deferred した改善B)。

## 実装

- **`src/release-wave/start.ts`** (新規):
  - `renderStartWaveSection(statuses)` — Start wave フォームの SSR。参加候補 repo は `getRepoReleaseStatuses` が discover する監視対象 repo を流用 (archived / tagless / 取得失敗は除外)。checkbox で選択し、repo ごとに `target_tag` をフォーム入力する。`require_compatibility` checkbox も用意 (backend repo の compat gate 用)。
  - `defaultWaveId()` — `wave_YYYY_MM_DD_HHMM` (UTC) の wave_id 候補を初期値に出す (operator 上書き可)。
  - `injectStartWaveSection()` — レンダリング済み一覧 HTML の `<h1>` 直下に section を string 注入。
  - `handleReleaseWaveStart(req, env)` — POST handler。各参加 repo の `head_sha` を **default branch HEAD** から server 側取得 (`cachedRepoMeta` + `GET /repos/.../commits/{branch}`)。`target_tag` 未入力は 400、HEAD sha 取得失敗は 502 で弾いてから `ReleaseWaveHub.start()` (= `createWave`) を呼ぶ。成功で wave 詳細へ 303。`ALREADY_EXISTS` / `WAVE_IN_PROGRESS` は 409。
- **`src/index.ts`**: `POST /api/release-wave/start` を登録 (静的セグメントなので `:wave_id/<action>` と衝突しない)。
- **`src/release-wave/repo-status-section.ts`**: 一覧ページ wrapper に Start wave section の注入を追加。

## 設計上の制約 / 妥協

- `flip_policy` は安全側の **manual-approval** を default にした (= stage 後に approve が必要)。`auto` も選べる。
- `target_tag` は **手入力** (自動採番しない)。最新 tag を placeholder に出すだけ。
- 参加候補は監視対象 repo の discover 結果。`config/release-wave-targets.yaml` (ci-workflows 側) は参照していない。
- CSP が strict (`script-src 'none'`, `form-action 'self'`) なので、素の `<form method="post">` のみで構成 (JS 無し)。
- `head_sha` は 1 repo ずつ直列に GitHub fetch する (= 参加 repo が多いと遅い可能性)。N=10 程度なら許容。

## テスト

- **`test/release-wave/start.test.ts`**: `hub.start` を mock + global `fetch` を stub し、SSR helper と POST route の**ロジックのみ**を検証。実 `createWave` / DO は起こさない。SSR (form / 候補除外 / escape)、wave_id・target_tag・repo 未選択の 400、HEAD sha 失敗の 502、resolved head_sha 付き start 呼び出し + 303、flip_policy 既定化、`ALREADY_EXISTS` / `WAVE_IN_PROGRESS` の 409 を網羅。

ローカルは `@ippoan/*` GitHub Packages の install に token が要り install 不可のため、typecheck / test は CI に委譲する。`src/release-wave/start.ts` 単体の `tsc` (module-resolution noise 除外) は型エラー無しを確認済み。

Refs ippoan/ci-dashboard#137
Refs ippoan/ci-dashboard#157

---
_Generated by [Claude Code](https://claude.ai/code/session_012zLhVkMuDnAyBWZNLnuorh)_