### PR TITLE
fix(release-wave): Start wave の target_tag prefill を latest+1 から実在 tag へ

### DIFF
--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -30,6 +30,7 @@ import {
   type TrafficRecord,
   type TrafficVersion,
 } from "./traffic";
+import { listPendingReleases } from "./pending-release";
 
 function escapeHtml(s: string): string {
   return s
@@ -528,7 +529,21 @@ export async function handleReleaseWaveListPageWithRepoStatus(
 
   // Start wave フォーム (Refs #137 / #157 改善B)。tagless でない監視対象 repo を
   // 候補に出し、画面から wave を start できるようにする。h1 直下に注入。
-  html = injectStartWaveSection(html, renderStartWaveSection(statuses));
+  // target_tag prefill は実在の pending release tag を優先する (Refs #237)。
+  const pendingTagByRepo = new Map<string, string>();
+  if (env.COMPAT_KV) {
+    try {
+      for (const p of await listPendingReleases(env.COMPAT_KV)) {
+        pendingTagByRepo.set(p.repo, p.tag);
+      }
+    } catch {
+      // pending release 取得失敗時は latest tag fallback で degrade。
+    }
+  }
+  html = injectStartWaveSection(
+    html,
+    renderStartWaveSection(statuses, new Date(), pendingTagByRepo),
+  );
 
   // Compatibility (all consumers) グラフ内 repo に Tag Release ボタンを足す。
   if (env.COMPAT_KV) {

--- a/src/release-wave/start.ts
+++ b/src/release-wave/start.ts
@@ -31,7 +31,7 @@ import {
   getRepoReleaseStatuses,
   type RepoReleaseStatus,
 } from "./repo-release-status";
-import { nextPatchTag } from "../release-helpers";
+import { parseStableSemver } from "../release-helpers";
 
 function escapeHtml(s: string): string {
   return s
@@ -86,24 +86,32 @@ export function defaultWaveId(now: Date = new Date()): string {
 export function renderStartWaveSection(
   statuses: RepoReleaseStatus[],
   now: Date = new Date(),
+  pendingTagByRepo: Map<string, string> = new Map(),
 ): string {
   const candidates = statuses.filter((s) => !s.tagless && s.behind >= 0);
   if (candidates.length === 0) return "";
 
   const rows = candidates
     .map((s) => {
-      // target_tag の prefill: 現 stable latest tag を patch +1 した値を value に
-      // 入れておく (= 手入力不要 + 異常 tag 防止)。s.latestTag は sortSemverDesc
-      // 由来で prerelease (`-wave-test-NN` / `-dev` / `-rc` 等) を含み得るが、
-      // nextPatchTag が stable semver 以外を null にするので prerelease は自動で
-      // 除外され value 空になる。value が無い (未tag / prerelease のみ) repo は
-      // 従来どおり placeholder のみ (operator が手で打つ)。
-      const prefill = s.latestTag ? (nextPatchTag(s.latestTag) ?? "") : "";
+      // target_tag の prefill (Refs #237):
+      // wave は「事前に tag push → no-traffic upload された pending release」を
+      // flip するだけなので、prefill は **実在 tag** を出す。latest+1 のような
+      // 未来の合成 tag は出さない (旧 stage-driven モデルの名残で、実態とずれる)。
+      //   1) その repo に pending release (no-traffic version) があればその tag。
+      //   2) 無ければ現 stable latest tag (そのまま、bump しない)。
+      //   3) latest が prerelease (`-wave-test-NN` / `-dev` / `-rc` 等) のみなら
+      //      value 空 (placeholder のみ、operator が手で打つ)。
+      const pendingTag = pendingTagByRepo.get(s.repo);
+      const stableLatest =
+        s.latestTag && parseStableSemver(s.latestTag) ? s.latestTag : "";
+      const prefill = pendingTag ?? stableLatest;
       const placeholder = s.latestTag ?? "v0.1.0";
       const id = `repo_${s.repo.replace(/[^a-zA-Z0-9]/g, "_")}`;
-      const tagHint = s.hasTag
-        ? `<span class="meta">latest: ${escapeHtml(s.latestTag ?? "")}</span>`
-        : `<span class="meta">未tag</span>`;
+      const tagHint = pendingTag
+        ? `<span class="meta">pending: ${escapeHtml(pendingTag)} (no-traffic)</span>`
+        : s.hasTag
+          ? `<span class="meta">latest: ${escapeHtml(s.latestTag ?? "")}</span>`
+          : `<span class="meta">未tag</span>`;
       return `
         <tr>
           <td>

--- a/test/release-wave/start.test.ts
+++ b/test/release-wave/start.test.ts
@@ -159,21 +159,34 @@ describe("renderStartWaveSection", () => {
     expect(html).toContain("&quot;");
   });
 
-  it("prefills target_tag value with latest stable tag patch-bumped", () => {
+  it("prefills target_tag value with the existing latest stable tag (NOT bumped) — Refs #237", () => {
     const html = renderStartWaveSection([
       status("ippoan/rust-alc-api", { latestTag: "v0.0.76" }),
       status("ippoan/alc-app", { latestTag: "v0.2.51" }),
     ]);
-    // value (not just placeholder) is the latest tag with patch +1
+    // wave は実在 tag を flip するだけ。latest+1 の合成はしない (= 実在 tag そのまま)。
     expect(html).toContain(
-      'name="target_tag__ippoan/rust-alc-api"\n              value="v0.0.77"',
+      'name="target_tag__ippoan/rust-alc-api"\n              value="v0.0.76"',
     );
     expect(html).toContain(
-      'name="target_tag__ippoan/alc-app"\n              value="v0.2.52"',
+      'name="target_tag__ippoan/alc-app"\n              value="v0.2.51"',
     );
-    // placeholder still shows the current latest tag
+    // placeholder も現 latest tag
     expect(html).toContain('placeholder="v0.0.76"');
     expect(html).toContain('placeholder="v0.2.51"');
+  });
+
+  it("prefers the pending release tag over latest when one exists — Refs #237", () => {
+    const html = renderStartWaveSection(
+      [status("ippoan/auth-worker", { latestTag: "v0.2.51" })],
+      new Date(),
+      new Map([["ippoan/auth-worker", "v0.2.51"]]),
+    );
+    // 実在の no-traffic version の tag を value に出す + hint も pending 表示。
+    expect(html).toContain(
+      'name="target_tag__ippoan/auth-worker"\n              value="v0.2.51"',
+    );
+    expect(html).toContain("pending: v0.2.51 (no-traffic)");
   });
 
   it("leaves prefill value empty when latest tag is a prerelease", () => {


### PR DESCRIPTION
## 問題

Start wave UI の target_tag prefill が **実在しない `latest+1` の合成 tag** を出していた（例: auth-worker は latest `v0.2.51` に対し input が `v0.2.52`）。これは旧 stage-driven モデル（wave が新規 tag を切る前提）の名残で、新モデルと実態がずれる（「tag がずれてる」）。

出どころ:
- `start.ts:101` `nextPatchTag(s.latestTag)` → `release-helpers.ts` で patch +1
- `repo-release-status.ts` の `latestTag`（= `v0.2.51`）

新モデルでは **tag は事前に push 済み → frontend-ci が no-traffic upload → pending-release → wave は flip するだけ**。wave 側で未来 tag を合成する意味はなく、prefill は実在 tag であるべき。

## 変更（Refs #237）

prefill ロジックを実在 tag に:
1. その repo に **pending release（no-traffic version）があればその tag を優先**（= 実際に flip 対象の version の tag）
2. 無ければ現 **stable latest tag をそのまま**（`+1` しない）
3. latest が prerelease のみなら value 空（従来どおり手入力）

- `start.ts`: `nextPatchTag` → `parseStableSemver`。`pendingTagByRepo` 引数を追加。pending 時は hint を `pending: <tag> (no-traffic)` 表示。
- `repo-status-section.ts`: `listPendingReleases` から `pendingTagByRepo` を組んで `renderStartWaveSection` に渡す。
- `start.test.ts`: prefill 期待値を `latest+1` → 実在 latest に修正、pending 優先ケース追加。prerelease→空 は維持。

Refs ippoan/ci-dashboard#237 Refs ippoan/ci-workflows#96

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNdmSA2s9AGH86Pu9eubVN)_