### PR TITLE
feat(release-wave): stuck wave を terminal failed に落とす force-clear 経路

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ import {
   handleReleaseWaveApprove,
   handleReleaseWaveRollback,
   handleReleaseWaveAbort,
+  handleReleaseWaveForceFail,
   handleReleaseWaveRetest,
   handleReleaseWaveRetestConsumer,
   handleReleaseWavePendingReleaseFlip,
@@ -282,6 +283,10 @@ app.post("/api/release-wave/:wave_id/rollback", (c) =>
 );
 app.post("/api/release-wave/:wave_id/abort", (c) =>
   handleReleaseWaveAbort(c.req.raw, c.env, c.req.param("wave_id")),
+);
+// stuck wave (flipping のまま hang 等) を terminal failed に落とす force-clear。
+app.post("/api/release-wave/:wave_id/fail", (c) =>
+  handleReleaseWaveForceFail(c.req.raw, c.env, c.req.param("wave_id")),
 );
 // compatibility matrix の赤 frontend に release-wave-retest を fan-out
 // (Refs #157 Phase B)。form field `frontend` で 1 件指定可、無ければ全 red。

--- a/src/mcp/tools/release-wave.ts
+++ b/src/mcp/tools/release-wave.ts
@@ -1,12 +1,13 @@
 /**
- * Release Wave 機構の MCP tools (6 個)。
+ * Release Wave 機構の MCP tools (7 個)。
  *
  * 設計の親 issue: ippoan/ci-dashboard#137
  *
  * 注: stage phase 撤去 (Refs ippoan/ci-workflows#96①) に伴い
  * `release_wave_start` / `release_wave_stage` tool は削除した。wave は Pending
  * releases / flip-all 経路で driven され、本 tool 群は status/approve/flip/
- * rollback/abort/contract_applied の 6 個。
+ * rollback/abort/fail/contract_applied の 7 個。
+ * (`release_wave_fail` = stuck wave を terminal failed に落とす force-clear 経路)
  *
  * 各 tool は ReleaseWaveHub DO の RPC を 1:1 で呼び出す薄い wrapper。
  * 認証は MCP server 側 (auth-worker introspect) で済んでいる前提。
@@ -228,6 +229,26 @@ export function registerReleaseWaveTools(server: McpServer, env: Env): void {
     },
     async ({ wave_id, aborted_by, reason }) => {
       const result = await hubStub(env).abort({ wave_id, aborted_by, reason });
+      return formatRpcResult(result);
+    },
+  );
+
+  // ============================================================
+  // release_wave_fail  (force-clear a stuck wave)
+  // ============================================================
+  server.registerTool(
+    "release_wave_fail",
+    {
+      description:
+        "Force-fail an in-progress wave to the terminal 'failed' state. Use to clear a stuck wave (e.g. a 'flipping' wave whose flip-report callback never arrived). Valid in staging / pending-approval / flipping; on a 'flipped' wave use rollback instead.",
+      inputSchema: {
+        wave_id: z.string().min(1),
+        reason: z.string().min(1).describe("Free-form reason recorded in audit"),
+      },
+      annotations: { readOnlyHint: false },
+    },
+    async ({ wave_id, reason }) => {
+      const result = await hubStub(env).fail({ wave_id, reason });
       return formatRpcResult(result);
     },
   );

--- a/src/release-wave/api.ts
+++ b/src/release-wave/api.ts
@@ -184,6 +184,51 @@ export async function handleReleaseWaveAbort(
 }
 
 // ----------------------------------------------------------------------------
+// POST /api/release-wave/:wave_id/fail  (force-clear a stuck wave)
+// ----------------------------------------------------------------------------
+
+/**
+ * in-progress な wave を terminal `failed` へ強制遷移させる (force-clear)。
+ *
+ * abort は flip 前 (staging / pending-approval) のみ、rollback は flipped のみ
+ * 有効なので、flip 途中で callback が来ず `flipping` のまま hang した wave は
+ * どちらでも片付けられなかった (= 「失敗してるのに進んでる」stuck 状態)。
+ * `fail` event は staging / pending-approval / flipping で有効なので、これを
+ * operator 経路として公開して stuck wave を terminal に落とす。`flipped` wave は
+ * applyFail が INVALID_TRANSITION で弾く (= rollback を使う)。
+ */
+export async function handleReleaseWaveForceFail(
+  req: Request,
+  env: Env,
+  wave_id: string,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return jsonResponse(405, { code: "METHOD_NOT_ALLOWED", error: "use POST" });
+  }
+  let reason = "force-failed via admin UI (stuck wave clear)";
+  try {
+    const form = await req.formData();
+    const r = String(form.get("reason") ?? "").trim();
+    if (r) reason = r;
+  } catch {
+    // form-data 以外は default reason
+  }
+  // audit: 操作者を reason に併記 (FailInput は actor field を持たないため)
+  reason = `${reason} [by ${actorEmail(req)}]`;
+  const result = (await hubStub(env).fail({
+    wave_id,
+    reason,
+  })) as RpcResult<WaveState>;
+  if (!result.ok) {
+    return jsonResponse(rpcErrorToHttpStatus(result.code), {
+      code: result.code,
+      error: result.error,
+    });
+  }
+  return redirectToDetail(wave_id);
+}
+
+// ----------------------------------------------------------------------------
 // POST /api/release-wave/:wave_id/retest  (Refs #157 Phase B)
 // ----------------------------------------------------------------------------
 

--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -343,6 +343,12 @@ export async function handleReleaseWaveDetailPage(
   const canApprove = w.state === "pending-approval";
   const canRollback = w.state === "flipped";
   const canAbort = w.state === "staging" || w.state === "pending-approval";
+  // force-fail (stuck wave clear): in-progress (staging / pending-approval /
+  // flipping) で有効。flipped は rollback を使うので対象外、terminal は不可。
+  const canForceFail =
+    w.state === "staging" ||
+    w.state === "pending-approval" ||
+    w.state === "flipping";
 
   const rollbackDisabledNote = !w.rollback.safe
     ? `<div class="unsafe">
@@ -383,6 +389,12 @@ export async function handleReleaseWaveDetailPage(
         <button type="submit" class="warn" ${canAbort ? "" : "disabled"}
           title="Abort before flip (valid in staging / pending-approval only)">
           Abort
+        </button>
+      </form>
+      <form method="post" action="/api/release-wave/${encodeURIComponent(w.wave_id)}/fail">
+        <button type="submit" class="danger" ${canForceFail ? "" : "disabled"}
+          title="Force-fail a stuck wave to terminal 'failed' (valid in staging / pending-approval / flipping). Use when a flip hung without a callback. For a flipped wave use Rollback instead.">
+          Force-fail (clear)
         </button>
       </form>
     </div>

--- a/test/mcp/release-wave.test.ts
+++ b/test/mcp/release-wave.test.ts
@@ -122,13 +122,14 @@ const STUB_ERR = {
 // ----------------------------------------------------------------------------
 
 describe("registerReleaseWaveTools registration", () => {
-  it("registers exactly 6 tools with expected names", () => {
+  it("registers exactly 7 tools with expected names", () => {
     const { tools } = setup();
     expect(Array.from(tools.keys()).sort()).toEqual(
       [
         "release_wave_abort",
         "release_wave_approve",
         "release_wave_contract_applied",
+        "release_wave_fail",
         "release_wave_flip",
         "release_wave_rollback",
         "release_wave_status",
@@ -289,6 +290,21 @@ describe("release_wave_abort", () => {
       wave_id: "w1",
       aborted_by: "ops",
       reason: "smoke broken",
+    });
+  });
+});
+
+describe("release_wave_fail", () => {
+  it("forwards wave_id + reason to hub.fail", async () => {
+    const { tools, spies } = setup();
+    spies.fail.mockResolvedValue(STUB_OK);
+    await tools.get("release_wave_fail")!.handler({
+      wave_id: "w1",
+      reason: "stuck in flipping",
+    });
+    expect(spies.fail).toHaveBeenCalledWith({
+      wave_id: "w1",
+      reason: "stuck in flipping",
     });
   });
 });

--- a/test/release-wave/api.test.ts
+++ b/test/release-wave/api.test.ts
@@ -3,6 +3,7 @@ import {
   handleReleaseWaveApprove,
   handleReleaseWaveRollback,
   handleReleaseWaveAbort,
+  handleReleaseWaveForceFail,
   handleReleaseWaveRetest,
   handleReleaseWaveRetestConsumer,
   handleReleaseWavePendingReleaseFlip,
@@ -26,6 +27,7 @@ function fakeEnv(spyOverrides: Partial<Record<string, ReturnType<typeof vi.fn>>>
     approve: spyOverrides.approve ?? vi.fn().mockResolvedValue({ ok: true, data: { wave_id: "w1" } }),
     rollback: spyOverrides.rollback ?? vi.fn().mockResolvedValue({ ok: true, data: { wave_id: "w1" } }),
     abort: spyOverrides.abort ?? vi.fn().mockResolvedValue({ ok: true, data: { wave_id: "w1" } }),
+    fail: spyOverrides.fail ?? vi.fn().mockResolvedValue({ ok: true, data: { wave_id: "w1" } }),
   };
   const hub = spies as unknown as ReleaseWaveHub;
   const env = {
@@ -268,6 +270,73 @@ describe("handleReleaseWaveAbort", () => {
     });
     const resp = await handleReleaseWaveAbort(req, env, "w1");
     expect(resp.status).toBe(409);
+  });
+});
+
+describe("handleReleaseWaveForceFail", () => {
+  it("calls hub.fail with default reason + actor and redirects", async () => {
+    const { env, spies } = fakeEnv();
+    const req = postRequest("/api/release-wave/w1/fail", { actorEmail: "ops@x" });
+    const resp = await handleReleaseWaveForceFail(req, env, "w1");
+    expect(resp.status).toBe(303);
+    expect(spies.fail).toHaveBeenCalledWith({
+      wave_id: "w1",
+      reason: "force-failed via admin UI (stuck wave clear) [by ops@x]",
+    });
+  });
+
+  it("uses provided reason (actor still appended)", async () => {
+    const { env, spies } = fakeEnv();
+    const req = postRequest("/api/release-wave/w1/fail", {
+      actorEmail: "ops@x",
+      formBody: { reason: "stuck in flipping" },
+    });
+    await handleReleaseWaveForceFail(req, env, "w1");
+    expect(spies.fail).toHaveBeenCalledWith({
+      wave_id: "w1",
+      reason: "stuck in flipping [by ops@x]",
+    });
+  });
+
+  it("returns 405 on GET", async () => {
+    const { env } = fakeEnv();
+    const req = new Request("https://ci-dashboard.ippoan.org/api/release-wave/w1/fail", {
+      method: "GET",
+    });
+    const resp = await handleReleaseWaveForceFail(req, env, "w1");
+    expect(resp.status).toBe(405);
+  });
+
+  it("maps INVALID_TRANSITION to 409 (e.g. force-fail on flipped)", async () => {
+    const { env } = fakeEnv({
+      fail: vi.fn().mockResolvedValue({
+        ok: false,
+        code: "INVALID_TRANSITION",
+        error: "fail invalid on 'flipped' state, use rollback instead",
+      }),
+    });
+    const resp = await handleReleaseWaveForceFail(
+      postRequest("/api/release-wave/w1/fail", { actorEmail: "ops@x" }),
+      env,
+      "w1",
+    );
+    expect(resp.status).toBe(409);
+  });
+
+  it("maps NOT_FOUND to 404", async () => {
+    const { env } = fakeEnv({
+      fail: vi.fn().mockResolvedValue({
+        ok: false,
+        code: "NOT_FOUND",
+        error: "no wave",
+      }),
+    });
+    const resp = await handleReleaseWaveForceFail(
+      postRequest("/api/release-wave/ghost/fail", { actorEmail: "ops@x" }),
+      env,
+      "ghost",
+    );
+    expect(resp.status).toBe(404);
   });
 });
 

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -464,6 +464,30 @@ describe("handleReleaseWaveDetailPage", () => {
     }
   });
 
+  it("force-fail (clear) button enabled in-progress (staging/pending-approval/flipping), disabled on flipped/terminal", async () => {
+    for (const state of ["staging", "pending-approval", "flipping"] as const) {
+      const r = await handleReleaseWaveDetailPage(
+        fakeEnv({ getReturn: { ok: true, data: makeWave({ state }) } }),
+        "w1",
+      );
+      const html = await r.text();
+      const m = html.match(/<form[^>]*\/fail[^>]*>[\s\S]*?<\/form>/);
+      expect(m).toBeTruthy();
+      expect(m![0]).toContain("Force-fail");
+      expect(m![0]).not.toContain("disabled");
+    }
+    // flipped は rollback を使う想定なので force-fail は disabled。terminal も不可。
+    for (const state of ["flipped", "rolled-back", "failed", "aborted"] as const) {
+      const r = await handleReleaseWaveDetailPage(
+        fakeEnv({ getReturn: { ok: true, data: makeWave({ state }) } }),
+        "w1",
+      );
+      const html = await r.text();
+      const m = html.match(/<form[^>]*\/fail[^>]*>[\s\S]*?<\/form>/);
+      expect(m![0]).toContain("disabled");
+    }
+  });
+
   it("renders rollback safety status correctly", async () => {
     // safe=true
     const r1 = await handleReleaseWaveDetailPage(


### PR DESCRIPTION
## 概要

flip 途中で callback が来ず `flipping` のまま hang した wave は、`abort`（flip 前のみ）も `rollback`（flipped のみ）も使えず詰んでいた（= ユーザー報告「rust-alc-api fail が abort できない、失敗してるのに進んでる」）。

state machine の `fail` event は `staging` / `pending-approval` / `flipping` で有効（`flipped` のみ rollback 推奨で reject）なのに **operator 経路が未公開**だったので公開する。

## 変更

- **api**: `handleReleaseWaveForceFail`（`POST /api/release-wave/:wave_id/fail`）。`hub.fail` を呼び、actor を reason に audit 併記。`NOT_FOUND`→404 / それ以外→409。
- **index**: route 追加。
- **page**: 詳細ページに「**Force-fail (clear)**」danger ボタン。`canForceFail = staging|pending-approval|flipping` で有効、`flipped`/terminal は disabled（flipped は Rollback を使う旨を title に明記）。
- **mcp**: `release_wave_fail` tool（`wave_id`, `reason`）を追加（6→7 tools）。
- **tests**: api（success / 既定 reason / provided reason / 405 / 409 / 404）、page（enabled/disabled マトリクス）、mcp（登録数 7 + handler forward）。

## 使い方（stuck wave のクリア）

UI: `/release-wave/<wave_id>` の「Force-fail (clear)」ボタン。
MCP: `release_wave_fail({ wave_id, reason })`。
→ `failed`（terminal）に遷移し、「進んでる」表示が止まる。既存の stuck rust-alc-api wave もこれで片付けられる。

## 検証

ローカルは `@ippoan` auth 不可で tsc/vitest 不可 → **CI で検証**。配線（export / route / import / mcp tool / page button / `hub.fail`）は grep 確認済み。

Refs ippoan/ci-dashboard#244

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYnhZeg24YNLyZsSb87YTo)_