### PR TITLE
feat(release-wave): /release-wave に更新（ハードリセット）ボタンを追加

### DIFF
--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -92,6 +92,12 @@ function htmlResponse(body: string, status = 200): Response {
     status,
     headers: {
       "Content-Type": "text/html; charset=utf-8",
+      // 「更新（ハードリセット）」ボタン用: ページは SSR で DO/KV の現在状態を
+      // 毎回引き直す。no-store でブラウザ/bfcache のキャッシュを一切無効化し、
+      // リンク再訪時に必ずサーバから取り直させる (= ハードリロード相当)。
+      // strict CSP (script-src 無し) で JS の location.reload(true) が使えないため、
+      // キャッシュ制御は response header 側で担保する。
+      "Cache-Control": "no-store, must-revalidate",
       // Defense in depth against XSS:
       // - `script-src 'none'` で <script> / event handler 経由の実行をブロック
       // - `style-src 'self' 'unsafe-inline'` は本ページが inline <style> を
@@ -143,6 +149,11 @@ const COMMON_STYLES = `
   .ok { color: #188038; }
   .err { color: #d93025; }
   .pending { color: #9aa0a6; }
+  .toolbar { margin: 8px 0 16px; display: flex; gap: 8px; align-items: center; }
+  .refresh-btn { display: inline-block; background: #1a73e8; color: #fff;
+    padding: 8px 16px; border-radius: 4px; font-size: 14px; font-weight: 500;
+    text-decoration: none; cursor: pointer; }
+  .refresh-btn:hover { background: #1765cc; text-decoration: none; }
 `;
 
 // ----------------------------------------------------------------------------
@@ -280,6 +291,10 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
   <div class="container">
     ${renderTabs("release-wave")}
     <h1>Release Waves</h1>
+    <div class="toolbar">
+      <a class="refresh-btn" href="/release-wave"
+        title="ページを再取得して最新状態に更新する (ブラウザキャッシュ無視 = ハードリセット)">🔄 更新（ハードリセット）</a>
+    </div>
     <p class="meta">
       Cross-repo coordinated release flows. Refs
       <a href="https://github.com/ippoan/ci-dashboard/issues/137">#137</a>.
@@ -481,6 +496,10 @@ export async function handleReleaseWaveDetailPage(
       ${escapeHtml(w.wave_id)}
       <span class="badge" style="background:${stateColor(w.state)}">${escapeHtml(w.state)}</span>
     </h1>
+    <div class="toolbar">
+      <a class="refresh-btn" href="/release-wave/${encodeURIComponent(w.wave_id)}"
+        title="この wave の状態を再取得して更新する (ブラウザキャッシュ無視 = ハードリセット)">🔄 更新（ハードリセット）</a>
+    </div>
     <p class="meta">
       flip_policy: <strong>${escapeHtml(w.flip_policy)}</strong> &middot;
       started_at: ${escapeHtml(w.started_at)}

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -123,6 +123,15 @@ describe("handleReleaseWaveListPage", () => {
     expect(html).toContain("No release waves yet");
   });
 
+  it("renders a hard-reset refresh button on the list page", async () => {
+    const env = fakeEnv({ listReturn: [] });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    expect(html).toContain('class="refresh-btn"');
+    expect(html).toContain("更新（ハードリセット）");
+    // 一覧ページ自身へ戻すリンク (= no-store により再取得 = ハードリセット)。
+    expect(html).toContain('href="/release-wave"');
+  });
+
   it("shows the Pending releases section placeholder when none (Refs #181 / #237)", async () => {
     const env = fakeEnv({ listReturn: [], compatKv: memKv() });
     const html = await (await handleReleaseWaveListPage(env)).text();
@@ -362,6 +371,17 @@ describe("handleReleaseWaveDetailPage", () => {
     expect(html).toContain("Repos");
     expect(html).toContain("Events");
     expect(html).toContain("Raw State");
+  });
+
+  it("renders a hard-reset refresh button on the detail page", async () => {
+    const env = fakeEnv({
+      getReturn: { ok: true, data: makeWave({ wave_id: "w1" }) },
+    });
+    const html = await (await handleReleaseWaveDetailPage(env, "w1")).text();
+    expect(html).toContain('class="refresh-btn"');
+    expect(html).toContain("更新（ハードリセット）");
+    // この wave 詳細ページ自身へ戻すリンク。
+    expect(html).toContain('href="/release-wave/w1"');
   });
 
   it("approve button enabled only in pending-approval", async () => {
@@ -668,6 +688,8 @@ describe("handleReleaseWaveDetailPage", () => {
     expect(csp).toContain("frame-ancestors 'none'");
     expect(resp.headers.get("X-Content-Type-Options")).toBe("nosniff");
     expect(resp.headers.get("Referrer-Policy")).toBe("no-referrer");
+    // 「更新（ハードリセット）」ボタン用にブラウザ/bfcache キャッシュを無効化する。
+    expect(resp.headers.get("Cache-Control")).toContain("no-store");
   });
 
   it("escapes HTML in repo names / wave_id / event summaries", async () => {


### PR DESCRIPTION
## 概要

`/release-wave` の一覧ページ・詳細ページに「🔄 更新（ハードリセット）」ボタンを追加する。

## 背景

- `/release-wave` は SSR ページで、`/` ダッシュボードのような WebSocket live 更新を持たない → wave の stage / flip / compat 突合が進んでも画面は自動更新されず、手動リロードが要る。
- ページは strict CSP（`default-src 'none'`、`script-src` 無し）で JS が全面禁止 → `location.reload(true)` のような JS ハードリロードが書けない。

## 変更

- 一覧ページ・詳細ページの見出し直下に「🔄 更新（ハードリセット）」リンクボタン（各ページ自身へ戻る `<a>`）を追加。
- `htmlResponse` に `Cache-Control: no-store, must-revalidate` を追加。ブラウザキャッシュ・bfcache を無効化し、リンク再訪時に必ずサーバから現在状態を取り直させる（= ハードリロード相当）。JS 不使用で strict CSP のまま動く。`handleReleaseWaveListPageWithRepoStatus` は `res.headers` をコピーして返すため一覧ページにも反映される。
- テスト追加: Cache-Control ヘッダ検証 + 両ページの更新ボタン存在検証。

## 検証

ローカル（`@ippoan/auth-client-worker` を `auth-worker` repo の file: 依存に差し替えて実行）:

- `npm run typecheck` → green
- `vitest run test/release-wave/page.test.ts test/release-wave/repo-status-section.test.ts` → **91 件 green**（追加 3 件含む）

Refs #253

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6KSfHUhgjDu3Mpvrh1Aew)_