### PR TITLE
fix(release-wave): pending-release の version_id UUID 強制を緩和 (cloudrun 対応)

### DIFF
--- a/src/release-wave/webhook.ts
+++ b/src/release-wave/webhook.ts
@@ -352,14 +352,15 @@ export async function handleBackendDeployReportWebhook(
  */
 const pendingReleaseSchema = z.object({
   repo: z.string().min(1),
-  // version_id は wrangler の version id (UUID)。flip 時に
-  // `wrangler versions deploy <id>@100%` に渡るため UUID 形式を強制する。
-  version_id: z
-    .string()
-    .regex(
-      /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/,
-      "version_id must be a UUID",
-    ),
+  // version_id:
+  //   - cloudflare-workers: wrangler の version id (UUID)。flip 時に
+  //     `wrangler versions deploy <id>@100%` に渡る。
+  //   - cloudrun: 単一 version id が無いので revision tag (例 `pending-v0-0-79`)
+  //     を入れる。flip-cloudrun は target_tag から `pending-<tag>` を再計算し
+  //     previewed_version_id は使わないため UUID でなくてよい。
+  // よって UUID 強制はやめ非空のみ要求する (flip 側が platform ごとに検証/無視)。
+  // Refs ippoan/ci-dashboard#237。
+  version_id: z.string().min(1),
   tag: z.string().min(1),
   preview_url: z.string().url().optional(),
 });

--- a/test/release-wave/webhook.test.ts
+++ b/test/release-wave/webhook.test.ts
@@ -612,19 +612,27 @@ describe("handlePendingReleaseWebhook", () => {
     expect(rec!.preview_url).toBeNull();
   });
 
-  it("rejects non-UUID version_id with 400", async () => {
+  it("accepts non-UUID version_id (cloudrun pending-<tag>) (Refs #237)", async () => {
+    // cloudrun は revision tag (pending-v0-0-79) を version_id に入れる。
+    // UUID 強制をやめたので 200 で受理し record を保存する。
     const kv = memKv();
     const { env } = fakeEnv({ compatKv: kv });
     const resp = await handlePendingReleaseWebhook(
       jsonRequest({
         url: PENDING_URL,
         secret: "expected-secret",
-        body: { repo: "ippoan/auth-worker", version_id: "not-a-uuid", tag: "v1.0.0" },
+        body: {
+          repo: "ippoan/rust-alc-api",
+          version_id: "pending-v0-0-79",
+          tag: "v0.0.79",
+        },
       }),
       env,
     );
-    expect(resp.status).toBe(400);
-    expect(await getPendingRelease(kv, "ippoan/auth-worker")).toBeNull();
+    expect(resp.status).toBe(200);
+    const rec = await getPendingRelease(kv, "ippoan/rust-alc-api");
+    expect(rec!.version_id).toBe("pending-v0-0-79");
+    expect(rec!.tag).toBe("v0.0.79");
   });
 
   it("rejects bad webhook secret with 401", async () => {


### PR DESCRIPTION
## 問題

rust-alc-api（cloudrun）の `report-pending-release`（#366）が `/webhooks/release-wave/pending-release` に POST した際、**HTTP 400** で弾かれ、rust-alc-api が「Pending releases」に登録されず flip できなかった。

実ログ:
```
reporting pending release: repo=ippoan/rust-alc-api tag=v0.0.79 version_id=pending-v0-0-79
curl: (22) The requested URL returned error: 400
```

## 根本原因

pending-release webhook の zod schema が **`version_id` を UUID 形式必須**にしていた（workers の `wrangler` version id 前提）。cloudrun は単一 version id を持たず revision tag `pending-v0-0-79` を送るため、UUID 検証に落ちて 400。

> Cloudflare Access ではない（Access なら 302/403。同 path の他 webhook = traffic-report / stage-report は成功しており、400 はアプリ到達後の schema 検証エラー）。

## 修正

`version_id` を UUID 強制 → **非空（`.min(1)`）** に緩和。

- cloudrun: flip-cloudrun は `target_tag` から `pending-<tag>` を再計算し `previewed_version_id` を使わないため UUID 不要。
- workers: UUID はそのまま `.min(1)` を満たすので影響なし。flip 側が platform ごとに UUID 検証/無視する。

test: 「非UUID→400」を「cloudrun `pending-<tag>` を 200 で受理」に置換。

Refs ippoan/ci-dashboard#237

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNdmSA2s9AGH86Pu9eubVN)_