### PR TITLE
refactor(release-wave): Pending releases を traffic から単一真実で導出

### DIFF
--- a/src/release-wave/api.ts
+++ b/src/release-wave/api.ts
@@ -396,23 +396,6 @@ function buildTrafficRollbackDispatch(
   };
 }
 
-/**
- * traffic record から「現在 active な version」(= flip 前の戻し先候補) を返す。
- * deploy_history の先頭 (index 0 = 現 active) を最優先。無ければ versions[] の
- * 100% / 最大 traffic から拾う。判定できなければ null。
- */
-function currentActiveVersion(
-  traffic: TrafficRecord | null,
-): { version_id: string; tag: string | null } | null {
-  if (!traffic) return null;
-  const hist = traffic.deploy_history ?? [];
-  if (hist[0]) return { version_id: hist[0].version_id, tag: hist[0].tag ?? null };
-  const active =
-    traffic.versions.find((v) => v.percentage === 100) ??
-    traffic.versions.find((v) => v.percentage > 0);
-  return active ? { version_id: active.version_id, tag: active.tag ?? null } : null;
-}
-
 // ----------------------------------------------------------------------------
 // POST /api/release-wave/pending-release/flip  (Refs #181 / #174)
 // ----------------------------------------------------------------------------
@@ -525,7 +508,8 @@ export async function handleReleaseWavePendingReleaseFlipAll(
   // source 別に dispatch を組む:
   //  - traffic (workers): traffic-rollback (wrangler versions deploy <id>@100%)
   //  - pending (cloudrun 等): release-wave-flip (handler が platform routing)
-  // 戻し先 (rollback_to) は traffic 由来のみ取れる (computeUnifiedPending が控える)。
+  // 戻し先 (rollback_to) は computeUnifiedPending が traffic:: record から控える
+  // (traffic source / pending source どちらも、traffic:: があれば現 active)。
   const dispatches = unified.map((u) =>
     u.source === "traffic"
       ? buildTrafficRollbackDispatch(u.repo, u.version_id, u.tag)
@@ -584,23 +568,32 @@ function unifiedToRecord(u: UnifiedPending): PendingReleaseRecord {
  */
 async function loadUnifiedPending(env: Env): Promise<UnifiedPending[]> {
   if (!env.COMPAT_KV) return [];
-  let trafficByRepo = new Map<string, TrafficRecord>();
-  try {
-    const compat = await computeGlobalCompatibility(env.COMPAT_KV);
-    const repos = new Set<string>();
-    for (const b of compat.backends) {
-      repos.add(b.backend_repo);
-      for (const m of b.matrix) repos.add(m.frontend);
-    }
-    trafficByRepo = await getTrafficForRepos(env.COMPAT_KV, repos);
-  } catch {
-    // traffic 取得失敗時は pending-release:: のみで degrade。
-  }
   let pending: PendingReleaseRecord[] = [];
   try {
     pending = await listPendingReleases(env.COMPAT_KV);
   } catch {
     pending = [];
+  }
+  // traffic を引く repo = compat グラフ (backend + frontend) ∪ pending repo。
+  // pending repo も含めることで、pending source (cloudrun 等で compat グラフに
+  // 出ていない repo) でも現 active を rollback 先として控えられる
+  // (= 一括 flip → flip-group rollback の戻し先確保、Refs #241)。
+  const repos = new Set<string>();
+  try {
+    const compat = await computeGlobalCompatibility(env.COMPAT_KV);
+    for (const b of compat.backends) {
+      repos.add(b.backend_repo);
+      for (const m of b.matrix) repos.add(m.frontend);
+    }
+  } catch {
+    // compat 取得失敗時は pending repo のみで degrade。
+  }
+  for (const r of pending) repos.add(r.repo);
+  let trafficByRepo = new Map<string, TrafficRecord>();
+  try {
+    trafficByRepo = await getTrafficForRepos(env.COMPAT_KV, repos);
+  } catch {
+    // traffic 取得失敗時は pending-release:: のみで degrade。
   }
   return computeUnifiedPending(trafficByRepo, pending);
 }

--- a/src/release-wave/api.ts
+++ b/src/release-wave/api.ts
@@ -15,6 +15,7 @@ import type { WaveState } from "./types";
 import {
   computeWaveCompatibility,
   computeCompatibility,
+  computeGlobalCompatibility,
   getBackendCurrent,
 } from "./compat";
 import { decideRetestDispatches, dispatchAll, type Dispatch } from "./dispatch";
@@ -26,10 +27,16 @@ import {
   recordFlipGroup,
   getFlipGroup,
   clearFlipGroup,
+  computeUnifiedPending,
   type PendingReleaseRecord,
   type FlipGroupItem,
+  type UnifiedPending,
 } from "./pending-release";
-import { getTraffic, type TrafficRecord } from "./traffic";
+import {
+  getTraffic,
+  getTrafficForRepos,
+  type TrafficRecord,
+} from "./traffic";
 import { serviceNameFromRevision } from "./revision";
 
 function hubStub(env: Env): DurableObjectStub<ReleaseWaveHub> {
@@ -507,40 +514,39 @@ export async function handleReleaseWavePendingReleaseFlipAll(
     });
   }
 
-  const records = await listPendingReleases(env.COMPAT_KV);
-  if (records.length === 0) {
+  // Pending releases の単一真実 (workers=traffic:: / cloudrun=pending-release::)
+  // を導出する (= 画面の表示と同じ source、Refs #237)。
+  const unified = await loadUnifiedPending(env);
+  if (unified.length === 0) {
     // flip 対象が無ければ何もせず一覧へ。
     return redirectToList();
   }
 
-  // flip 前に各 repo の現 active version (= 戻し先) を控える。
-  const rollbackByRepo = new Map<
-    string,
-    { version_id: string; tag: string | null } | null
-  >();
-  await Promise.all(
-    records.map(async (r) => {
-      const traffic = await getTraffic(env.COMPAT_KV, r.repo);
-      rollbackByRepo.set(r.repo, currentActiveVersion(traffic));
-    }),
+  // source 別に dispatch を組む:
+  //  - traffic (workers): traffic-rollback (wrangler versions deploy <id>@100%)
+  //  - pending (cloudrun 等): release-wave-flip (handler が platform routing)
+  // 戻し先 (rollback_to) は traffic 由来のみ取れる (computeUnifiedPending が控える)。
+  const dispatches = unified.map((u) =>
+    u.source === "traffic"
+      ? buildTrafficRollbackDispatch(u.repo, u.version_id, u.tag)
+      : buildPendingFlipDispatch(unifiedToRecord(u)),
   );
-
-  const dispatches = records.map(buildPendingFlipDispatch);
   const results = await dispatchAll(env, dispatches);
 
   const items: FlipGroupItem[] = [];
-  for (let i = 0; i < records.length; i++) {
-    const rec = records[i]!;
+  for (let i = 0; i < unified.length; i++) {
+    const u = unified[i]!;
     if (!results[i]?.ok) continue;
-    const rb = rollbackByRepo.get(rec.repo) ?? null;
     items.push({
-      repo: rec.repo,
-      flipped_version_id: rec.version_id,
-      flipped_tag: rec.tag,
-      rollback_to: rb?.version_id ?? null,
-      rollback_tag: rb?.tag ?? null,
+      repo: u.repo,
+      flipped_version_id: u.version_id,
+      flipped_tag: u.tag ?? "",
+      rollback_to: u.rollback_to,
+      rollback_tag: u.rollback_tag,
     });
-    await clearPendingRelease(env.COMPAT_KV, rec.repo);
+    // pending-release:: 由来 (cloudrun) は flip したので消す。traffic 由来は
+    // traffic-report (flip 後) が状態を更新するので KV 操作不要。
+    if (u.source === "pending") await clearPendingRelease(env.COMPAT_KV, u.repo);
   }
 
   if (items.length === 0) {
@@ -548,7 +554,7 @@ export async function handleReleaseWavePendingReleaseFlipAll(
     const err = failed && !failed.ok ? failed.error : "dispatch failed";
     return jsonResponse(502, {
       code: "DISPATCH_FAILED",
-      error: `failed to dispatch flip for all ${records.length} pending release(s): ${err}`,
+      error: `failed to dispatch flip for all ${unified.length} pending release(s): ${err}`,
     });
   }
 
@@ -558,6 +564,45 @@ export async function handleReleaseWavePendingReleaseFlipAll(
     items,
   });
   return redirectToList();
+}
+
+/** UnifiedPending を buildPendingFlipDispatch 用の record 形に変換する。 */
+function unifiedToRecord(u: UnifiedPending): PendingReleaseRecord {
+  return {
+    schema_version: 1,
+    repo: u.repo,
+    version_id: u.version_id,
+    tag: u.tag ?? "",
+    preview_url: u.preview_url,
+    uploaded_at: u.uploaded_at,
+  };
+}
+
+/**
+ * Pending releases の単一真実リストをサーバ側で導出する (Refs #237)。
+ * page.ts の表示と同じ source: workers=traffic:: / cloudrun=pending-release::。
+ */
+async function loadUnifiedPending(env: Env): Promise<UnifiedPending[]> {
+  if (!env.COMPAT_KV) return [];
+  let trafficByRepo = new Map<string, TrafficRecord>();
+  try {
+    const compat = await computeGlobalCompatibility(env.COMPAT_KV);
+    const repos = new Set<string>();
+    for (const b of compat.backends) {
+      repos.add(b.backend_repo);
+      for (const m of b.matrix) repos.add(m.frontend);
+    }
+    trafficByRepo = await getTrafficForRepos(env.COMPAT_KV, repos);
+  } catch {
+    // traffic 取得失敗時は pending-release:: のみで degrade。
+  }
+  let pending: PendingReleaseRecord[] = [];
+  try {
+    pending = await listPendingReleases(env.COMPAT_KV);
+  } catch {
+    pending = [];
+  }
+  return computeUnifiedPending(trafficByRepo, pending);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -24,8 +24,10 @@ import {
 import {
   listPendingReleases,
   getFlipGroup,
+  computeUnifiedPending,
   type PendingReleaseRecord,
   type FlipGroupRecord,
+  type UnifiedPending,
 } from "./pending-release";
 import { getTrafficForRepos, type TrafficRecord } from "./traffic";
 
@@ -207,8 +209,11 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
       flipGroup = null;
     }
   }
+  // Pending releases は単一真実 (Refs #237): workers=traffic:: の no-traffic
+  // version / cloudrun=pending-release:: を統合し、Traffic セクションと一致させる。
+  const unifiedPending = computeUnifiedPending(trafficByRepo, pendingReleases);
   const pendingReleaseSection = renderPendingReleaseSection(
-    pendingReleases,
+    unifiedPending,
     flipGroup,
   );
 
@@ -524,7 +529,7 @@ export async function handleReleaseWaveDetailPage(
  * (= 「ここで単独リリースを flip できる」affordance を常設)。
  */
 function renderPendingReleaseSection(
-  records: PendingReleaseRecord[],
+  records: UnifiedPending[],
   flipGroup: FlipGroupRecord | null,
 ): string {
   const rows = records
@@ -535,22 +540,37 @@ function renderPendingReleaseSection(
         : `<span class="meta">—</span>`;
       const shortVid =
         r.version_id.length > 8 ? r.version_id.slice(0, 8) : r.version_id;
-      return `
-        <tr>
-          <td>${escapeHtml(r.repo)}</td>
-          <td class="meta">${escapeHtml(r.tag)}</td>
-          <td class="meta" title="${escapeHtml(r.version_id)}">${escapeHtml(shortVid)}…</td>
-          <td>${previewCell}</td>
-          <td class="meta">${escapeHtml(r.uploaded_at)}</td>
-          <td class="actions">
-            <form method="post" action="/api/release-wave/pending-release/flip" style="margin:0">
+      const tagCell = r.tag ? escapeHtml(r.tag) : `<span class="meta">—</span>`;
+      // flip 入口は source 別:
+      //  - traffic (workers): /traffic-rollback に version_id を渡して
+      //    `wrangler versions deploy <id>@100%`。
+      //  - pending (cloudrun 等): /pending-release/flip に repo を渡す
+      //    (handler が platform で routing、cloudrun は target_tag→pending-<tag>)。
+      const flipForm =
+        r.source === "traffic"
+          ? `<form method="post" action="/api/release-wave/traffic-rollback" style="margin:0">
               <input type="hidden" name="repo" value="${escapeHtml(r.repo)}">
+              <input type="hidden" name="version_id" value="${escapeHtml(r.version_id)}">
               <button type="submit"
                 title="Promote this no-traffic version to 100% (wrangler versions deploy ${escapeHtml(r.version_id)}@100%)">
                 Flip to 100%
               </button>
-            </form>
-          </td>
+            </form>`
+          : `<form method="post" action="/api/release-wave/pending-release/flip" style="margin:0">
+              <input type="hidden" name="repo" value="${escapeHtml(r.repo)}">
+              <button type="submit"
+                title="Promote this no-traffic release to 100% traffic">
+                Flip to 100%
+              </button>
+            </form>`;
+      return `
+        <tr>
+          <td>${escapeHtml(r.repo)}</td>
+          <td class="meta">${tagCell}</td>
+          <td class="meta" title="${escapeHtml(r.version_id)}">${escapeHtml(shortVid)}…</td>
+          <td>${previewCell}</td>
+          <td class="meta">${escapeHtml(r.uploaded_at)}</td>
+          <td class="actions">${flipForm}</td>
         </tr>`;
     })
     .join("");
@@ -579,15 +599,16 @@ function renderPendingReleaseSection(
         </thead>
         <tbody>${rows}</tbody>
       </table>`
-    : `<p class="meta">no-traffic でアップロード済みの単独リリースはありません。
-        v* tag を打つと frontend-ci がここに version を登録する。</p>`;
+    : `<p class="meta">flip 待ちの no-traffic version はありません。
+        v* tag を打つと no-traffic で deploy され、ここに出ます。</p>`;
 
   return `
     <div class="section">
       <h2>Pending releases (no-traffic)</h2>
-      <p class="meta">単独 <code>v*</code> リリースで <code>wrangler versions upload</code>
-        した no-traffic version。Flip で 100% traffic へ promote する。
-        Refs <a href="https://github.com/ippoan/ci-dashboard/issues/181">#181</a>.</p>
+      <p class="meta">flip 待ちの no-traffic version (= Cloudflare 実機 0% / cloudrun
+        pending revision)。Flip で 100% traffic へ promote する。Traffic セクションと
+        同じ単一真実 (traffic 由来) から導出。
+        Refs <a href="https://github.com/ippoan/ci-dashboard/issues/237">#237</a>.</p>
       ${body}
       ${renderFlipGroupRollback(flipGroup)}
     </div>`;

--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -172,29 +172,11 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
       globalCompat = null;
     }
   }
-  // compat グラフに出る repo (backend + frontend) の version traffic を引く。
-  // グラフの frontend ノード hover に「現 active version の % / id」を出す用。
-  let trafficByRepo: Map<string, TrafficRecord> = new Map();
-  if (env.COMPAT_KV && globalCompat) {
-    const repos = new Set<string>();
-    for (const b of globalCompat.backends) {
-      repos.add(b.backend_repo);
-      for (const m of b.matrix) repos.add(m.frontend);
-    }
-    try {
-      trafficByRepo = await getTrafficForRepos(env.COMPAT_KV, repos);
-    } catch {
-      trafficByRepo = new Map();
-    }
-  }
-  const compatSection = renderGlobalCompatibilitySection(
-    globalCompat,
-    buildActiveWaveInfo(waves),
-    trafficByRepo,
-  );
-
   // 単独 v* リリースで upload された no-traffic version の一覧 (Refs #181)。
   // + 直近の一括 flip (flip-group) — 一括 rollback 用 (Refs #237)。
+  // traffic fetch より先に引く: pending repo の traffic も併せて取得して、
+  // computeUnifiedPending が pending source の rollback 先を埋められるようにする
+  // (= flip-all / flip-group rollback と表示を揃える、Refs #241)。
   let pendingReleases: PendingReleaseRecord[] = [];
   let flipGroup: FlipGroupRecord | null = null;
   if (env.COMPAT_KV) {
@@ -209,6 +191,32 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
       flipGroup = null;
     }
   }
+
+  // compat グラフに出る repo (backend + frontend) + pending repo の version
+  // traffic を引く。グラフの frontend ノード hover に「現 active version の
+  // % / id」を出す用 + Pending releases の単一真実導出用 (Refs #237)。
+  let trafficByRepo: Map<string, TrafficRecord> = new Map();
+  if (env.COMPAT_KV) {
+    const repos = new Set<string>();
+    if (globalCompat) {
+      for (const b of globalCompat.backends) {
+        repos.add(b.backend_repo);
+        for (const m of b.matrix) repos.add(m.frontend);
+      }
+    }
+    for (const r of pendingReleases) repos.add(r.repo);
+    try {
+      trafficByRepo = await getTrafficForRepos(env.COMPAT_KV, repos);
+    } catch {
+      trafficByRepo = new Map();
+    }
+  }
+  const compatSection = renderGlobalCompatibilitySection(
+    globalCompat,
+    buildActiveWaveInfo(waves),
+    trafficByRepo,
+  );
+
   // Pending releases は単一真実 (Refs #237): workers=traffic:: の no-traffic
   // version / cloudrun=pending-release:: を統合し、Traffic セクションと一致させる。
   const unifiedPending = computeUnifiedPending(trafficByRepo, pendingReleases);

--- a/src/release-wave/pending-release.ts
+++ b/src/release-wave/pending-release.ts
@@ -161,3 +161,122 @@ export async function getFlipGroup(
 export async function clearFlipGroup(kv: KVNamespace): Promise<void> {
   await kv.delete(FLIP_GROUP_KEY);
 }
+
+// ----------------------------------------------------------------------------
+// 単一真実の Pending releases 導出 (Refs #237)
+// ----------------------------------------------------------------------------
+//
+// 「flip 待ちの no-traffic version」を 1 系統に統合する。従来は
+// pending-release:: KV と traffic:: の 0% version が別々に表示され drift して
+// いた。ここでは:
+//   - workers (traffic::<repo> を持つ): Cloudflare 実機 (traffic-report) の
+//     no-traffic promotable version を真実とする。flip は traffic-rollback 経由
+//     (= wrangler versions deploy <id>@100%)。
+//   - cloudrun 等 (traffic:: を持たない): pending-release:: record を使う。
+//     flip は pending-release/flip 経由 (handler が platform routing)。
+// traffic:: を持つ repo は traffic:: を優先し、pending-release:: は無視する。
+
+import type { TrafficRecord, TrafficVersion } from "./traffic";
+
+/** flip 入口の種別。traffic=workers / pending=cloudrun 等。 */
+export type PendingSource = "traffic" | "pending";
+
+/** Pending releases の 1 行 (統合表現)。 */
+export interface UnifiedPending {
+  repo: string;
+  version_id: string;
+  tag: string | null;
+  uploaded_at: string;
+  preview_url: string | null;
+  source: PendingSource;
+  /** flip 直前の active version (= rollback 先)。traffic source のみ取れる。 */
+  rollback_to: string | null;
+  rollback_tag: string | null;
+}
+
+/**
+ * traffic record から「flip 待ちの最新 no-traffic version」を返す。
+ * = 0% かつ現 active より新しい version の最新 1 件 (renderTrafficVersionsBlock の
+ * zeroShown と同義)。無ければ null。
+ */
+export function noTrafficPromotable(
+  rec: TrafficRecord,
+): TrafficVersion | null {
+  const versions = rec.versions ?? [];
+  const active = versions.filter((v) => v.percentage > 0);
+  const activeNewest = active
+    .map((v) => v.created_on)
+    .filter((c): c is string => !!c)
+    .sort()
+    .at(-1);
+  const zero = versions
+    .filter((v) => v.percentage <= 0)
+    .filter((v) => {
+      if (!activeNewest) return true; // active の日時不明 → 全て候補
+      if (!v.created_on) return false; // 日時不明の古い 0% は除外
+      return v.created_on > activeNewest; // active より新しいものだけ
+    })
+    .sort((a, b) => {
+      const ca = a.created_on ?? "";
+      const cb = b.created_on ?? "";
+      if (ca === cb) return 0;
+      if (!ca) return 1;
+      if (!cb) return -1;
+      return ca < cb ? 1 : -1; // 新しい順
+    });
+  return zero[0] ?? null;
+}
+
+/** traffic record の現 active version (= rollback 先候補) を返す。 */
+function currentActiveOf(
+  rec: TrafficRecord,
+): { version_id: string; tag: string | null } | null {
+  const hist = rec.deploy_history ?? [];
+  if (hist[0]) return { version_id: hist[0].version_id, tag: hist[0].tag ?? null };
+  const a =
+    (rec.versions ?? []).find((v) => v.percentage === 100) ??
+    (rec.versions ?? []).find((v) => v.percentage > 0);
+  return a ? { version_id: a.version_id, tag: a.tag ?? null } : null;
+}
+
+/**
+ * Pending releases の単一真実リストを組む (Refs #237)。uploaded_at 降順。
+ */
+export function computeUnifiedPending(
+  trafficByRepo: Map<string, TrafficRecord>,
+  pendingRecords: PendingReleaseRecord[],
+): UnifiedPending[] {
+  const out: UnifiedPending[] = [];
+  const seen = new Set<string>();
+  for (const [repo, rec] of trafficByRepo) {
+    const v = noTrafficPromotable(rec);
+    if (!v) continue;
+    const active = currentActiveOf(rec);
+    out.push({
+      repo,
+      version_id: v.version_id,
+      tag: v.tag ?? null,
+      uploaded_at: v.created_on ?? "",
+      preview_url: null,
+      source: "traffic",
+      rollback_to: active?.version_id ?? null,
+      rollback_tag: active?.tag ?? null,
+    });
+    seen.add(repo);
+  }
+  for (const r of pendingRecords) {
+    if (seen.has(r.repo)) continue; // traffic:: を持つ repo は traffic:: 優先
+    out.push({
+      repo: r.repo,
+      version_id: r.version_id,
+      tag: r.tag,
+      uploaded_at: r.uploaded_at,
+      preview_url: r.preview_url ?? null,
+      source: "pending",
+      rollback_to: null,
+      rollback_tag: null,
+    });
+  }
+  out.sort((a, b) => (a.uploaded_at < b.uploaded_at ? 1 : -1));
+  return out;
+}

--- a/src/release-wave/pending-release.ts
+++ b/src/release-wave/pending-release.ts
@@ -265,7 +265,13 @@ export function computeUnifiedPending(
     seen.add(repo);
   }
   for (const r of pendingRecords) {
-    if (seen.has(r.repo)) continue; // traffic:: を持つ repo は traffic:: 優先
+    if (seen.has(r.repo)) continue; // traffic:: の no-traffic version を持つ repo は traffic:: 優先
+    // pending source (cloudrun 等) でも traffic:: record があれば現 active を
+    // rollback 先として控える (= 一括 flip → flip-group rollback の戻し先確保、
+    // Refs ippoan/ci-dashboard#241)。traffic:: が無ければ null (戻し先不明)。
+    const active = trafficByRepo.has(r.repo)
+      ? currentActiveOf(trafficByRepo.get(r.repo)!)
+      : null;
     out.push({
       repo: r.repo,
       version_id: r.version_id,
@@ -273,8 +279,8 @@ export function computeUnifiedPending(
       uploaded_at: r.uploaded_at,
       preview_url: r.preview_url ?? null,
       source: "pending",
-      rollback_to: null,
-      rollback_tag: null,
+      rollback_to: active?.version_id ?? null,
+      rollback_tag: active?.tag ?? null,
     });
   }
   out.sort((a, b) => (a.uploaded_at < b.uploaded_at ? 1 : -1));

--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -323,9 +323,9 @@ export function renderTrafficVersionsBlock(
           ),
         )
         .join("");
-      // 直前以前の active version への rollback ボタン + 表示中 no-traffic
-      // (zeroShown) の Flip ボタン行を続ける。
-      return versionRows + renderTrafficRollbackRow(repo, rec, zeroShown);
+      // 直前以前の active version への rollback ボタン行を続ける
+      // (no-traffic version の flip は Pending releases に一本化、Refs #237)。
+      return versionRows + renderTrafficRollbackRow(repo, rec);
     })
     .join("");
 
@@ -352,11 +352,7 @@ export function renderTrafficVersionsBlock(
  * 現 active は traffic の最大 percentage version。deploy_history[0] が現 active と
  * 一致する想定だが、念のため active version_id を除いて候補を作る。
  */
-function renderTrafficRollbackRow(
-  repo: string,
-  rec: TrafficRecord,
-  promotable: TrafficVersion[],
-): string {
+function renderTrafficRollbackRow(repo: string, rec: TrafficRecord): string {
   const versions = rec.versions ?? [];
   const history = rec.deploy_history ?? [];
   const activeId = versions.find((v) => v.percentage > 0)?.version_id ?? null;
@@ -364,14 +360,10 @@ function renderTrafficRollbackRow(
   // 候補: 過去に active だった (deploy_history) が現 active でないもの。
   const candidates = history.filter((e) => e.version_id !== activeId);
 
-  // promotable = renderTrafficVersionsBlock が「行として表示する no-traffic
-  // version」(= active より新しい最新 0% = zeroShown)。flip ボタンの対象を
-  // これに揃えることで、行表示と flip ボタンの対象がずれない (古い / 隠した
-  // 0% を勝手にボタン化しない)。active 自身は念のため除く。Refs ippoan/ci-dashboard#237。
-  const noTraffic = promotable.filter((v) => v.version_id !== activeId);
-
-  // 候補も no-traffic も無ければ従来どおり行を出さない。
-  if (candidates.length === 0 && noTraffic.length === 0) return "";
+  // no-traffic (0%) version の flip は「Pending releases」セクションに一本化した
+  // (Refs ippoan/ci-dashboard#237)。Traffic セクションの本行は「過去に active
+  // だった version へ戻す」rollback 専用。戻し先が無ければ行を出さない。
+  if (candidates.length === 0) return "";
 
   const buttons = candidates
     .map((e) => {
@@ -389,47 +381,12 @@ function renderTrafficRollbackRow(
     })
     .join("");
 
-  // 候補が 1 件も無いとき、行が黙って消える挙動をやめて理由を出す (Refs #196)。
-  const noCandidateNote =
-    candidates.length === 0
-      ? `<div class="meta" style="margin-top:4px">過去に active だった version がまだないため、戻せる先がありません。</div>`
-      : "";
-
-  // 表示中の no-traffic (0%) version に「Flip to 100%」を出す (Refs ippoan/ci-dashboard#237)。
-  // flip → rollback で no-traffic に戻った version が Pending releases にも rollback
-  // 候補にも出ず再 flip できなくなる事故の救済経路。traffic-rollback endpoint は
-  // versions[] にある version をそのまま `wrangler versions deploy <id>@100%` する。
-  const flipButtons = noTraffic
-    .map((v) => {
-      const label = v.tag ? escapeHtml(v.tag) : escapeHtml(shortId(v.version_id));
-      const when = escapeHtml(shortWhen(v.created_on));
-      return `
-            <form method="post" action="/api/release-wave/traffic-rollback" style="margin:0 6px 4px 0;display:inline-block">
-              <input type="hidden" name="repo" value="${escapeHtml(repo)}">
-              <input type="hidden" name="version_id" value="${escapeHtml(v.version_id)}">
-              <button type="submit"
-                title="${escapeHtml(repo)} の no-traffic version ${escapeHtml(v.version_id)} を即 100% に flip (wrangler versions deploy ${escapeHtml(v.version_id)}@100%)">
-                Flip to ${label} <span class="meta">(0% · ${when})</span>
-              </button>
-            </form>`;
-    })
-    .join("");
-  const nonActiveBlock =
-    noTraffic.length > 0
-      ? `<div style="margin-top:6px">
-                <span class="meta">no-traffic version を 100% に flip:</span>
-                <div style="margin-top:4px">${flipButtons}</div>
-              </div>`
-      : "";
-
   return `
             <tr>
               <td></td>
               <td colspan="3">
                 <span class="meta">Rollback to (過去の deployed version):</span>
-                ${noCandidateNote}
-                ${buttons ? `<div style="margin-top:4px">${buttons}</div>` : ""}
-                ${nonActiveBlock}
+                <div style="margin-top:4px">${buttons}</div>
               </td>
             </tr>`;
 }

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -123,11 +123,12 @@ describe("handleReleaseWaveListPage", () => {
     expect(html).toContain("No release waves yet");
   });
 
-  it("shows the Pending releases section placeholder when none (Refs #181)", async () => {
+  it("shows the Pending releases section placeholder when none (Refs #181 / #237)", async () => {
     const env = fakeEnv({ listReturn: [], compatKv: memKv() });
     const html = await (await handleReleaseWaveListPage(env)).text();
     expect(html).toContain("Pending releases (no-traffic)");
-    expect(html).toContain("単独");
+    // 単一真実化後 (#237) の placeholder 文言。
+    expect(html).toContain("flip 待ちの no-traffic version はありません");
     expect(html).not.toContain("Flip to 100%");
   });
 

--- a/test/release-wave/repo-status-section.test.ts
+++ b/test/release-wave/repo-status-section.test.ts
@@ -400,11 +400,11 @@ describe("renderTrafficVersionsBlock", () => {
     expect(html).not.toContain("/api/release-wave/traffic-rollback");
   });
 
-  it("offers a Flip-to-100% button for no-traffic 0% versions (Refs #196 / #237)", () => {
+  it("no longer renders a Flip button in the Traffic section for no-traffic 0% versions (moved to Pending releases, Refs #237)", () => {
     // 現 active 1 つ + 0% no-traffic のみ。deploy_history は現 active だけなので
-    // rollback (過去 active への戻し) 候補は 0 件。だが 0% no-traffic version は
-    // 「Flip to 100%」で再 flip できるようにする (#237: flip→rollback で戻った
-    // no-traffic version の救済)。
+    // 過去 active への rollback 候補は 0 件。0% no-traffic version の flip は
+    // 「Pending releases」セクションに一本化した (#237) ので、Traffic セクションの
+    // 本ブロックには flip ボタンも、戻し先ゼロの rollback 行も出ない。
     const r: TrafficRecord = {
       schema_version: 4,
       repo: "ippoan/auth-worker",
@@ -421,15 +421,15 @@ describe("renderTrafficVersionsBlock", () => {
       ["ippoan/auth-worker"],
       new Map([["ippoan/auth-worker", r]]),
     );
-    // 行は黙って消えない。
-    expect(html).toContain("Rollback to (過去の deployed version):");
-    // 過去 active への rollback 候補ゼロの理由は出る。
-    expect(html).toContain("戻せる先がありません");
-    // 0% no-traffic version は「Flip to 100%」ボタンで再 flip できる。
-    expect(html).toContain("no-traffic version を 100% に flip:");
+    // 0% no-traffic version は version split の行としては引き続き表示される。
+    expect(html).toContain("pending-id");
     expect(html).toContain("v0.2.49");
-    expect(html).toContain('action="/api/release-wave/traffic-rollback"');
-    expect(html).toContain('value="pending-id"');
+    // が、Traffic セクションからの flip 経路 (二重表示の片割れ) は撤去された。
+    expect(html).not.toContain("no-traffic version を 100% に flip:");
+    expect(html).not.toContain('action="/api/release-wave/traffic-rollback"');
+    expect(html).not.toContain('value="pending-id"');
+    // 過去 active への rollback 候補が無いので rollback 行自体も出ない。
+    expect(html).not.toContain("Rollback to (過去の deployed version):");
   });
 });
 


### PR DESCRIPTION
## 概要

`ippoan/ci-dashboard#244` スレッド B (WIP) の完成。「flip 待ち no-traffic version」が **2 系統** (`pending-release::` KV = Pending releases セクション / `traffic::` 0% = Traffic の Flip ボタン #242) で別々に表示され「ずれていた」問題を、**Pending releases を単一真実から導出**する形で解消する。

WIP branch `claude/sweet-noether-Bbfyx` (commit `6e5b5e3`) を取り込み、未完だった test 追従・退行修正・未使用クリーンアップを完了させた。

## 変更

### 実装 (WIP 由来 + 本 PR で補完)
- **`pending-release.ts`**: `computeUnifiedPending` / `noTrafficPromotable`。workers = `traffic::` の no-traffic promotable / cloudrun = `pending-release::` を統合 (traffic 優先)。
  - 本 PR 追加: pending source (cloudrun 等) でも `traffic::` record があれば現 active を `rollback_to` に控える。
- **`page.ts`**: `renderPendingReleaseSection` を `UnifiedPending[]` 対応に。source 別 flip 入口 (traffic→`/traffic-rollback` with version_id / pending→`/pending-release/flip` with repo)。
  - 本 PR 追加: traffic fetch に pending repo を含め、flip-all / flip-group rollback と表示の source 判定を揃える。
- **`repo-status-section.ts`**: Traffic セクションの重複 Flip ボタン (#242) を撤去 → rollback-to-past-active 専用に。
- **`api.ts`**: `handleReleaseWavePendingReleaseFlipAll` を `loadUnifiedPending` ベースに (source 別 dispatch、flip-group 記録)。
  - 本 PR 追加: `loadUnifiedPending` を compat グラフ ∪ pending repo の traffic fetch に変更し、pending source でも rollback 先を導出 (**cloudrun の flip-group rollback #241 を退行させない**)。未使用 `currentActiveVersion` を削除。

### test 追従
- `page.test.ts`: Pending releases placeholder 文言を #237 後に更新。
- `repo-status-section.test.ts`: Traffic セクションの no-traffic flip ボタン撤去を反映 (flip 経路は Pending releases に一本化)。

## 受け入れ条件 (#244 スレッド B)
- [x] Pending releases と Traffic セクションの「flip 待ち no-traffic」を単一真実 (traffic 由来) から導出 → 二重表示解消
- [x] Pending releases の per-row Flip / Flip all が source 別に正しく dispatch
- [x] pending source の rollback 先保全 (#241 退行回避)
- [ ] vitest / typecheck green ← **CI で検証** (ローカルは `@ippoan` GitHub Packages auth 不可で未実行)

## 注記
スレッド A (cloudrun flip インフラ = `release-wave-gcp` proxy の初回構築) は SA 作成・IAM grant・Cloud Run 初回 deploy・Secret 作成という GCP 管理操作で、issue 自身が「user 判断ポイント」と明記しているため本 PR には含めない。別途 user 確認の上で対応する。

Refs ippoan/ci-dashboard#244
Refs ippoan/ci-dashboard#237

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYnhZeg24YNLyZsSb87YTo)_