### PR TITLE
feat(release-wave): flip-group に単一 repo rollback ボタン/経路を追加

### DIFF
--- a/src/release-wave/api.ts
+++ b/src/release-wave/api.ts
@@ -596,11 +596,57 @@ export async function handleReleaseWaveFlipGroupRollback(
     });
   }
 
-  const targets = group.items.filter(
+  // optional form field `repo`: 指定時はその repo 1 件だけ rollback (= 単一 rollback)。
+  // 未指定なら group 全件を一括 rollback (= 従来の Rollback last flip)。
+  let repoFilter = "";
+  try {
+    const form = await req.formData();
+    repoFilter = String(form.get("repo") ?? "").trim();
+  } catch {
+    // form-data 以外 (= bulk ボタンの空 body 等) は repoFilter 無しで全件扱い。
+  }
+
+  const rollbackable = group.items.filter(
     (it): it is FlipGroupItem & { rollback_to: string } =>
       typeof it.rollback_to === "string" && it.rollback_to.length > 0,
   );
-  if (targets.length === 0) {
+
+  // ---- 単一 rollback (repo 指定) ----
+  if (repoFilter) {
+    const item = rollbackable.find((it) => it.repo === repoFilter);
+    if (!item) {
+      return jsonResponse(404, {
+        code: "NOT_FOUND",
+        error: `no rollback target for ${repoFilter} in the latest flip group`,
+      });
+    }
+    const results = await dispatchAll(env, [
+      buildTrafficRollbackDispatch(item.repo, item.rollback_to, item.rollback_tag),
+    ]);
+    if (!(results.length > 0 && results[0]!.ok)) {
+      const err =
+        results.length > 0 && !results[0]!.ok ? results[0]!.error : "dispatch failed";
+      return jsonResponse(502, {
+        code: "DISPATCH_FAILED",
+        error: `failed to dispatch rollback for ${repoFilter}: ${err}`,
+      });
+    }
+    // rollback した repo を group から除く。残りが無ければ group ごと消す。
+    const remaining = group.items.filter((it) => it.repo !== repoFilter);
+    if (remaining.length === 0) {
+      await clearFlipGroup(env.COMPAT_KV);
+    } else {
+      await recordFlipGroup(env.COMPAT_KV, {
+        flipped_at: group.flipped_at,
+        actor: group.actor,
+        items: remaining,
+      });
+    }
+    return redirectToList();
+  }
+
+  // ---- 一括 rollback (repo 未指定) ----
+  if (rollbackable.length === 0) {
     // 戻し先が 1 件も無い (= flip 時に active を特定できなかった)。group は消す。
     await clearFlipGroup(env.COMPAT_KV);
     return jsonResponse(409, {
@@ -609,7 +655,7 @@ export async function handleReleaseWaveFlipGroupRollback(
     });
   }
 
-  const dispatches = targets.map((it) =>
+  const dispatches = rollbackable.map((it) =>
     buildTrafficRollbackDispatch(it.repo, it.rollback_to, it.rollback_tag),
   );
   const results = await dispatchAll(env, dispatches);
@@ -619,7 +665,7 @@ export async function handleReleaseWaveFlipGroupRollback(
     const err = failed && !failed.ok ? failed.error : "dispatch failed";
     return jsonResponse(502, {
       code: "DISPATCH_FAILED",
-      error: `failed to dispatch rollback for flip group (${targets.length} repo(s)): ${err}`,
+      error: `failed to dispatch rollback for flip group (${rollbackable.length} repo(s)): ${err}`,
     });
   }
 

--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -603,10 +603,19 @@ function renderFlipGroupRollback(flipGroup: FlipGroupRecord | null): string {
   const rollbackable = flipGroup.items.filter((it) => it.rollback_to);
   const repoList = flipGroup.items
     .map((it) => {
-      const to = it.rollback_to
-        ? `→ ${escapeHtml((it.rollback_tag ?? it.rollback_to).slice(0, 16))}`
+      // 単一 rollback: repo を指定して flip-group-rollback に POST (= その repo
+      // だけ flip 直前の version へ戻す)。戻し先未記録の repo はボタンを出さない。
+      const single = it.rollback_to
+        ? `→ ${escapeHtml((it.rollback_tag ?? it.rollback_to).slice(0, 16))}
+           <form method="post" action="/api/release-wave/pending-release/flip-group-rollback"
+                 style="display:inline;margin-left:6px"
+                 onsubmit="return confirm('${escapeHtml(it.repo)} を flip 直前の version へ rollback します。よろしいですか？');">
+             <input type="hidden" name="repo" value="${escapeHtml(it.repo)}">
+             <button type="submit"
+               title="この repo だけ flip 直前の version へ rollback">↩ Rollback</button>
+           </form>`
         : `<span class="meta">(戻し先不明)</span>`;
-      return `<li>${escapeHtml(it.repo)} <span class="meta">${escapeHtml(it.flipped_tag)}</span> ${to}</li>`;
+      return `<li>${escapeHtml(it.repo)} <span class="meta">${escapeHtml(it.flipped_tag)}</span> ${single}</li>`;
     })
     .join("");
   const btn =

--- a/test/release-wave/api.test.ts
+++ b/test/release-wave/api.test.ts
@@ -1047,3 +1047,108 @@ describe("handleReleaseWaveFlipGroupRollback", () => {
     expect(await getFlipGroup(kv)).toBeNull();
   });
 });
+
+// ============================================================================
+// flip-group-rollback: 単一 repo 指定 (Refs #237)
+// ============================================================================
+
+describe("handleReleaseWaveFlipGroupRollback (single repo)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function twoItemGroupKv(): KVNamespace {
+    return memKv({
+      "flip-group::latest": {
+        schema_version: 1,
+        flipped_at: "2026-05-28T12:00:00Z",
+        actor: "op@example.com",
+        items: [
+          {
+            repo: "ippoan/auth-worker",
+            flipped_version_id: PENDING_VID,
+            flipped_tag: "v0.2.38",
+            rollback_to: "prior-aw-0001",
+            rollback_tag: "v0.2.37",
+          },
+          {
+            repo: "ippoan/nuxt-trouble",
+            flipped_version_id: "vid-nuxt-trouble",
+            flipped_tag: "v0.0.18",
+            rollback_to: "prior-nt-0001",
+            rollback_tag: "v0.0.17",
+          },
+        ],
+      },
+    });
+  }
+
+  it("rolls back only the specified repo and keeps the rest in the group", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    const kv = twoItemGroupKv();
+    const resp = await handleReleaseWaveFlipGroupRollback(
+      postRequest("/api/release-wave/pending-release/flip-group-rollback", {
+        formBody: { repo: "ippoan/auth-worker" },
+      }),
+      pendingFlipEnv(kv),
+    );
+    expect(resp.status).toBe(303);
+    const awCall = fetchSpy.mock.calls.find((c) =>
+      String(c[0]).includes("/repos/ippoan/auth-worker/dispatches"),
+    );
+    expect(awCall).toBeDefined();
+    const body = JSON.parse(awCall![1].body);
+    expect(body.event_type).toBe("release-wave-traffic-rollback");
+    expect(body.client_payload.previewed_version_id).toBe("prior-aw-0001");
+    // 指定外 (nuxt-trouble) へは dispatch しない
+    expect(
+      fetchSpy.mock.calls.find((c) =>
+        String(c[0]).includes("/repos/ippoan/nuxt-trouble/dispatches"),
+      ),
+    ).toBeUndefined();
+    // group には未 rollback の nuxt-trouble だけ残る
+    const g = await getFlipGroup(kv);
+    expect(g).not.toBeNull();
+    expect(g!.items.map((i) => i.repo)).toEqual(["ippoan/nuxt-trouble"]);
+  });
+
+  it("clears the group when the last remaining repo is rolled back", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    const kv = memKv({
+      "flip-group::latest": {
+        schema_version: 1,
+        flipped_at: "2026-05-28T12:00:00Z",
+        actor: "op@example.com",
+        items: [
+          {
+            repo: "ippoan/auth-worker",
+            flipped_version_id: PENDING_VID,
+            flipped_tag: "v0.2.38",
+            rollback_to: "prior-aw-0001",
+            rollback_tag: "v0.2.37",
+          },
+        ],
+      },
+    });
+    const resp = await handleReleaseWaveFlipGroupRollback(
+      postRequest("/api/release-wave/pending-release/flip-group-rollback", {
+        formBody: { repo: "ippoan/auth-worker" },
+      }),
+      pendingFlipEnv(kv),
+    );
+    expect(resp.status).toBe(303);
+    expect(await getFlipGroup(kv)).toBeNull();
+  });
+
+  it("returns 404 when the specified repo is not in the flip group", async () => {
+    const resp = await handleReleaseWaveFlipGroupRollback(
+      postRequest("/api/release-wave/pending-release/flip-group-rollback", {
+        formBody: { repo: "ippoan/no-such" },
+      }),
+      pendingFlipEnv(twoItemGroupKv()),
+    );
+    expect(resp.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## 問題

flip-group パネル（直近の一括 flip）には一括「↩ Rollback last flip」ボタンしか無く、**特定 repo だけを rollback する UI が無かった**（#237、ユーザー指摘）。

## 変更

- **endpoint**: `/api/release-wave/pending-release/flip-group-rollback` に optional form field **`repo`** を追加。
  - 指定時 → その repo 1 件だけ flip 直前の version へ rollback（`release-wave-traffic-rollback` dispatch）。成功後、その repo を flip-group から除外（残り 0 なら group ごと削除）。
  - 未指定時 → 従来どおり全件一括 rollback（後方互換）。
- **UI** (`page.ts`): flip-group パネルの各行に「↩ Rollback」ボタンを追加（戻し先が記録された repo のみ）。一括ボタンは据え置き。
- **test**: 単一 rollback（指定 repo のみ dispatch + group から除外）/ 最後の 1 件で group 消去 / group に無い repo 指定で 404。

これで「nuxt-notify だけ rollback」のような単一操作が UI から行える（戻し先は flip 時に flip-group へ記録済みの値を使うため、stale な `traffic::` に依存しない）。

Refs ippoan/ci-dashboard#237

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNdmSA2s9AGH86Pu9eubVN)_