### PR TITLE
feat(release-wave): operator が flip を起動できる MCP tool を追加

### DIFF
--- a/src/mcp/tools/release-wave.ts
+++ b/src/mcp/tools/release-wave.ts
@@ -21,6 +21,7 @@ import type { Env } from "../../index";
 import type { ReleaseWaveHub, RpcResult } from "../../release-wave/do";
 import type { WaveState } from "../../release-wave/types";
 import { computeWaveCompatibility } from "../../release-wave/compat";
+import { pendingFlipCore, pendingFlipAllCore } from "../../release-wave/api";
 
 // ----------------------------------------------------------------------------
 // Hub helper
@@ -282,6 +283,69 @@ export function registerReleaseWaveTools(server: McpServer, env: Env): void {
         migration_id,
       });
       return formatRpcResult(result);
+    },
+  );
+
+  // ============================================================
+  // release_wave_pending_flip   (operator が単一 repo を flip 起動)
+  // ============================================================
+  // 注: 上の release_wave_flip は per-repo flip "callback" (handler →
+  // ci-dashboard) で、operator が flip を起動する口ではない。こちらは
+  // /release-wave の「Flip」ボタンと同じ経路を MCP から叩く: pending release
+  // (release CI が報告した no-traffic version) を 100% traffic へ promote する。
+  // wave state machine は経由しない。
+  server.registerTool(
+    "release_wave_pending_flip",
+    {
+      description:
+        "Flip a single repo's pending release (the no-traffic version its release CI reported) to 100% traffic, without the wave state machine. Mirrors the /release-wave 'Flip' button. cloudrun promotes the latest-ready revision; workers deploys the previewed version at 100%. The actual flip runs in GitHub Actions (no callback); inspect the run for the result.",
+      inputSchema: {
+        repo: z
+          .string()
+          .min(1)
+          .describe("owner/name whose pending release to flip to 100%"),
+      },
+      annotations: { readOnlyHint: false },
+    },
+    async ({ repo }) => {
+      const result = await pendingFlipCore(env, repo);
+      return {
+        content: [
+          { type: "text" as const, text: JSON.stringify(result, null, 2) },
+        ],
+        ...(result.ok ? {} : { isError: true }),
+      };
+    },
+  );
+
+  // ============================================================
+  // release_wave_pending_flip_all   (wave 一括 flip 起動)
+  // ============================================================
+  // /release-wave の「Flip all」ボタンと同じ経路。全 pending release を一括
+  // flip し、flip-group を記録する (= 後で一括 rollback できるよう戻し先を確保)。
+  server.registerTool(
+    "release_wave_pending_flip_all",
+    {
+      description:
+        "Flip ALL pending releases (no-traffic versions across repos) to 100% traffic at once — the /release-wave 'Flip all' button. Records a flip-group so the same set can be rolled back together. Returns the list of flipped repos; no-op (flipped:[]) when nothing is pending.",
+      inputSchema: {
+        flipped_by: z
+          .string()
+          .min(1)
+          .describe(
+            "Email or identifier of the operator (recorded in the flip-group audit trail)",
+          ),
+      },
+      annotations: { readOnlyHint: false },
+    },
+    async ({ flipped_by }) => {
+      const result = await pendingFlipAllCore(env, flipped_by);
+      return {
+        content: [
+          { type: "text" as const, text: JSON.stringify(result, null, 2) },
+        ],
+        ...(result.ok ? {} : { isError: true }),
+      };
     },
   );
 }

--- a/src/release-wave/api.ts
+++ b/src/release-wave/api.ts
@@ -31,6 +31,7 @@ import {
   type PendingReleaseRecord,
   type FlipGroupItem,
   type UnifiedPending,
+  type PendingSource,
 } from "./pending-release";
 import {
   getTraffic,
@@ -460,6 +461,52 @@ function buildTrafficRollbackDispatch(
  *
  * 実 flip の成否は GitHub Actions 側で確認する (callback は来ない)。
  */
+/**
+ * pending release flip の core ロジック (HTTP handler と MCP tool が共有)。
+ *
+ * getPendingRelease → `release-wave-flip` dispatch → 着火成功なら record clear。
+ * 戻り値は判別 union で、HTTP handler は status code に、MCP tool は isError に
+ * map する。実 flip の成否は GitHub Actions 側で確認する (callback は来ない)。
+ */
+export type PendingFlipResult =
+  | { ok: true; repo: string; tag: string; version_id: string }
+  | {
+      ok: false;
+      code: "KV_NOT_CONFIGURED" | "BAD_REQUEST" | "NOT_FOUND" | "DISPATCH_FAILED";
+      error: string;
+    };
+
+export async function pendingFlipCore(
+  env: Env,
+  repo: string,
+): Promise<PendingFlipResult> {
+  if (!env.COMPAT_KV) {
+    return { ok: false, code: "KV_NOT_CONFIGURED", error: "COMPAT_KV is not bound" };
+  }
+  const r = repo.trim();
+  if (!r) {
+    return { ok: false, code: "BAD_REQUEST", error: "repo is required" };
+  }
+  const record = await getPendingRelease(env.COMPAT_KV, r);
+  if (!record) {
+    return { ok: false, code: "NOT_FOUND", error: `no pending release for ${r}` };
+  }
+  const results = await dispatchAll(env, [buildPendingFlipDispatch(record)]);
+  const ok = results.length > 0 && results[0]!.ok;
+  if (!ok) {
+    const err = results.length > 0 && !results[0]!.ok ? results[0]!.error : "dispatch failed";
+    return {
+      ok: false,
+      code: "DISPATCH_FAILED",
+      error: `failed to dispatch flip for ${r}: ${err}`,
+    };
+  }
+  // 着火できたら record を消す (optimistic)。着火失敗時は上で return 済みなので
+  // record は残り、operator が再試行できる。
+  await clearPendingRelease(env.COMPAT_KV, r);
+  return { ok: true, repo: r, tag: record.tag, version_id: record.version_id };
+}
+
 export async function handleReleaseWavePendingReleaseFlip(
   req: Request,
   env: Env,
@@ -488,26 +535,17 @@ export async function handleReleaseWavePendingReleaseFlip(
     });
   }
 
-  const record = await getPendingRelease(env.COMPAT_KV, repo);
-  if (!record) {
-    return jsonResponse(404, {
-      code: "NOT_FOUND",
-      error: `no pending release for ${repo}`,
-    });
-  }
-
-  const results = await dispatchAll(env, [buildPendingFlipDispatch(record)]);
-  const ok = results.length > 0 && results[0]!.ok;
-  if (ok) {
-    // dispatch が着火できたら record を消す (optimistic)。実 flip の成否は
-    // GitHub Actions 側で確認する。着火失敗時は record を残し再試行可能にする。
-    await clearPendingRelease(env.COMPAT_KV, repo);
-  } else {
-    const err = results.length > 0 && !results[0]!.ok ? results[0]!.error : "dispatch failed";
-    return jsonResponse(502, {
-      code: "DISPATCH_FAILED",
-      error: `failed to dispatch flip for ${repo}: ${err}`,
-    });
+  const result = await pendingFlipCore(env, repo);
+  if (!result.ok) {
+    const status =
+      result.code === "KV_NOT_CONFIGURED"
+        ? 500
+        : result.code === "NOT_FOUND"
+          ? 404
+          : result.code === "DISPATCH_FAILED"
+            ? 502
+            : 400;
+    return jsonResponse(status, { code: result.code, error: result.error });
   }
   return redirectToList();
 }
@@ -528,26 +566,39 @@ export async function handleReleaseWavePendingReleaseFlip(
  * - dispatch 成功した repo のみ pending-release を clear し flip-group に積む。
  * - 全 dispatch 失敗時のみ 502。一部成功は成功分を記録して一覧へ redirect。
  */
-export async function handleReleaseWavePendingReleaseFlipAll(
-  req: Request,
+/**
+ * pending release 一括 flip の core ロジック (HTTP handler と MCP tool が共有)。
+ *
+ * 単一真実の Pending releases を全件 flip し、各 repo の flip 直前 active version
+ * を flip-group として記録する (後で一括 rollback 可能)。0 件は no-op で
+ * ok:true / flipped:[] を返す。actor は flip-group の audit 記録に使う。
+ */
+export type PendingFlipAllResult =
+  | {
+      ok: true;
+      flipped: Array<{
+        repo: string;
+        version_id: string;
+        tag: string | null;
+        source: PendingSource;
+      }>;
+    }
+  | { ok: false; code: "KV_NOT_CONFIGURED" | "DISPATCH_FAILED"; error: string };
+
+export async function pendingFlipAllCore(
   env: Env,
-): Promise<Response> {
-  if (req.method !== "POST") {
-    return jsonResponse(405, { code: "METHOD_NOT_ALLOWED", error: "use POST" });
-  }
+  actor: string,
+): Promise<PendingFlipAllResult> {
   if (!env.COMPAT_KV) {
-    return jsonResponse(500, {
-      code: "KV_NOT_CONFIGURED",
-      error: "COMPAT_KV is not bound",
-    });
+    return { ok: false, code: "KV_NOT_CONFIGURED", error: "COMPAT_KV is not bound" };
   }
 
   // Pending releases の単一真実 (workers=traffic:: / cloudrun=pending-release::)
   // を導出する (= 画面の表示と同じ source、Refs #237)。
   const unified = await loadUnifiedPending(env);
   if (unified.length === 0) {
-    // flip 対象が無ければ何もせず一覧へ。
-    return redirectToList();
+    // flip 対象が無ければ no-op。
+    return { ok: true, flipped: [] };
   }
 
   // source 別に dispatch を組む:
@@ -563,6 +614,12 @@ export async function handleReleaseWavePendingReleaseFlipAll(
   const results = await dispatchAll(env, dispatches);
 
   const items: FlipGroupItem[] = [];
+  const flipped: Array<{
+    repo: string;
+    version_id: string;
+    tag: string | null;
+    source: PendingSource;
+  }> = [];
   for (let i = 0; i < unified.length; i++) {
     const u = unified[i]!;
     if (!results[i]?.ok) continue;
@@ -573,6 +630,12 @@ export async function handleReleaseWavePendingReleaseFlipAll(
       rollback_to: u.rollback_to,
       rollback_tag: u.rollback_tag,
     });
+    flipped.push({
+      repo: u.repo,
+      version_id: u.version_id,
+      tag: u.tag,
+      source: u.source,
+    });
     // pending-release:: 由来 (cloudrun) は flip したので消す。traffic 由来は
     // traffic-report (flip 後) が状態を更新するので KV 操作不要。
     if (u.source === "pending") await clearPendingRelease(env.COMPAT_KV, u.repo);
@@ -581,17 +644,39 @@ export async function handleReleaseWavePendingReleaseFlipAll(
   if (items.length === 0) {
     const failed = results.find((r) => !r.ok);
     const err = failed && !failed.ok ? failed.error : "dispatch failed";
-    return jsonResponse(502, {
+    return {
+      ok: false,
       code: "DISPATCH_FAILED",
       error: `failed to dispatch flip for all ${unified.length} pending release(s): ${err}`,
-    });
+    };
   }
 
   await recordFlipGroup(env.COMPAT_KV, {
     flipped_at: new Date().toISOString(),
-    actor: actorEmail(req),
+    actor,
     items,
   });
+  return { ok: true, flipped };
+}
+
+export async function handleReleaseWavePendingReleaseFlipAll(
+  req: Request,
+  env: Env,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return jsonResponse(405, { code: "METHOD_NOT_ALLOWED", error: "use POST" });
+  }
+  if (!env.COMPAT_KV) {
+    return jsonResponse(500, {
+      code: "KV_NOT_CONFIGURED",
+      error: "COMPAT_KV is not bound",
+    });
+  }
+  const result = await pendingFlipAllCore(env, actorEmail(req));
+  if (!result.ok) {
+    const status = result.code === "KV_NOT_CONFIGURED" ? 500 : 502;
+    return jsonResponse(status, { code: result.code, error: result.error });
+  }
   return redirectToList();
 }
 

--- a/test/mcp/release-wave.test.ts
+++ b/test/mcp/release-wave.test.ts
@@ -122,7 +122,7 @@ const STUB_ERR = {
 // ----------------------------------------------------------------------------
 
 describe("registerReleaseWaveTools registration", () => {
-  it("registers exactly 7 tools with expected names", () => {
+  it("registers exactly 9 tools with expected names", () => {
     const { tools } = setup();
     expect(Array.from(tools.keys()).sort()).toEqual(
       [
@@ -131,6 +131,8 @@ describe("registerReleaseWaveTools registration", () => {
         "release_wave_contract_applied",
         "release_wave_fail",
         "release_wave_flip",
+        "release_wave_pending_flip",
+        "release_wave_pending_flip_all",
         "release_wave_rollback",
         "release_wave_status",
       ].sort(),
@@ -323,6 +325,34 @@ describe("release_wave_contract_applied", () => {
       repo: "ippoan/rust-alc-api",
       migration_id: "20260601_001_drop",
     });
+  });
+});
+
+// pending flip 系は DO RPC ではなく COMPAT_KV + dispatch を直接叩く
+// (= /release-wave の Flip / Flip all ボタンと同じ core)。fakeEnv は
+// emptyCompatKv なので、ここでは「pending 無し」経路の wiring だけを見る。
+// 実 dispatch を伴う成功経路は api.test.ts の handler test がカバーする。
+describe("release_wave_pending_flip", () => {
+  it("returns NOT_FOUND (isError) when the repo has no pending release", async () => {
+    const { tools } = setup();
+    const r = await tools
+      .get("release_wave_pending_flip")!
+      .handler({ repo: "ippoan/no-such" });
+    expect(r.isError).toBe(true);
+    expect(JSON.parse(r.content[0]!.text).code).toBe("NOT_FOUND");
+  });
+});
+
+describe("release_wave_pending_flip_all", () => {
+  it("is a no-op (ok, flipped:[]) when nothing is pending", async () => {
+    const { tools } = setup();
+    const r = await tools
+      .get("release_wave_pending_flip_all")!
+      .handler({ flipped_by: "ops@example.com" });
+    expect(r.isError).toBeUndefined();
+    const payload = JSON.parse(r.content[0]!.text);
+    expect(payload.ok).toBe(true);
+    expect(payload.flipped).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## 概要

operator が **flip を MCP から起動**できる tool を 2 つ追加する。

既存の `release_wave_flip` tool は各 repo handler からの **flip 完了 callback** で、operator が flip を起動する口ではなかった。`/release-wave` の「Flip」「Flip all」ボタン(HTTP `POST /api/release-wave/pending-release/flip[-all]`)と同じ core を MCP から叩けるようにする。

## 追加 tool

| tool | 動作 |
|---|---|
| `release_wave_pending_flip` | 単一 repo の pending release(no-traffic version)を 100% flip |
| `release_wave_pending_flip_all` | 全 pending release を一括 flip + flip-group 記録(一括 rollback 用) |

## 実装

- `pendingFlipCore` / `pendingFlipAllCore` を `src/release-wave/api.ts` から切り出し、既存 HTTP handler と新 MCP tool で共有(**handler の挙動は不変**)
- `registerReleaseWaveTools` を 7 → 9 tool に
- MCP tool は DO RPC ではなく `COMPAT_KV` + dispatch を直接叩く(UI ボタンと同経路)

## なぜ proxy/handler を触らないか

当初 release-wave-gcp の flip-traffic に `to_revision` を足す方向で着手したが、最新 origin/main では **#248(PR #4 / #6 / #8)で flip-traffic は「latest-ready revision を自動 flip」へ作り直し済み**(揮発する tag/revision 指定依存を意図的に撤廃)。flip 自体は UI/HTTP で既に動作し、欠けていたのは MCP の口だけだった。release-wave-gcp PR #9 は close、ci-workflows 変更も撤回済み。

## テスト

- `test/mcp/release-wave.test.ts`: registration 7→9 + 新 tool の wiring(pending 無し経路)
- 成功 dispatch 経路は既存 `test/release-wave/api.test.ts` の handler test が core 経由でカバー
- ⚠️ CCoW container は `@ippoan/auth-client-worker`(GitHub Packages)の npm 認証 token を持てず**ローカル typecheck/test 不可**。CI(frontend-ci.yml, `packages: read`)で検証する

Refs #137 / #248 / #249

---
_Generated by [Claude Code](https://claude.ai/code/session_01TM9BeWn7iQHr55uhTC9aBu)_