### PR TITLE
fix(release-wave): 旧 Start wave (stage 駆動) UI を撤去し flip-all に一本化

### DIFF
--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -24,13 +24,11 @@ import {
 } from "./repo-release-status";
 import { computeGlobalCompatibility, type WaveCompatibility } from "./compat";
 import { parseTaglessRepos } from "../tagless-repos";
-import { renderStartWaveSection, injectStartWaveSection } from "./start";
 import {
   getTrafficForRepos,
   type TrafficRecord,
   type TrafficVersion,
 } from "./traffic";
-import { listPendingReleases } from "./pending-release";
 
 function escapeHtml(s: string): string {
   return s
@@ -527,23 +525,15 @@ export async function handleReleaseWaveListPageWithRepoStatus(
   let html = await res.text();
   html = injectRepoStatusSection(html, section);
 
-  // Start wave フォーム (Refs #137 / #157 改善B)。tagless でない監視対象 repo を
-  // 候補に出し、画面から wave を start できるようにする。h1 直下に注入。
-  // target_tag prefill は実在の pending release tag を優先する (Refs #237)。
-  const pendingTagByRepo = new Map<string, string>();
-  if (env.COMPAT_KV) {
-    try {
-      for (const p of await listPendingReleases(env.COMPAT_KV)) {
-        pendingTagByRepo.set(p.repo, p.tag);
-      }
-    } catch {
-      // pending release 取得失敗時は latest tag fallback で degrade。
-    }
-  }
-  html = injectStartWaveSection(
-    html,
-    renderStartWaveSection(statuses, new Date(), pendingTagByRepo),
-  );
+  // 旧「Start wave」(stage 駆動) フォームは撤去 (Refs #237)。
+  // stage は wave と切り離し済み: tag push 時点で frontend-ci が no-traffic upload
+  // → ci-dashboard に pending-release 報告される。wave は「Pending releases」の
+  // ⚡ Flip all で一括 flip するだけ (wave-state 非依存)。
+  // stage 駆動の Start wave は (1) callback 待ちで staging 滞留 → WAVE_IN_PROGRESS、
+  // (2) cloudrun は新規 tag push 前提で、実在 tag を渡すと git tag が即失敗、と
+  // 新モデルと構造的に非互換だったため UI から外す。
+  // backend route (/api/release-wave/start) と handler stage job の撤去は
+  // ippoan/ci-workflows#96 で段階的に行う。
 
   // Compatibility (all consumers) グラフ内 repo に Tag Release ボタンを足す。
   if (env.COMPAT_KV) {


### PR DESCRIPTION
## 問題

「Start wave」(stage 駆動) を起動するたび wave が stuck / failed になる:

- **workers**: stage callback 待ちで `staging` 滞留 → 次 wave が `WAVE_IN_PROGRESS` でブロック（`wave_2026_06_03_1115` の事例）
- **cloudrun (rust-alc-api)**: `wave_2026_06_03_1245` で stage が **start から ~24 秒で failed**（20 分 poll timeout ではない）。cloudrun stage は `target_tag` を**新規 git push** → `deploy.yml` が `pending-` revision 生成 → stage-check、という設計。#239 で prefill を**実在 latest tag**（`v0.0.77`）にした結果、既存 tag が渡り冒頭の `git tag` が即失敗 → `stage_error: cloudrun stage failed (timeout or upstream error)`。

= **Start wave / stage 駆動フローが、移行済みの「tag→no-traffic→pending-release→flip」モデルと構造的に非互換。**

## 修正

ci-dashboard の list page から **Start wave フォーム injection を撤去**。wave の入口は「Pending releases」の **⚡ Flip all (wave)**（#238）に一本化。

- flip-all / 単一 flip / flip-group rollback は `release-wave-flip` を直接 dispatch する **wave-state 非依存**経路なので、`WAVE_IN_PROGRESS` は発生しない。
- stage は wave と無関係に tag 時点で完結（frontend-ci の no-traffic upload + pending-release 報告）。

## スコープ

- 本 PR: UI から Start wave セクションを外す（`repo-status-section.ts` の injection 削除 + 未使用 import 整理）。これだけで trap を除去。
- backend の `/api/release-wave/start` route / handler の `stage-*` job 撤去は **ippoan/ci-workflows#96** で段階的に（`renderStartWaveSection` / `handleReleaseWaveStart` は dormant のまま残り、`start.test.ts` も不変で通る）。

Refs ippoan/ci-dashboard#237 Refs ippoan/ci-workflows#96

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNdmSA2s9AGH86Pu9eubVN)_