### PR TITLE
fix(release-wave): rollback→Pending releases 復活 + 既存 no-traffic version の Flip 救済

### DIFF
--- a/src/release-wave/api.ts
+++ b/src/release-wave/api.ts
@@ -22,6 +22,7 @@ import {
   getPendingRelease,
   clearPendingRelease,
   listPendingReleases,
+  recordPendingRelease,
   recordFlipGroup,
   getFlipGroup,
   clearFlipGroup,
@@ -631,6 +632,14 @@ export async function handleReleaseWaveFlipGroupRollback(
         error: `failed to dispatch rollback for ${repoFilter}: ${err}`,
       });
     }
+    // rollback で flip 対象 version は再び no-traffic に戻るので、Pending releases
+    // に再登録して再 flip できるようにする (Refs ippoan/ci-dashboard#237)。
+    await recordPendingRelease(env.COMPAT_KV, {
+      repo: item.repo,
+      version_id: item.flipped_version_id,
+      tag: item.flipped_tag,
+      now: new Date().toISOString(),
+    });
     // rollback した repo を group から除く。残りが無ければ group ごと消す。
     const remaining = group.items.filter((it) => it.repo !== repoFilter);
     if (remaining.length === 0) {
@@ -666,6 +675,20 @@ export async function handleReleaseWaveFlipGroupRollback(
     return jsonResponse(502, {
       code: "DISPATCH_FAILED",
       error: `failed to dispatch rollback for flip group (${rollbackable.length} repo(s)): ${err}`,
+    });
+  }
+
+  // dispatch 成功した repo は flip 対象 version が no-traffic に戻るので、
+  // Pending releases に再登録して再 flip できるようにする (Refs ippoan/ci-dashboard#237)。
+  const now = new Date().toISOString();
+  for (let i = 0; i < rollbackable.length; i++) {
+    if (!results[i]?.ok) continue;
+    const it = rollbackable[i]!;
+    await recordPendingRelease(env.COMPAT_KV, {
+      repo: it.repo,
+      version_id: it.flipped_version_id,
+      tag: it.flipped_tag,
+      now,
     });
   }
 

--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -323,8 +323,9 @@ export function renderTrafficVersionsBlock(
           ),
         )
         .join("");
-      // 直前以前の active version への rollback ボタン行を続ける。
-      return versionRows + renderTrafficRollbackRow(repo, rec);
+      // 直前以前の active version への rollback ボタン + 表示中 no-traffic
+      // (zeroShown) の Flip ボタン行を続ける。
+      return versionRows + renderTrafficRollbackRow(repo, rec, zeroShown);
     })
     .join("");
 
@@ -351,7 +352,11 @@ export function renderTrafficVersionsBlock(
  * 現 active は traffic の最大 percentage version。deploy_history[0] が現 active と
  * 一致する想定だが、念のため active version_id を除いて候補を作る。
  */
-function renderTrafficRollbackRow(repo: string, rec: TrafficRecord): string {
+function renderTrafficRollbackRow(
+  repo: string,
+  rec: TrafficRecord,
+  promotable: TrafficVersion[],
+): string {
   const versions = rec.versions ?? [];
   const history = rec.deploy_history ?? [];
   const activeId = versions.find((v) => v.percentage > 0)?.version_id ?? null;
@@ -359,27 +364,14 @@ function renderTrafficRollbackRow(repo: string, rec: TrafficRecord): string {
   // 候補: 過去に active だった (deploy_history) が現 active でないもの。
   const candidates = history.filter((e) => e.version_id !== activeId);
 
-  // 候補外: 現存する 0% (no-traffic) で、まだ一度も active になっていない
-  // (= deploy_history に過去 active として載っていない) version。新しい順。
-  const historyIds = new Set(history.map((e) => e.version_id));
-  const nonActive = versions
-    .filter(
-      (v) =>
-        v.percentage <= 0 &&
-        v.version_id !== activeId &&
-        !historyIds.has(v.version_id),
-    )
-    .sort((a, b) => {
-      const ca = a.created_on ?? "";
-      const cb = b.created_on ?? "";
-      if (ca === cb) return 0;
-      if (!ca) return 1;
-      if (!cb) return -1;
-      return ca < cb ? 1 : -1; // 新しい順
-    });
+  // promotable = renderTrafficVersionsBlock が「行として表示する no-traffic
+  // version」(= active より新しい最新 0% = zeroShown)。flip ボタンの対象を
+  // これに揃えることで、行表示と flip ボタンの対象がずれない (古い / 隠した
+  // 0% を勝手にボタン化しない)。active 自身は念のため除く。Refs ippoan/ci-dashboard#237。
+  const noTraffic = promotable.filter((v) => v.version_id !== activeId);
 
-  // 候補も候補外も無ければ従来どおり行を出さない。
-  if (candidates.length === 0 && nonActive.length === 0) return "";
+  // 候補も no-traffic も無ければ従来どおり行を出さない。
+  if (candidates.length === 0 && noTraffic.length === 0) return "";
 
   const buttons = candidates
     .map((e) => {
@@ -403,17 +395,11 @@ function renderTrafficRollbackRow(repo: string, rec: TrafficRecord): string {
       ? `<div class="meta" style="margin-top:4px">過去に active だった version がまだないため、戻せる先がありません。</div>`
       : "";
 
-  // 0% (no-traffic / 一度も active になっていない) version も「Flip to 100%」で
-  // 再 flip できるようにする (Refs ippoan/ci-dashboard#237)。flip → rollback で
-  // no-traffic に戻った version が Pending releases にも rollback 候補にも出ず
-  // 再 flip できなくなる事故 (= 旧 rollback が pending-release を復活させなかった
-  // 名残) の救済経路。traffic-rollback endpoint は versions[] にある version を
-  // そのまま `wrangler versions deploy <id>@100%` するので、これで promote できる。
-  // 新しい順に最大 5 件をボタン表示、残りは件数のみ。
-  const NON_ACTIVE_SHOW = 5;
-  const shownNonActive = nonActive.slice(0, NON_ACTIVE_SHOW);
-  const moreNonActive = nonActive.length - shownNonActive.length;
-  const nonActiveButtons = shownNonActive
+  // 表示中の no-traffic (0%) version に「Flip to 100%」を出す (Refs ippoan/ci-dashboard#237)。
+  // flip → rollback で no-traffic に戻った version が Pending releases にも rollback
+  // 候補にも出ず再 flip できなくなる事故の救済経路。traffic-rollback endpoint は
+  // versions[] にある version をそのまま `wrangler versions deploy <id>@100%` する。
+  const flipButtons = noTraffic
     .map((v) => {
       const label = v.tag ? escapeHtml(v.tag) : escapeHtml(shortId(v.version_id));
       const when = escapeHtml(shortWhen(v.created_on));
@@ -429,11 +415,10 @@ function renderTrafficRollbackRow(repo: string, rec: TrafficRecord): string {
     })
     .join("");
   const nonActiveBlock =
-    nonActive.length > 0
+    noTraffic.length > 0
       ? `<div style="margin-top:6px">
                 <span class="meta">no-traffic version を 100% に flip:</span>
-                <div style="margin-top:4px">${nonActiveButtons}</div>
-                ${moreNonActive > 0 ? `<div class="meta" style="margin-top:2px">他${moreNonActive}件</div>` : ""}
+                <div style="margin-top:4px">${flipButtons}</div>
               </div>`
       : "";
 

--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -403,17 +403,39 @@ function renderTrafficRollbackRow(repo: string, rec: TrafficRecord): string {
       ? `<div class="meta" style="margin-top:4px">過去に active だった version がまだないため、戻せる先がありません。</div>`
       : "";
 
-  // 候補外 (0% / 一度も active になっていない) version を理由付きで併記する。
-  // 最新 1 件を代表表示し、残りは「他N件」で件数だけ示す。
-  let nonActiveNote = "";
-  if (nonActive.length > 0) {
-    const head = nonActive[0]!;
-    const label = head.tag
-      ? escapeHtml(head.tag)
-      : escapeHtml(shortId(head.version_id));
-    const more = nonActive.length > 1 ? ` 他${nonActive.length - 1}件` : "";
-    nonActiveNote = `<div class="meta" style="margin-top:4px">候補外 (rollback 先になりません): ${label} (0% · 一度も active になっていない)${more}</div>`;
-  }
+  // 0% (no-traffic / 一度も active になっていない) version も「Flip to 100%」で
+  // 再 flip できるようにする (Refs ippoan/ci-dashboard#237)。flip → rollback で
+  // no-traffic に戻った version が Pending releases にも rollback 候補にも出ず
+  // 再 flip できなくなる事故 (= 旧 rollback が pending-release を復活させなかった
+  // 名残) の救済経路。traffic-rollback endpoint は versions[] にある version を
+  // そのまま `wrangler versions deploy <id>@100%` するので、これで promote できる。
+  // 新しい順に最大 5 件をボタン表示、残りは件数のみ。
+  const NON_ACTIVE_SHOW = 5;
+  const shownNonActive = nonActive.slice(0, NON_ACTIVE_SHOW);
+  const moreNonActive = nonActive.length - shownNonActive.length;
+  const nonActiveButtons = shownNonActive
+    .map((v) => {
+      const label = v.tag ? escapeHtml(v.tag) : escapeHtml(shortId(v.version_id));
+      const when = escapeHtml(shortWhen(v.created_on));
+      return `
+            <form method="post" action="/api/release-wave/traffic-rollback" style="margin:0 6px 4px 0;display:inline-block">
+              <input type="hidden" name="repo" value="${escapeHtml(repo)}">
+              <input type="hidden" name="version_id" value="${escapeHtml(v.version_id)}">
+              <button type="submit"
+                title="${escapeHtml(repo)} の no-traffic version ${escapeHtml(v.version_id)} を即 100% に flip (wrangler versions deploy ${escapeHtml(v.version_id)}@100%)">
+                Flip to ${label} <span class="meta">(0% · ${when})</span>
+              </button>
+            </form>`;
+    })
+    .join("");
+  const nonActiveBlock =
+    nonActive.length > 0
+      ? `<div style="margin-top:6px">
+                <span class="meta">no-traffic version を 100% に flip:</span>
+                <div style="margin-top:4px">${nonActiveButtons}</div>
+                ${moreNonActive > 0 ? `<div class="meta" style="margin-top:2px">他${moreNonActive}件</div>` : ""}
+              </div>`
+      : "";
 
   return `
             <tr>
@@ -422,7 +444,7 @@ function renderTrafficRollbackRow(repo: string, rec: TrafficRecord): string {
                 <span class="meta">Rollback to (過去の deployed version):</span>
                 ${noCandidateNote}
                 ${buttons ? `<div style="margin-top:4px">${buttons}</div>` : ""}
-                ${nonActiveNote}
+                ${nonActiveBlock}
               </td>
             </tr>`;
 }

--- a/test/release-wave/api.test.ts
+++ b/test/release-wave/api.test.ts
@@ -1045,6 +1045,10 @@ describe("handleReleaseWaveFlipGroupRollback", () => {
     });
     // rollback dispatch 後に flip-group は消える
     expect(await getFlipGroup(kv)).toBeNull();
+    // flip 対象 version は Pending releases に復活する
+    const restored = await getPendingRelease(kv, "ippoan/auth-worker");
+    expect(restored?.version_id).toBe(PENDING_VID);
+    expect(restored?.tag).toBe("v0.2.38");
   });
 });
 
@@ -1111,6 +1115,12 @@ describe("handleReleaseWaveFlipGroupRollback (single repo)", () => {
     const g = await getFlipGroup(kv);
     expect(g).not.toBeNull();
     expect(g!.items.map((i) => i.repo)).toEqual(["ippoan/nuxt-trouble"]);
+    // rollback した repo の flip 対象 version は Pending releases に復活する
+    const restored = await getPendingRelease(kv, "ippoan/auth-worker");
+    expect(restored?.version_id).toBe(PENDING_VID);
+    expect(restored?.tag).toBe("v0.2.38");
+    // rollback していない repo は Pending releases に出ない
+    expect(await getPendingRelease(kv, "ippoan/nuxt-trouble")).toBeNull();
   });
 
   it("clears the group when the last remaining repo is rolled back", async () => {

--- a/test/release-wave/repo-status-section.test.ts
+++ b/test/release-wave/repo-status-section.test.ts
@@ -400,10 +400,11 @@ describe("renderTrafficVersionsBlock", () => {
     expect(html).not.toContain("/api/release-wave/traffic-rollback");
   });
 
-  it("shows a reason (not a hidden row) when only no-traffic 0% versions exist (Refs #196)", () => {
+  it("offers a Flip-to-100% button for no-traffic 0% versions (Refs #196 / #237)", () => {
     // 現 active 1 つ + 0% no-traffic のみ。deploy_history は現 active だけなので
-    // rollback 候補は 0 件。従来は行ごと消えて理由が分からなかったが、候補外
-    // version を「rollback 先になりません」と理由付きで併記する。
+    // rollback (過去 active への戻し) 候補は 0 件。だが 0% no-traffic version は
+    // 「Flip to 100%」で再 flip できるようにする (#237: flip→rollback で戻った
+    // no-traffic version の救済)。
     const r: TrafficRecord = {
       schema_version: 4,
       repo: "ippoan/auth-worker",
@@ -422,14 +423,13 @@ describe("renderTrafficVersionsBlock", () => {
     );
     // 行は黙って消えない。
     expect(html).toContain("Rollback to (過去の deployed version):");
-    // 候補ゼロの理由が出る。
+    // 過去 active への rollback 候補ゼロの理由は出る。
     expect(html).toContain("戻せる先がありません");
-    // 候補外 version が理由付きで出る。
-    expect(html).toContain("候補外 (rollback 先になりません)");
+    // 0% no-traffic version は「Flip to 100%」ボタンで再 flip できる。
+    expect(html).toContain("no-traffic version を 100% に flip:");
     expect(html).toContain("v0.2.49");
-    expect(html).toContain("一度も active になっていない");
-    // 実 rollback ボタン (dispatch) は出さない。
-    expect(html).not.toContain('action="/api/release-wave/traffic-rollback"');
+    expect(html).toContain('action="/api/release-wave/traffic-rollback"');
+    expect(html).toContain('value="pending-id"');
   });
 });
 


### PR DESCRIPTION
## 問題（ユーザー指摘）

1. **rollback しても Pending releases に戻らない**: rollback（単一/一括）は直前 version を 100% に戻すが、戻った結果 no-traffic になる「flip していた version」を Pending releases に再登録していなかったため、再 flip できなかった。
2. **さっき（修正前）の rollback で戻ってない version がある**: 旧 rollback で no-traffic に戻った version は、Pending releases にも Traffic の rollback 候補にも出ず（「候補外 (rollback 先になりません)」と注記されるだけ）、再 flip 経路が無かった。

## 変更

**(1) rollback → Pending releases 復活** (`api.ts`)
`flip-group-rollback`（単一/一括）の dispatch 成功時に、その repo の `flipped_version_id` / `flipped_tag` で `recordPendingRelease` し、Pending releases に復活させる。→ rollback → 再 flip のループが回る。

**(2) 既存 orphaned no-traffic の救済** (`repo-status-section.ts`)
Traffic セクションの **0%（一度も active でない）no-traffic version に「Flip to 100%」ボタン**を追加（新しい順に最大 5 件）。既存の `traffic-rollback` endpoint（= `wrangler versions deploy <id>@100%`、`versions[]` にある version を受ける）で promote する。endpoint 改修不要。→ (1) 以前に戻れなくなった version もここから再 flip できる。

## test
- 単一/一括 rollback 後に `getPendingRelease` で復活を確認、未 rollback repo は出ないことも確認。
- 0% no-traffic version に Flip ボタン（traffic-rollback action + version_id）が出ることを確認（旧「候補外」注記の assertion を置換）。

Refs ippoan/ci-dashboard#237 Refs ippoan/ci-dashboard#196

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNdmSA2s9AGH86Pu9eubVN)_