### PR TITLE
fix(release-wave): flip 済みの workers が Pending releases に残る (stale pending-release:: leak)

### DIFF
--- a/src/release-wave/pending-release.ts
+++ b/src/release-wave/pending-release.ts
@@ -265,13 +265,27 @@ export function computeUnifiedPending(
     seen.add(repo);
   }
   for (const r of pendingRecords) {
-    if (seen.has(r.repo)) continue; // traffic:: の no-traffic version を持つ repo は traffic:: 優先
+    if (seen.has(r.repo)) continue; // traffic:: の no-traffic promotable を持つ repo は traffic:: 優先
+    const rec = trafficByRepo.get(r.repo) ?? null;
+    // flip 済み判定: pending-release:: が指す version が traffic:: で既に active
+    // (percentage > 0) なら、その release は既に flip 済み。pending-release:: は
+    // deploy 時 (frontend-ci) に作られ traffic-report では clear されないため、
+    // flip 後も stale record として残る。これを出すと「flip 済みなのに Pending に
+    // 残る」状態になる (Refs ippoan/ci-dashboard#248)。
+    // ※ deploy 直後 (未 flip) は traffic:: に当該 version が無い (= active 判定
+    //    false) ので、ちゃんと Pending に出る。
+    if (
+      rec &&
+      (rec.versions ?? []).some(
+        (v) => v.version_id === r.version_id && v.percentage > 0,
+      )
+    ) {
+      continue;
+    }
     // pending source (cloudrun 等) でも traffic:: record があれば現 active を
     // rollback 先として控える (= 一括 flip → flip-group rollback の戻し先確保、
     // Refs ippoan/ci-dashboard#241)。traffic:: が無ければ null (戻し先不明)。
-    const active = trafficByRepo.has(r.repo)
-      ? currentActiveOf(trafficByRepo.get(r.repo)!)
-      : null;
+    const active = rec ? currentActiveOf(rec) : null;
     out.push({
       repo: r.repo,
       version_id: r.version_id,

--- a/test/release-wave/pending-release.test.ts
+++ b/test/release-wave/pending-release.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeUnifiedPending,
+  type PendingReleaseRecord,
+} from "../../src/release-wave/pending-release";
+import type { TrafficRecord, TrafficVersion } from "../../src/release-wave/traffic";
+
+function traffic(repo: string, versions: TrafficVersion[]): TrafficRecord {
+  return {
+    schema_version: 4,
+    repo,
+    versions,
+    reported_at: "2026-06-03T23:52:00.000Z",
+  };
+}
+
+function pending(
+  repo: string,
+  version_id: string,
+  tag: string,
+  uploaded_at: string,
+): PendingReleaseRecord {
+  return {
+    schema_version: 1,
+    repo,
+    version_id,
+    tag,
+    preview_url: null,
+    uploaded_at,
+  };
+}
+
+describe("computeUnifiedPending — flip 済みの stale pending-release:: を出さない (Refs #248)", () => {
+  // 実害: workers を flip すると traffic:: は 100% に更新されるが、deploy 時に
+  // frontend-ci が作った pending-release:: は traffic-report で clear されない。
+  // flip 済み version が pending-release:: source として漏れ「flip 済みなのに
+  // Pending に残る」状態になっていた。
+  it("flip 済み (traffic:: で当該 version が active) なら Pending に出さない", () => {
+    const repo = "ippoan/nuxt-notify";
+    const V = "1601602a-6672-4615-bc07-0f3ec0ece237";
+    const trafficByRepo = new Map<string, TrafficRecord>([
+      [
+        repo,
+        traffic(repo, [
+          { version_id: V, percentage: 100, created_on: "2026-06-03T16:20:24.948Z" },
+          { version_id: "old-v0-0-20", percentage: 0, created_on: "2026-06-03T13:04:11.020Z" },
+        ]),
+      ],
+    ]);
+    const pendingRecords = [pending(repo, V, "v0.0.21", "2026-06-03T16:20:26.432Z")];
+
+    const out = computeUnifiedPending(trafficByRepo, pendingRecords);
+    expect(out).toEqual([]);
+  });
+
+  it("未 flip (deploy 直後で traffic:: にまだ当該 version が無い) なら Pending に出す", () => {
+    const repo = "ippoan/nuxt-notify";
+    const V = "1601602a-6672-4615-bc07-0f3ec0ece237";
+    // traffic:: は前回 flip した古い version しか知らない (deploy では traffic-report
+    // が来ないため)。新 version V は pending-release:: にだけ存在する。
+    const trafficByRepo = new Map<string, TrafficRecord>([
+      [
+        repo,
+        traffic(repo, [
+          { version_id: "old-v0-0-20", percentage: 100, created_on: "2026-06-03T13:04:11.020Z" },
+        ]),
+      ],
+    ]);
+    const pendingRecords = [pending(repo, V, "v0.0.21", "2026-06-03T16:20:26.432Z")];
+
+    const out = computeUnifiedPending(trafficByRepo, pendingRecords);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ repo, version_id: V, source: "pending", tag: "v0.0.21" });
+    // rollback 先 = 現 active (old)。
+    expect(out[0]?.rollback_to).toBe("old-v0-0-20");
+  });
+
+  it("traffic:: source: active より新しい 0% promotable は traffic source で出す", () => {
+    const repo = "ippoan/auth-worker";
+    const Z = "newer-0pct";
+    const trafficByRepo = new Map<string, TrafficRecord>([
+      [
+        repo,
+        traffic(repo, [
+          { version_id: "active", percentage: 100, created_on: "2026-06-03T10:00:00.000Z" },
+          { version_id: Z, percentage: 0, created_on: "2026-06-03T12:00:00.000Z" },
+        ]),
+      ],
+    ]);
+    const out = computeUnifiedPending(trafficByRepo, []);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ repo, version_id: Z, source: "traffic" });
+  });
+
+  it("cloudrun (traffic:: 無し) は pending-release:: source でそのまま出す", () => {
+    const repo = "ippoan/rust-alc-api";
+    const pendingRecords = [pending(repo, "pending-v0-0-82", "v0.0.82", "2026-06-03T22:18:19.000Z")];
+    const out = computeUnifiedPending(new Map(), pendingRecords);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ repo, source: "pending", tag: "v0.0.82" });
+  });
+});


### PR DESCRIPTION
## 症状

workers (nuxt-notify / nuxt-trouble 等) を flip して traffic 100% になっても `/release-wave` の **Pending releases に残り続ける**（ハード再読み込みでも消えない）。

## 根本原因（一次情報で確定）

1. `frontend-ci.yml` は deploy 時に `pending-release::<repo>` を報告する（no-traffic version marker）。→ workers も pending-release:: を持つ。
2. flip（traffic-rollback = `wrangler versions deploy @100%` + report-traffic-split）後、`traffic::<repo>` は 100% に更新されるが **`pending-release::` は traffic-report で clear されない** → stale record が残る。
3. `computeUnifiedPending` は traffic:: に promotable な 0% version が無いと `seen.add` せず、残った `pending-release::` を source "pending" として出していた（コメント L177 の意図に実装が不一致）。

実データ（23:52 traffic-report）で nuxt-notify=`1601602a`(v0.0.21) / nuxt-trouble=`f25b5031`(v0.0.19) が **100%** 報告済みなのに Pending に残っていたことを確認。

## 修正

pending loop で **pending-release:: の version が traffic:: で既に active (percentage > 0) なら flip 済みと判定して出さない**。

- flip 済み（traffic:: で当該 version active）→ 出さない
- 未 flip（deploy 直後で traffic:: にまだ当該 version が無い）→ そのまま出す（回帰しない）
- 一律 `seen.add` は不可（未 flip の新 version を消す）ので version 単位で active 判定

`test/release-wave/pending-release.test.ts` に 4 ケース追加（flip済→空 / 未flip→出る / traffic source / cloudrun）。

> ローカルは @ippoan private dep の 401 で install 不可のため typecheck/test は CI に委ねる。修正ロジックは 4 ケースを手動トレースで検証済み。

Refs #237
Refs #248
Refs #250

---
_Generated by [Claude Code](https://claude.ai/code/session_01CY9pr17zwdXcPgk47TMfwZ)_