### PR TITLE
feat(release-wave): wave = pending releases の一括 flip + 一括 rollback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,8 @@ import {
   handleReleaseWaveRetest,
   handleReleaseWaveRetestConsumer,
   handleReleaseWavePendingReleaseFlip,
+  handleReleaseWavePendingReleaseFlipAll,
+  handleReleaseWaveFlipGroupRollback,
   handleReleaseWaveTrafficRollback,
   handleReleaseWaveBackendRollback,
 } from "./release-wave/api";
@@ -315,6 +317,16 @@ app.post("/api/release-wave/retest-consumer", (c) =>
 // で区別されるため衝突しない。
 app.post("/api/release-wave/pending-release/flip", (c) =>
   handleReleaseWavePendingReleaseFlip(c.req.raw, c.env),
+);
+// wave = 複数 repo の pending release を一括 flip (Refs #237)。flip 直前の
+// active version を flip-group に控え、下の flip-group-rollback で一括復旧可能。
+app.post("/api/release-wave/pending-release/flip-all", (c) =>
+  handleReleaseWavePendingReleaseFlipAll(c.req.raw, c.env),
+);
+// 直近の一括 flip (flip-group) を一括 rollback (Refs #237)。各 repo を flip
+// 直前の active version へ release-wave-traffic-rollback で戻す。
+app.post("/api/release-wave/pending-release/flip-group-rollback", (c) =>
+  handleReleaseWaveFlipGroupRollback(c.req.raw, c.env),
 );
 // frontend worker の traffic を任意の過去 version に即 100% で戻す (Refs #196)。
 // form field `repo` + `version_id`。release-wave-traffic-rollback を dispatch。

--- a/src/release-wave/api.ts
+++ b/src/release-wave/api.ts
@@ -18,8 +18,17 @@ import {
   getBackendCurrent,
 } from "./compat";
 import { decideRetestDispatches, dispatchAll, type Dispatch } from "./dispatch";
-import { getPendingRelease, clearPendingRelease } from "./pending-release";
-import { getTraffic } from "./traffic";
+import {
+  getPendingRelease,
+  clearPendingRelease,
+  listPendingReleases,
+  recordFlipGroup,
+  getFlipGroup,
+  clearFlipGroup,
+  type PendingReleaseRecord,
+  type FlipGroupItem,
+} from "./pending-release";
+import { getTraffic, type TrafficRecord } from "./traffic";
 import { serviceNameFromRevision } from "./revision";
 
 function hubStub(env: Env): DurableObjectStub<ReleaseWaveHub> {
@@ -329,6 +338,74 @@ export async function handleReleaseWaveRetestConsumer(
 }
 
 // ----------------------------------------------------------------------------
+// Pending release flip / rollback の dispatch ビルダー (single / bulk 共有)
+// ----------------------------------------------------------------------------
+
+/**
+ * pending release (no-traffic version) を 100% へ flip する dispatch を組む。
+ * single (`/pending-release/flip`) と bulk (`/pending-release/flip-all`) で共有。
+ */
+function buildPendingFlipDispatch(record: PendingReleaseRecord): Dispatch {
+  // synthetic wave_id: handler の dispatch job の wave_id 形式検証
+  // (^[a-zA-Z0-9._-]{1,128}$) を満たすよう `/` を `-` に潰す。
+  const wave_id = `pending-${record.repo.replace(/[^a-zA-Z0-9._-]/g, "-")}-${Date.now()}`;
+  return {
+    repo: record.repo,
+    event_type: "release-wave-flip",
+    client_payload: {
+      wave_id,
+      target_tag: record.tag,
+      head_sha: "",
+      previewed_version_id: record.version_id,
+      // handler が wave flip-report callback を skip するためのマーカー。
+      pending_release: true,
+    },
+  };
+}
+
+/**
+ * 任意 version への traffic rollback dispatch を組む。single
+ * (`/traffic-rollback`) と bulk (flip-group rollback) で共有。
+ */
+function buildTrafficRollbackDispatch(
+  repo: string,
+  versionId: string,
+  tag: string | null,
+): Dispatch {
+  const wave_id = `traffic-rollback-${repo.replace(/[^a-zA-Z0-9._-]/g, "-")}-${Date.now()}`;
+  return {
+    repo,
+    event_type: "release-wave-traffic-rollback",
+    client_payload: {
+      wave_id,
+      ...(tag ? { target_tag: tag } : {}),
+      head_sha: "",
+      // handler が `wrangler versions deploy <id>@100%` の対象にする version。
+      previewed_version_id: versionId,
+      // handler が wave callback を skip するためのマーカー。
+      traffic_rollback: true,
+    },
+  };
+}
+
+/**
+ * traffic record から「現在 active な version」(= flip 前の戻し先候補) を返す。
+ * deploy_history の先頭 (index 0 = 現 active) を最優先。無ければ versions[] の
+ * 100% / 最大 traffic から拾う。判定できなければ null。
+ */
+function currentActiveVersion(
+  traffic: TrafficRecord | null,
+): { version_id: string; tag: string | null } | null {
+  if (!traffic) return null;
+  const hist = traffic.deploy_history ?? [];
+  if (hist[0]) return { version_id: hist[0].version_id, tag: hist[0].tag ?? null };
+  const active =
+    traffic.versions.find((v) => v.percentage === 100) ??
+    traffic.versions.find((v) => v.percentage > 0);
+  return active ? { version_id: active.version_id, tag: active.tag ?? null } : null;
+}
+
+// ----------------------------------------------------------------------------
 // POST /api/release-wave/pending-release/flip  (Refs #181 / #174)
 // ----------------------------------------------------------------------------
 
@@ -383,23 +460,7 @@ export async function handleReleaseWavePendingReleaseFlip(
     });
   }
 
-  // synthetic wave_id: handler の dispatch job の wave_id 形式検証
-  // (^[a-zA-Z0-9._-]{1,128}$) を満たすよう `/` を `-` に潰す。
-  const wave_id = `pending-${repo.replace(/[^a-zA-Z0-9._-]/g, "-")}-${Date.now()}`;
-  const dispatch: Dispatch = {
-    repo,
-    event_type: "release-wave-flip",
-    client_payload: {
-      wave_id,
-      target_tag: record.tag,
-      head_sha: "",
-      previewed_version_id: record.version_id,
-      // handler が wave flip-report を skip するためのマーカー。
-      pending_release: true,
-    },
-  };
-
-  const results = await dispatchAll(env, [dispatch]);
+  const results = await dispatchAll(env, [buildPendingFlipDispatch(record)]);
   const ok = results.length > 0 && results[0]!.ok;
   if (ok) {
     // dispatch が着火できたら record を消す (optimistic)。実 flip の成否は
@@ -412,6 +473,157 @@ export async function handleReleaseWavePendingReleaseFlip(
       error: `failed to dispatch flip for ${repo}: ${err}`,
     });
   }
+  return redirectToList();
+}
+
+// ----------------------------------------------------------------------------
+// POST /api/release-wave/pending-release/flip-all  (wave 一括 flip, Refs #237)
+// ----------------------------------------------------------------------------
+
+/**
+ * 「wave = 複数 repo の pending release を一括 flip」。KV の pending-release を
+ * 全件まとめて `release-wave-flip` dispatch し、各 repo の **flip 直前の active
+ * version (= 戻し先)** を flip-group として記録する。後で
+ * `/pending-release/flip-group-rollback` で同じ set を一括 rollback できる。
+ *
+ * - pending-release が 0 件なら no-op で一覧へ redirect。
+ * - 戻し先は flip 前に `traffic::<repo>` から控える (flip CI が traffic を
+ *   書き換える前のスナップショット)。取得できない repo は rollback_to=null。
+ * - dispatch 成功した repo のみ pending-release を clear し flip-group に積む。
+ * - 全 dispatch 失敗時のみ 502。一部成功は成功分を記録して一覧へ redirect。
+ */
+export async function handleReleaseWavePendingReleaseFlipAll(
+  req: Request,
+  env: Env,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return jsonResponse(405, { code: "METHOD_NOT_ALLOWED", error: "use POST" });
+  }
+  if (!env.COMPAT_KV) {
+    return jsonResponse(500, {
+      code: "KV_NOT_CONFIGURED",
+      error: "COMPAT_KV is not bound",
+    });
+  }
+
+  const records = await listPendingReleases(env.COMPAT_KV);
+  if (records.length === 0) {
+    // flip 対象が無ければ何もせず一覧へ。
+    return redirectToList();
+  }
+
+  // flip 前に各 repo の現 active version (= 戻し先) を控える。
+  const rollbackByRepo = new Map<
+    string,
+    { version_id: string; tag: string | null } | null
+  >();
+  await Promise.all(
+    records.map(async (r) => {
+      const traffic = await getTraffic(env.COMPAT_KV, r.repo);
+      rollbackByRepo.set(r.repo, currentActiveVersion(traffic));
+    }),
+  );
+
+  const dispatches = records.map(buildPendingFlipDispatch);
+  const results = await dispatchAll(env, dispatches);
+
+  const items: FlipGroupItem[] = [];
+  for (let i = 0; i < records.length; i++) {
+    const rec = records[i]!;
+    if (!results[i]?.ok) continue;
+    const rb = rollbackByRepo.get(rec.repo) ?? null;
+    items.push({
+      repo: rec.repo,
+      flipped_version_id: rec.version_id,
+      flipped_tag: rec.tag,
+      rollback_to: rb?.version_id ?? null,
+      rollback_tag: rb?.tag ?? null,
+    });
+    await clearPendingRelease(env.COMPAT_KV, rec.repo);
+  }
+
+  if (items.length === 0) {
+    const err =
+      results.find((r) => !r.ok && r.error)?.error ?? "dispatch failed";
+    return jsonResponse(502, {
+      code: "DISPATCH_FAILED",
+      error: `failed to dispatch flip for all ${records.length} pending release(s): ${err}`,
+    });
+  }
+
+  await recordFlipGroup(env.COMPAT_KV, {
+    flipped_at: new Date().toISOString(),
+    actor: actorEmail(req),
+    items,
+  });
+  return redirectToList();
+}
+
+// ----------------------------------------------------------------------------
+// POST /api/release-wave/pending-release/flip-group-rollback  (一括 rollback)
+// ----------------------------------------------------------------------------
+
+/**
+ * 直近の一括 flip (flip-group) を一括 rollback する。各 repo を flip 直前の
+ * active version (`rollback_to`) へ `release-wave-traffic-rollback` dispatch で
+ * 即 100% に戻す。
+ *
+ * - flip-group が無ければ 404。
+ * - `rollback_to` を記録できていた item のみ対象 (= flip 時に戻し先が判明して
+ *   いた repo)。1 件も無ければ 409。
+ * - 全 dispatch 失敗時のみ 502。一部でも成功すれば flip-group を clear して
+ *   一覧へ redirect (= rollback 済みとみなす)。
+ */
+export async function handleReleaseWaveFlipGroupRollback(
+  req: Request,
+  env: Env,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return jsonResponse(405, { code: "METHOD_NOT_ALLOWED", error: "use POST" });
+  }
+  if (!env.COMPAT_KV) {
+    return jsonResponse(500, {
+      code: "KV_NOT_CONFIGURED",
+      error: "COMPAT_KV is not bound",
+    });
+  }
+
+  const group = await getFlipGroup(env.COMPAT_KV);
+  if (!group) {
+    return jsonResponse(404, {
+      code: "NOT_FOUND",
+      error: "no flip group to rollback",
+    });
+  }
+
+  const targets = group.items.filter(
+    (it): it is FlipGroupItem & { rollback_to: string } =>
+      typeof it.rollback_to === "string" && it.rollback_to.length > 0,
+  );
+  if (targets.length === 0) {
+    // 戻し先が 1 件も無い (= flip 時に active を特定できなかった)。group は消す。
+    await clearFlipGroup(env.COMPAT_KV);
+    return jsonResponse(409, {
+      code: "NO_ROLLBACK_TARGET",
+      error: "flip group has no recorded rollback targets",
+    });
+  }
+
+  const dispatches = targets.map((it) =>
+    buildTrafficRollbackDispatch(it.repo, it.rollback_to, it.rollback_tag),
+  );
+  const results = await dispatchAll(env, dispatches);
+
+  if (!results.some((r) => r.ok)) {
+    const err =
+      results.find((r) => !r.ok && r.error)?.error ?? "dispatch failed";
+    return jsonResponse(502, {
+      code: "DISPATCH_FAILED",
+      error: `failed to dispatch rollback for flip group (${targets.length} repo(s)): ${err}`,
+    });
+  }
+
+  await clearFlipGroup(env.COMPAT_KV);
   return redirectToList();
 }
 
@@ -482,22 +694,9 @@ export async function handleReleaseWaveTrafficRollback(
   }
   const tag = fromHistory?.tag ?? fromVersions?.tag ?? null;
 
-  const wave_id = `traffic-rollback-${repo.replace(/[^a-zA-Z0-9._-]/g, "-")}-${Date.now()}`;
-  const dispatch: Dispatch = {
-    repo,
-    event_type: "release-wave-traffic-rollback",
-    client_payload: {
-      wave_id,
-      ...(tag ? { target_tag: tag } : {}),
-      head_sha: "",
-      // handler が `wrangler versions deploy <id>@100%` の対象にする version。
-      previewed_version_id: versionId,
-      // handler が wave callback を skip するためのマーカー。
-      traffic_rollback: true,
-    },
-  };
-
-  const results = await dispatchAll(env, [dispatch]);
+  const results = await dispatchAll(env, [
+    buildTrafficRollbackDispatch(repo, versionId, tag),
+  ]);
   if (!(results.length > 0 && results[0]!.ok)) {
     const err = results.length > 0 && !results[0]!.ok ? results[0]!.error : "dispatch failed";
     return jsonResponse(502, {

--- a/src/release-wave/api.ts
+++ b/src/release-wave/api.ts
@@ -543,8 +543,8 @@ export async function handleReleaseWavePendingReleaseFlipAll(
   }
 
   if (items.length === 0) {
-    const err =
-      results.find((r) => !r.ok && r.error)?.error ?? "dispatch failed";
+    const failed = results.find((r) => !r.ok);
+    const err = failed && !failed.ok ? failed.error : "dispatch failed";
     return jsonResponse(502, {
       code: "DISPATCH_FAILED",
       error: `failed to dispatch flip for all ${records.length} pending release(s): ${err}`,
@@ -615,8 +615,8 @@ export async function handleReleaseWaveFlipGroupRollback(
   const results = await dispatchAll(env, dispatches);
 
   if (!results.some((r) => r.ok)) {
-    const err =
-      results.find((r) => !r.ok && r.error)?.error ?? "dispatch failed";
+    const failed = results.find((r) => !r.ok);
+    const err = failed && !failed.ok ? failed.error : "dispatch failed";
     return jsonResponse(502, {
       code: "DISPATCH_FAILED",
       error: `failed to dispatch rollback for flip group (${targets.length} repo(s)): ${err}`,

--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -23,7 +23,9 @@ import {
 } from "./compat";
 import {
   listPendingReleases,
+  getFlipGroup,
   type PendingReleaseRecord,
+  type FlipGroupRecord,
 } from "./pending-release";
 import { getTrafficForRepos, type TrafficRecord } from "./traffic";
 
@@ -190,15 +192,25 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
   );
 
   // 単独 v* リリースで upload された no-traffic version の一覧 (Refs #181)。
+  // + 直近の一括 flip (flip-group) — 一括 rollback 用 (Refs #237)。
   let pendingReleases: PendingReleaseRecord[] = [];
+  let flipGroup: FlipGroupRecord | null = null;
   if (env.COMPAT_KV) {
     try {
       pendingReleases = await listPendingReleases(env.COMPAT_KV);
     } catch {
       pendingReleases = [];
     }
+    try {
+      flipGroup = await getFlipGroup(env.COMPAT_KV);
+    } catch {
+      flipGroup = null;
+    }
   }
-  const pendingReleaseSection = renderPendingReleaseSection(pendingReleases);
+  const pendingReleaseSection = renderPendingReleaseSection(
+    pendingReleases,
+    flipGroup,
+  );
 
   const rows = waves.length === 0
     ? `<tr><td colspan="7" class="empty">No release waves yet.</td></tr>`
@@ -511,7 +523,10 @@ export async function handleReleaseWaveDetailPage(
  * record が無ければセクション自体は出すが「pending release はありません」を表示
  * (= 「ここで単独リリースを flip できる」affordance を常設)。
  */
-function renderPendingReleaseSection(records: PendingReleaseRecord[]): string {
+function renderPendingReleaseSection(
+  records: PendingReleaseRecord[],
+  flipGroup: FlipGroupRecord | null,
+): string {
   const rows = records
     .map((r) => {
       const safe = safeHttpUrl(r.preview_url);
@@ -540,8 +555,22 @@ function renderPendingReleaseSection(records: PendingReleaseRecord[]): string {
     })
     .join("");
 
+  // wave = 一括 flip。pending が 2 件以上なら「全部まとめて flip」ボタンを出す
+  // (Refs #237)。1 件でも押せるが、単独行の Flip と機能は同じなので 2 件以上で表示。
+  const flipAllBtn =
+    records.length >= 2
+      ? `<form method="post" action="/api/release-wave/pending-release/flip-all"
+              style="margin:0 0 8px 0"
+              onsubmit="return confirm('${records.length} 件の pending release を一括で 100% flip します。よろしいですか？');">
+           <button type="submit"
+             title="全 pending release を一括で 100% traffic へ flip (wave)">
+             ⚡ Flip all ${records.length} to 100% (wave)
+           </button>
+         </form>`
+      : "";
+
   const body = records.length > 0
-    ? `<table>
+    ? `${flipAllBtn}<table>
         <thead>
           <tr>
             <th>Repo</th><th>Tag</th><th>Version</th><th>Preview</th>
@@ -560,6 +589,45 @@ function renderPendingReleaseSection(records: PendingReleaseRecord[]): string {
         した no-traffic version。Flip で 100% traffic へ promote する。
         Refs <a href="https://github.com/ippoan/ci-dashboard/issues/181">#181</a>.</p>
       ${body}
+      ${renderFlipGroupRollback(flipGroup)}
+    </div>`;
+}
+
+/**
+ * 直近の一括 flip (flip-group) の rollback パネル。flip-group があれば「直前の
+ * active version へ一括で戻す」ボタンを出す。戻し先 (rollback_to) を控えられた
+ * repo のみが対象。Refs #237。
+ */
+function renderFlipGroupRollback(flipGroup: FlipGroupRecord | null): string {
+  if (!flipGroup || flipGroup.items.length === 0) return "";
+  const rollbackable = flipGroup.items.filter((it) => it.rollback_to);
+  const repoList = flipGroup.items
+    .map((it) => {
+      const to = it.rollback_to
+        ? `→ ${escapeHtml((it.rollback_tag ?? it.rollback_to).slice(0, 16))}`
+        : `<span class="meta">(戻し先不明)</span>`;
+      return `<li>${escapeHtml(it.repo)} <span class="meta">${escapeHtml(it.flipped_tag)}</span> ${to}</li>`;
+    })
+    .join("");
+  const btn =
+    rollbackable.length > 0
+      ? `<form method="post" action="/api/release-wave/pending-release/flip-group-rollback"
+              style="margin:8px 0 0 0"
+              onsubmit="return confirm('直近の一括 flip (${rollbackable.length} repo) を直前の version へ一括 rollback します。よろしいですか？');">
+           <button type="submit"
+             title="直近の一括 flip を一括 rollback (各 repo を flip 直前の version へ戻す)">
+             ↩ Rollback last flip (${rollbackable.length} repo)
+           </button>
+         </form>`
+      : `<p class="meta">この flip-group には戻し先が記録された repo がありません
+          (各行の traffic-rollback で個別に戻してください)。</p>`;
+  return `
+    <div class="subsection" style="margin-top:12px;border-top:1px solid #2a2a2a;padding-top:10px">
+      <h3 style="margin:0 0 4px 0;font-size:0.95em">直近の一括 flip
+        <span class="meta">(${escapeHtml(flipGroup.flipped_at)} by ${escapeHtml(flipGroup.actor)})</span>
+      </h3>
+      <ul class="meta" style="margin:4px 0">${repoList}</ul>
+      ${btn}
     </div>`;
 }
 

--- a/src/release-wave/pending-release.ts
+++ b/src/release-wave/pending-release.ts
@@ -95,3 +95,69 @@ export async function clearPendingRelease(
 ): Promise<void> {
   await kv.delete(pendingReleaseKey(repo));
 }
+
+// ----------------------------------------------------------------------------
+// Flip group (= wave 一括 flip / 一括 rollback の単位) — Refs #237 / #96
+// ----------------------------------------------------------------------------
+//
+// 「wave = 複数 repo の pending release を一括 flip する箱」。一括 flip 時に
+// 各 repo の「直前の active version (= 戻し先)」を控えて 1 件の flip-group として
+// 保存し、後から同じ set を一括 rollback できるようにする。最新 1 件のみ保持
+// (= 直近の一括 flip を rollback する用途)。
+
+const FLIP_GROUP_KEY = "flip-group::latest";
+const FLIP_GROUP_SCHEMA = 1 as const;
+
+/** flip-group に含まれる repo 1 件分。 */
+export interface FlipGroupItem {
+  /** "owner/name"。 */
+  repo: string;
+  /** 今回 100% に flip した version id。 */
+  flipped_version_id: string;
+  /** flip した version の release tag。 */
+  flipped_tag: string;
+  /** flip 直前に active だった version id (= 一括 rollback の戻し先)。不明なら null。 */
+  rollback_to: string | null;
+  /** 戻し先 version の release tag (不明なら null)。 */
+  rollback_tag: string | null;
+}
+
+/** 直近の一括 flip の record (最新 1 件のみ KV 保持)。 */
+export interface FlipGroupRecord {
+  schema_version: typeof FLIP_GROUP_SCHEMA;
+  /** 一括 flip を実行した UTC ISO。 */
+  flipped_at: string;
+  /** 実行者 email (audit)。 */
+  actor: string;
+  /** 一括 flip した repo 群。 */
+  items: FlipGroupItem[];
+}
+
+/** 一括 flip 実行時に flip-group を保存する (最新で上書き)。 */
+export async function recordFlipGroup(
+  kv: KVNamespace,
+  input: { flipped_at: string; actor: string; items: FlipGroupItem[] },
+): Promise<FlipGroupRecord> {
+  const record: FlipGroupRecord = {
+    schema_version: FLIP_GROUP_SCHEMA,
+    flipped_at: input.flipped_at,
+    actor: input.actor,
+    items: input.items,
+  };
+  await kv.put(FLIP_GROUP_KEY, JSON.stringify(record));
+  return record;
+}
+
+/** 直近の flip-group を取得 (無ければ null)。 */
+export async function getFlipGroup(
+  kv: KVNamespace,
+): Promise<FlipGroupRecord | null> {
+  const v = await kv.get<FlipGroupRecord>(FLIP_GROUP_KEY, "json");
+  if (!v || v.schema_version !== FLIP_GROUP_SCHEMA) return null;
+  return v;
+}
+
+/** 一括 rollback 完了後に flip-group を消す。 */
+export async function clearFlipGroup(kv: KVNamespace): Promise<void> {
+  await kv.delete(FLIP_GROUP_KEY);
+}

--- a/test/release-wave/api.test.ts
+++ b/test/release-wave/api.test.ts
@@ -6,10 +6,15 @@ import {
   handleReleaseWaveRetest,
   handleReleaseWaveRetestConsumer,
   handleReleaseWavePendingReleaseFlip,
+  handleReleaseWavePendingReleaseFlipAll,
+  handleReleaseWaveFlipGroupRollback,
   handleReleaseWaveTrafficRollback,
   handleReleaseWaveBackendRollback,
 } from "../../src/release-wave/api";
-import { getPendingRelease } from "../../src/release-wave/pending-release";
+import {
+  getPendingRelease,
+  getFlipGroup,
+} from "../../src/release-wave/pending-release";
 import type { Env } from "../../src/index";
 import type { ReleaseWaveHub } from "../../src/release-wave/do";
 
@@ -874,5 +879,171 @@ describe("handleReleaseWaveBackendRollback", () => {
     expect(body.client_payload.rollback_target).toEqual({
       "rust-alc-api": "rust-alc-api-00041-xyz",
     });
+  });
+});
+
+// ============================================================================
+// /api/release-wave/pending-release/flip-all  (wave 一括 flip, Refs #237)
+// ============================================================================
+
+describe("handleReleaseWavePendingReleaseFlipAll", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns 405 on GET", async () => {
+    const req = new Request(
+      "https://ci-dashboard.ippoan.org/api/release-wave/pending-release/flip-all",
+      { method: "GET" },
+    );
+    const resp = await handleReleaseWavePendingReleaseFlipAll(req, pendingFlipEnv(pendingKv()));
+    expect(resp.status).toBe(405);
+  });
+
+  it("redirects with no dispatch when there are no pending releases", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    const resp = await handleReleaseWavePendingReleaseFlipAll(
+      postRequest("/api/release-wave/pending-release/flip-all"),
+      pendingFlipEnv(memKv()),
+    );
+    expect(resp.status).toBe(303);
+    const dispatchCall = fetchSpy.mock.calls.find((c) =>
+      String(c[0]).includes("/dispatches"),
+    );
+    expect(dispatchCall).toBeUndefined();
+  });
+
+  it("flips all pending releases, clears them, and records a flip-group with the prior active version as rollback target", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    // pending release + 直前 active (deploy_history[0]) を持つ traffic record。
+    const kv = memKv({
+      "pending-release::ippoan/auth-worker": {
+        schema_version: 1,
+        repo: "ippoan/auth-worker",
+        version_id: PENDING_VID,
+        tag: "v0.2.38",
+        preview_url: null,
+        uploaded_at: "2026-05-28T12:00:00Z",
+      },
+      "traffic::ippoan/auth-worker": {
+        schema_version: 4,
+        repo: "ippoan/auth-worker",
+        versions: [{ version_id: "prior-active-1111", percentage: 100 }],
+        deploy_history: [
+          { version_id: "prior-active-1111", tag: "v0.2.37", became_active_at: "2026-05-27T00:00:00Z" },
+        ],
+        reported_at: "2026-05-28T00:00:00Z",
+      },
+    });
+    const resp = await handleReleaseWavePendingReleaseFlipAll(
+      postRequest("/api/release-wave/pending-release/flip-all"),
+      pendingFlipEnv(kv),
+    );
+    expect(resp.status).toBe(303);
+    const dispatchCall = fetchSpy.mock.calls.find((c) =>
+      String(c[0]).includes("/repos/ippoan/auth-worker/dispatches"),
+    );
+    expect(dispatchCall).toBeDefined();
+    const body = JSON.parse(dispatchCall![1].body);
+    expect(body.event_type).toBe("release-wave-flip");
+    expect(body.client_payload).toMatchObject({
+      previewed_version_id: PENDING_VID,
+      pending_release: true,
+    });
+    // pending record は消える
+    expect(await getPendingRelease(kv, "ippoan/auth-worker")).toBeNull();
+    // flip-group が記録され、戻し先 = 直前 active version
+    const group = await getFlipGroup(kv);
+    expect(group).not.toBeNull();
+    expect(group!.items).toHaveLength(1);
+    expect(group!.items[0]).toMatchObject({
+      repo: "ippoan/auth-worker",
+      flipped_version_id: PENDING_VID,
+      rollback_to: "prior-active-1111",
+      rollback_tag: "v0.2.37",
+    });
+  });
+});
+
+// ============================================================================
+// /api/release-wave/pending-release/flip-group-rollback  (一括 rollback, Refs #237)
+// ============================================================================
+
+describe("handleReleaseWaveFlipGroupRollback", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns 404 when there is no flip-group", async () => {
+    const resp = await handleReleaseWaveFlipGroupRollback(
+      postRequest("/api/release-wave/pending-release/flip-group-rollback"),
+      pendingFlipEnv(memKv()),
+    );
+    expect(resp.status).toBe(404);
+  });
+
+  it("returns 409 and clears the group when no item has a rollback target", async () => {
+    const kv = memKv({
+      "flip-group::latest": {
+        schema_version: 1,
+        flipped_at: "2026-05-28T12:00:00Z",
+        actor: "op@example.com",
+        items: [
+          {
+            repo: "ippoan/auth-worker",
+            flipped_version_id: PENDING_VID,
+            flipped_tag: "v0.2.38",
+            rollback_to: null,
+            rollback_tag: null,
+          },
+        ],
+      },
+    });
+    const resp = await handleReleaseWaveFlipGroupRollback(
+      postRequest("/api/release-wave/pending-release/flip-group-rollback"),
+      pendingFlipEnv(kv),
+    );
+    expect(resp.status).toBe(409);
+    expect(await getFlipGroup(kv)).toBeNull();
+  });
+
+  it("dispatches traffic-rollback to the prior version for each group item, then clears the group", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    const kv = memKv({
+      "flip-group::latest": {
+        schema_version: 1,
+        flipped_at: "2026-05-28T12:00:00Z",
+        actor: "op@example.com",
+        items: [
+          {
+            repo: "ippoan/auth-worker",
+            flipped_version_id: PENDING_VID,
+            flipped_tag: "v0.2.38",
+            rollback_to: "prior-active-1111",
+            rollback_tag: "v0.2.37",
+          },
+        ],
+      },
+    });
+    const resp = await handleReleaseWaveFlipGroupRollback(
+      postRequest("/api/release-wave/pending-release/flip-group-rollback"),
+      pendingFlipEnv(kv),
+    );
+    expect(resp.status).toBe(303);
+    const dispatchCall = fetchSpy.mock.calls.find((c) =>
+      String(c[0]).includes("/repos/ippoan/auth-worker/dispatches"),
+    );
+    expect(dispatchCall).toBeDefined();
+    const body = JSON.parse(dispatchCall![1].body);
+    expect(body.event_type).toBe("release-wave-traffic-rollback");
+    expect(body.client_payload).toMatchObject({
+      previewed_version_id: "prior-active-1111",
+      traffic_rollback: true,
+    });
+    // rollback dispatch 後に flip-group は消える
+    expect(await getFlipGroup(kv)).toBeNull();
   });
 });


### PR DESCRIPTION
## 主旨: wave = 「pending releases を一括 flip する箱」

#237 の議論で確定した設計を実装する。

- **stage** = `ver tag` push 時点で済む（frontend-ci が `release_no_traffic` で no-traffic upload → `/webhooks/release-wave/pending-release` 報告）。
- **wave** = それを **一括で flip（traffic 投入）するだけ**。+ 一括 rollback。

個別の「Pending releases → Flip」(#181) は既存。本 PR はそれを **複数 repo まとめて** flip / rollback できるようにする。

## 変更

**`pending-release.ts`** — `flip-group` KV を追加。一括 flip の単位。各 item に `flipped_version_id` と **`rollback_to`（flip 直前の active version = 戻し先）** を持つ。最新 1 件のみ保持。

**`api.ts`**
- 単一 flip / traffic-rollback の dispatch 構築を helper に切り出して共有（`buildPendingFlipDispatch` / `buildTrafficRollbackDispatch`、既存挙動・既存テスト不変）。
- `POST /api/release-wave/pending-release/flip-all` — 全 pending release を一括 `release-wave-flip`。flip **前**に各 repo の現 active version（`traffic::<repo>` の `deploy_history[0]`）を控え、成功分を flip-group に記録。
- `POST /api/release-wave/pending-release/flip-group-rollback` — 直近の flip-group を各 repo の `rollback_to` へ `release-wave-traffic-rollback` で一括復旧。

**`index.ts`** — 上記 2 route を登録。

**`page.ts`** — Pending releases セクションに「⚡ Flip all N to 100% (wave)」ボタン（2 件以上で表示）と「↩ Rollback last flip」パネル（直近の flip-group があれば表示、各 repo の戻し先付き）を追加。

**`test/release-wave/api.test.ts`** — flip-all（no-op / 一括 flip + flip-group 記録）と flip-group-rollback（404 / 戻し先なし 409 / 一括 traffic-rollback + group clear）の単体テスト。

## 設計メモ

- stage を wave が駆動する旧フロー（`release-wave-stage` dispatch / handler stage job）は本 PR では撤去せず温存（#237 で動かした側）。旧フロー撤去は ci-workflows#96 で段階的に。
- 一括 rollback の戻し先は **flip 時に控える**（flip CI が traffic を書き換える前のスナップショット）。控えられなかった repo は個別 traffic-rollback に委ねる（パネルに明記）。
- ローカルは `@ippoan` private package 認証が CCoW で通らず typecheck/test 未実行。CI（frontend-ci, GHCR 認証あり）で検証。

Refs ippoan/ci-dashboard#237 Refs ippoan/ci-dashboard#181 Refs ippoan/ci-workflows#96

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNdmSA2s9AGH86Pu9eubVN)_