### PR TITLE
feat(release-wave): prefill Start wave target_tag with latest stable +1

### DIFF
--- a/src/release-helpers.ts
+++ b/src/release-helpers.ts
@@ -79,6 +79,43 @@ export function isSemverTag(tag: string): boolean {
   return SEMVER_RE.test(tag);
 }
 
+// A *stable* release tag: `v?MAJOR.MINOR.PATCH` with no prerelease/build
+// suffix. Anchored at end so `v0.5.99-wave-test-08`, `v1.2.3-dev`, `v1.2.3-rc.1`
+// etc. are rejected — those must never be treated as the latest stable release
+// when prefilling the next target tag (a `-wave-test-NN` tag slipping through
+// here is exactly what polluted the npm `latest` dist-tag before). Returns the
+// parsed components (and whether the tag carried a leading `v`), or null for
+// non-stable / non-semver input.
+const STABLE_SEMVER_RE = /^(v?)(\d+)\.(\d+)\.(\d+)$/;
+
+export interface ParsedSemver {
+  hasV: boolean;
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+export function parseStableSemver(tag: string): ParsedSemver | null {
+  const m = tag.trim().match(STABLE_SEMVER_RE);
+  if (!m) return null;
+  return {
+    hasV: m[1] === "v",
+    major: Number(m[2]),
+    minor: Number(m[3]),
+    patch: Number(m[4]),
+  };
+}
+
+// Given a stable semver tag, return the same tag with patch incremented by one
+// (preserving the `v` prefix), e.g. `v0.0.76 -> v0.0.77`, `v0.2.51 -> v0.2.52`,
+// `1.4.0 -> 1.4.1`. Returns null when `tag` is not a stable semver (prerelease
+// suffix, missing component, or junk) — callers fall back to an empty prefill.
+export function nextPatchTag(tag: string): string | null {
+  const p = parseStableSemver(tag);
+  if (!p) return null;
+  return `${p.hasV ? "v" : ""}${p.major}.${p.minor}.${p.patch + 1}`;
+}
+
 function compareTagsDesc(a: string, b: string): number {
   const ma = a.match(SEMVER_RE);
   const mb = b.match(SEMVER_RE);

--- a/src/release-wave/start.ts
+++ b/src/release-wave/start.ts
@@ -31,6 +31,7 @@ import {
   getRepoReleaseStatuses,
   type RepoReleaseStatus,
 } from "./repo-release-status";
+import { nextPatchTag } from "../release-helpers";
 
 function escapeHtml(s: string): string {
   return s
@@ -91,7 +92,13 @@ export function renderStartWaveSection(
 
   const rows = candidates
     .map((s) => {
-      // target_tag の placeholder は最新 tag。未tag は v0.1.0 を例示。
+      // target_tag の prefill: 現 stable latest tag を patch +1 した値を value に
+      // 入れておく (= 手入力不要 + 異常 tag 防止)。s.latestTag は sortSemverDesc
+      // 由来で prerelease (`-wave-test-NN` / `-dev` / `-rc` 等) を含み得るが、
+      // nextPatchTag が stable semver 以外を null にするので prerelease は自動で
+      // 除外され value 空になる。value が無い (未tag / prerelease のみ) repo は
+      // 従来どおり placeholder のみ (operator が手で打つ)。
+      const prefill = s.latestTag ? (nextPatchTag(s.latestTag) ?? "") : "";
       const placeholder = s.latestTag ?? "v0.1.0";
       const id = `repo_${s.repo.replace(/[^a-zA-Z0-9]/g, "_")}`;
       const tagHint = s.hasTag
@@ -106,6 +113,7 @@ export function renderStartWaveSection(
           <td>${tagHint}</td>
           <td>
             <input type="text" name="target_tag__${escapeHtml(s.repo)}"
+              value="${escapeHtml(prefill)}"
               placeholder="${escapeHtml(placeholder)}"
               style="width:140px">
           </td>

--- a/test/release-helpers.test.ts
+++ b/test/release-helpers.test.ts
@@ -7,6 +7,8 @@ import {
   isSemverTag,
   previousTag,
   computeWarnings,
+  parseStableSemver,
+  nextPatchTag,
 } from "../src/release-helpers";
 
 describe("extractRefIssues", () => {
@@ -166,5 +168,61 @@ describe("computeWarnings", () => {
   it("closed state remains the sole warning regardless of labels", () => {
     const w = computeWarnings({ state: "closed", labels: ["bug", "regression"] });
     expect(w).toEqual(["already closed"]);
+  });
+});
+
+describe("parseStableSemver", () => {
+  it("parses v-prefixed and bare stable semver", () => {
+    expect(parseStableSemver("v0.0.76")).toEqual({
+      hasV: true,
+      major: 0,
+      minor: 0,
+      patch: 76,
+    });
+    expect(parseStableSemver("1.4.0")).toEqual({
+      hasV: false,
+      major: 1,
+      minor: 4,
+      patch: 0,
+    });
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    expect(parseStableSemver("  v2.3.4  ")?.patch).toBe(4);
+  });
+
+  it("rejects prerelease / build suffixes", () => {
+    expect(parseStableSemver("v0.5.99-wave-test-08")).toBeNull();
+    expect(parseStableSemver("v1.2.3-dev")).toBeNull();
+    expect(parseStableSemver("v1.2.3-rc.1")).toBeNull();
+    expect(parseStableSemver("v1.2.3+build.5")).toBeNull();
+  });
+
+  it("rejects incomplete or junk tags", () => {
+    expect(parseStableSemver("v1.2")).toBeNull();
+    expect(parseStableSemver("v1")).toBeNull();
+    expect(parseStableSemver("dev-3")).toBeNull();
+    expect(parseStableSemver("")).toBeNull();
+  });
+});
+
+describe("nextPatchTag", () => {
+  it("increments the patch component, preserving the v prefix", () => {
+    expect(nextPatchTag("v0.0.76")).toBe("v0.0.77");
+    expect(nextPatchTag("v0.2.51")).toBe("v0.2.52");
+    expect(nextPatchTag("v1.9.9")).toBe("v1.9.10");
+    expect(nextPatchTag("2.0.0")).toBe("2.0.1");
+  });
+
+  it("returns null for prerelease tags (no bump → empty prefill)", () => {
+    expect(nextPatchTag("v0.5.99-wave-test-08")).toBeNull();
+    expect(nextPatchTag("v1.2.3-dev")).toBeNull();
+    expect(nextPatchTag("v1.2.3-rc.1")).toBeNull();
+  });
+
+  it("returns null for non-semver junk", () => {
+    expect(nextPatchTag("latest")).toBeNull();
+    expect(nextPatchTag("v1.2")).toBeNull();
+    expect(nextPatchTag("")).toBeNull();
   });
 });

--- a/test/release-wave/start.test.ts
+++ b/test/release-wave/start.test.ts
@@ -158,6 +158,55 @@ describe("renderStartWaveSection", () => {
     expect(html).not.toContain('value="ippoan/x"y"');
     expect(html).toContain("&quot;");
   });
+
+  it("prefills target_tag value with latest stable tag patch-bumped", () => {
+    const html = renderStartWaveSection([
+      status("ippoan/rust-alc-api", { latestTag: "v0.0.76" }),
+      status("ippoan/alc-app", { latestTag: "v0.2.51" }),
+    ]);
+    // value (not just placeholder) is the latest tag with patch +1
+    expect(html).toContain(
+      'name="target_tag__ippoan/rust-alc-api"\n              value="v0.0.77"',
+    );
+    expect(html).toContain(
+      'name="target_tag__ippoan/alc-app"\n              value="v0.2.52"',
+    );
+    // placeholder still shows the current latest tag
+    expect(html).toContain('placeholder="v0.0.76"');
+    expect(html).toContain('placeholder="v0.2.51"');
+  });
+
+  it("leaves prefill value empty when latest tag is a prerelease", () => {
+    // A polluted prerelease (`-wave-test-NN` / `-dev` / `-rc`) must NOT bump
+    // into a new stable tag — value stays empty, operator types manually.
+    const html = renderStartWaveSection([
+      status("ippoan/poll-1", { latestTag: "v0.5.99-wave-test-08" }),
+      status("ippoan/poll-2", { latestTag: "v1.2.3-dev" }),
+      status("ippoan/poll-3", { latestTag: "v1.2.3-rc.1" }),
+    ]);
+    expect(html).toContain(
+      'name="target_tag__ippoan/poll-1"\n              value=""',
+    );
+    expect(html).toContain(
+      'name="target_tag__ippoan/poll-2"\n              value=""',
+    );
+    expect(html).toContain(
+      'name="target_tag__ippoan/poll-3"\n              value=""',
+    );
+    // but the placeholder still surfaces the (prerelease) latest for context
+    expect(html).toContain('placeholder="v0.5.99-wave-test-08"');
+  });
+
+  it("leaves prefill value empty for repos with no tag", () => {
+    const html = renderStartWaveSection([
+      status("ippoan/fresh", { hasTag: false, latestTag: null }),
+    ]);
+    expect(html).toContain(
+      'name="target_tag__ippoan/fresh"\n              value=""',
+    );
+    //未tag repo keeps the v0.1.0 example placeholder
+    expect(html).toContain('placeholder="v0.1.0"');
+  });
 });
 
 describe("injectStartWaveSection", () => {


### PR DESCRIPTION
## 概要

`/release-wave` の Start wave UI で、各 repo の `target_tag` 入力欄を **現 stable latest tag を patch +1 した値**で `value` に prefill する。

## 背景

現状 `target_tag` は `placeholder` に latest を出すだけで `value` が空だった。そのため:

- ユーザーが手入力せず Start wave すると `MISSING_TARGET_TAG` エラーになる
- 手入力で異常タグ (例 `v0.5.99-wave-test-08`) を打って npm `latest` dist-tag を汚染する事故が起きた

default で正しい次バージョンを `value` に入れておけば、手入力不要 + 異常タグ防止になる。

## 実装

### latest をどこで取るか
`renderStartWaveSection` は `RepoReleaseStatus.latestTag` を使う。これは `getRepoReleaseStatuses` が既に `cachedTags` (release-cache KV) 経由で取得済みの値なので、追加の GitHub fetch は発生しない (タグ無し repo は `latestTag: null`)。

### どう patch bump するか
`src/release-helpers.ts` に純粋関数を 2 つ追加:
- `parseStableSemver(tag)` — `v?MAJOR.MINOR.PATCH` を**末尾 anchor**で受理し `{hasV, major, minor, patch}` を返す。stable 以外は `null`。
- `nextPatchTag(tag)` — patch を +1 して `v` prefix を保つ (`v0.0.76 → v0.0.77`、`v0.2.51 → v0.2.52`、`1.4.0 → 1.4.1`)。stable semver でなければ `null`。

`renderStartWaveSection` で `const prefill = s.latestTag ? (nextPatchTag(s.latestTag) ?? "") : "";` とし、`<input ... value="${escapeHtml(prefill)}">` をセット (placeholder は従来どおり残す)。

### prerelease 除外
`STABLE_SEMVER_RE = /^(v?)(\d+)\.(\d+)\.(\d+)$/` を**末尾固定**にしてあるので、`-wave-test-NN` / `-dev` / `-rc.1` / `+build.5` 等の suffix 付きは `parseStableSemver` が `null` を返す → `nextPatchTag` も `null` → prefill は空文字。`latestTag` は `sortSemverDesc` 由来で prerelease を含み得る (同 MAJOR.MINOR.PATCH の prerelease が先頭に来る可能性) が、ここで自動的に弾かれる。

`value` が取れない repo (未tag / prerelease のみ) は従来どおり `value` 空 + placeholder で、ユーザーが手で打つ。

## テスト
- `test/release-wave/start.test.ts`: prefill が latest+patch になる / prerelease は value 空 / 未tag は value 空 の 3 ケースを追加 (実 `createWave` は起こさない、純粋 SSR レンダリングのみ)。
- `test/release-helpers.test.ts`: `parseStableSemver` / `nextPatchTag` の単体テスト (stable / prerelease / build / 不完全 / junk)。

typecheck/test はローカルでは `@ippoan/*` GitHub Packages の install token が無く install 不可のため CI に委譲。純粋ロジックと HTML レンダリング出力は手元で standalone node により検算済み。

Refs ippoan/ci-dashboard#137
Refs ippoan/ci-dashboard#157

https://claude.ai/code/session_012zLhVkMuDnAyBWZNLnuorh

---
_Generated by [Claude Code](https://claude.ai/code/session_012zLhVkMuDnAyBWZNLnuorh)_