### PR TITLE
feat(release-wave): backend (Cloud Run) 状態表示に image sha / tag / 100% traffic を出す

### DIFF
--- a/src/release-wave/compat.ts
+++ b/src/release-wave/compat.ts
@@ -367,6 +367,8 @@ export interface WaveBackendCompat {
   current_image: string | null;
   /** current_image に対応する git release tag (v2 record のみ、無ければ null)。Refs #197。 */
   current_tag: string | null;
+  /** 現 active image を deploy した UTC ISO (`backend::<repo>.deployed_at`、record 無しは null)。 */
+  deployed_at: string | null;
   /** 過去 revision の rollback 先候補 (新しい順、record 無し / v1 なら空)。Refs #197。 */
   deploy_history: BackendDeployHistoryEntry[];
   /** 当該 backend を test 済みの frontend の matrix (consumer 無しなら空)。 */
@@ -408,6 +410,7 @@ export async function computeWaveCompatibility(
       wave_id: rec.wave_id ?? null,
       current_image: rec.current_image,
       current_tag: rec.current_tag ?? null,
+      deployed_at: rec.deployed_at ?? null,
       deploy_history: Array.isArray(rec.deploy_history) ? rec.deploy_history : [],
       matrix: compat.matrix,
     });

--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -22,7 +22,11 @@ import {
   getRepoReleaseStatuses,
   type RepoReleaseStatus,
 } from "./repo-release-status";
-import { computeGlobalCompatibility, type WaveCompatibility } from "./compat";
+import {
+  computeGlobalCompatibility,
+  type WaveCompatibility,
+  type WaveBackendCompat,
+} from "./compat";
 import { parseTaglessRepos } from "../tagless-repos";
 import {
   getTrafficForRepos,
@@ -392,44 +396,30 @@ function renderTrafficRollbackRow(repo: string, rec: TrafficRecord): string {
 }
 
 /**
- * Compatibility グラフに出ている backend repo の Cloud Run revision rollback
- * ボタンを HTML で返す (Refs #197)。`backend::<repo>.deploy_history` から
- * 「現 active 以外」の過去 revision を rollback 先候補とし、各候補に
- * `Rollback to <tag/revision>` ボタンを出す。候補がある repo が無ければ ""。
+ * Compatibility グラフに出ている backend repo の Cloud Run revision 状態 +
+ * rollback ボタンを HTML で返す (Refs #197)。
  *
- * frontend の Traffic rollback と方針を揃える: 任意の過去 revision を選択 / 即 100%。
+ * frontend の「Traffic (version split)」と対称に、各 backend について:
+ *   - **現 active 行**: 100% badge + git tag (ver) + image sha (full は hover) +
+ *     deploy 日時。Cloud Run backend は「最新 ready revision に 100% flip」運用
+ *     (canary % 配分なし) なので、現 active = 100% traffic として出す。これで
+ *     ver / image sha / traffic が一目で分かる。従来は rollback 候補 (過去
+ *     revision) が無い backend を丸ごと隠していたため、deploy 直後で履歴 1 件の
+ *     Cloud Run repo は image sha も tag も traffic も見えなかった。それを解消する。
+ *   - **rollback 行**: `deploy_history` のうち「現 active 以外」(= 過去に active
+ *     だった revision) があれば各候補に `Rollback to <tag/sha>` ボタンを出す。
+ *     frontend の Traffic rollback と方針を揃える (任意の過去 revision を即 100%)。
+ *
+ * backend record (`backend::<repo>`) を持ち current_image が分かる repo は必ず
+ * 現 active 行を出す (rollback 候補の有無に依らない)。current_image 不明 (稀) な
+ * repo だけ skip。1 行も出せなければ ""。
  */
 export function renderBackendRollbackBlock(compat: WaveCompatibility): string {
   const rows = compat.backends
     .map((b) => {
-      const history = b.deploy_history ?? [];
-      if (history.length === 0) return "";
-      const candidates = history.filter((e) => e.image !== b.current_image);
-      if (candidates.length === 0) return "";
-
-      const buttons = candidates
-        .map((e) => {
-          const label = e.tag ? escapeHtml(e.tag) : escapeHtml(shortId(e.image));
-          const when = escapeHtml(shortWhen(e.became_active_at));
-          return `
-            <form method="post" action="/api/release-wave/backend-rollback" style="margin:0 6px 4px 0;display:inline-block">
-              <input type="hidden" name="repo" value="${escapeHtml(b.backend_repo)}">
-              <input type="hidden" name="image" value="${escapeHtml(e.image)}">
-              <button type="submit" class="danger"
-                title="${escapeHtml(b.backend_repo)} の Cloud Run traffic を ${escapeHtml(e.image)} に即 100% で戻す">
-                Rollback to ${label} <span class="meta">(${when})</span>
-              </button>
-            </form>`;
-        })
-        .join("");
-
-      const curTag = b.current_tag ? `${escapeHtml(b.current_tag)} · ` : "";
-      return `
-        <tr>
-          <td>${escapeHtml(b.backend_repo)}</td>
-          <td class="meta" title="${escapeHtml(b.current_image ?? "—")}">${curTag}${escapeHtml(shortId(b.current_image ?? "—"))}</td>
-          <td><div>${buttons}</div></td>
-        </tr>`;
+      const active = renderBackendActiveRow(b);
+      if (!active) return ""; // current_image 不明な record は出さない
+      return active + renderBackendRollbackRow(b);
     })
     .filter((r) => r !== "")
     .join("");
@@ -438,12 +428,74 @@ export function renderBackendRollbackBlock(compat: WaveCompatibility): string {
 
   return `
     <div style="margin-top:10px">
-      <strong class="meta">Backend rollback (Cloud Run revision)</strong>
+      <strong class="meta">Backend traffic / rollback (Cloud Run revision)</strong>
+      <p class="meta" style="margin:4px 0">Cloud Run backend は現 active revision に 100% traffic
+        (canary % 配分なし)。image sha は hover で full、tag は git release tag。</p>
       <table style="margin-top:6px">
-        <thead><tr><th>Backend repo</th><th>Current</th><th>Rollback to (過去 revision)</th></tr></thead>
+        <thead><tr><th>Backend repo</th><th>%</th><th>Tag / Image (sha)</th><th>Deployed (UTC)</th></tr></thead>
         <tbody>${rows}</tbody>
       </table>
     </div>`;
+}
+
+/**
+ * 1 backend の現 active 行 (100% badge + tag + image sha + deployed)。
+ * current_image 不明なら "" (= 行を出さない)。
+ *
+ * Tag (ver) は `<strong>`、image sha は `<code>` (short 表示 / full は title
+ * hover) に分けて markup し、「どれが ver でどれが sha か」を一目で区別できる
+ * ようにする (= 旧 `Current` 列で tag と image が `·` 区切りで混在していた問題)。
+ */
+function renderBackendActiveRow(b: WaveBackendCompat): string {
+  const image = b.current_image;
+  if (!image) return "";
+  const tagPart = b.current_tag
+    ? `<strong>${escapeHtml(b.current_tag)}</strong> `
+    : "";
+  const imgCode = `<code title="${escapeHtml(image)}">${escapeHtml(shortId(image))}</code>`;
+  const when = `<span class="meta" title="${escapeHtml(b.deployed_at ?? "")}">${escapeHtml(shortWhen(b.deployed_at))}</span>`;
+  return `
+            <tr>
+              <td>${escapeHtml(b.backend_repo)}</td>
+              <td><span class="badge" style="background:${GREEN}">100%</span></td>
+              <td>${tagPart}${imgCode}</td>
+              <td>${when}</td>
+            </tr>`;
+}
+
+/**
+ * 1 backend の rollback 行 (deploy_history の「現 active 以外」)。候補無しなら ""。
+ * frontend の Traffic rollback と同じ方針: 過去 revision を即 100% に戻す。
+ */
+function renderBackendRollbackRow(b: WaveBackendCompat): string {
+  const history = b.deploy_history ?? [];
+  const candidates = history.filter((e) => e.image !== b.current_image);
+  if (candidates.length === 0) return "";
+
+  const buttons = candidates
+    .map((e) => {
+      const label = e.tag ? escapeHtml(e.tag) : escapeHtml(shortId(e.image));
+      const when = escapeHtml(shortWhen(e.became_active_at));
+      return `
+            <form method="post" action="/api/release-wave/backend-rollback" style="margin:0 6px 4px 0;display:inline-block">
+              <input type="hidden" name="repo" value="${escapeHtml(b.backend_repo)}">
+              <input type="hidden" name="image" value="${escapeHtml(e.image)}">
+              <button type="submit" class="danger"
+                title="${escapeHtml(b.backend_repo)} の Cloud Run traffic を ${escapeHtml(e.image)} に即 100% で戻す">
+                Rollback to ${label} <span class="meta">(${when})</span>
+              </button>
+            </form>`;
+    })
+    .join("");
+
+  return `
+            <tr>
+              <td></td>
+              <td colspan="3">
+                <span class="meta">Rollback to (過去 revision):</span>
+                <div style="margin-top:4px">${buttons}</div>
+              </td>
+            </tr>`;
 }
 
 /**

--- a/test/release-wave/repo-status-section.test.ts
+++ b/test/release-wave/repo-status-section.test.ts
@@ -438,13 +438,14 @@ describe("renderBackendRollbackBlock", () => {
     return { verified: true, checked: true, backends };
   }
 
-  it("renders Rollback buttons for prior Cloud Run revisions (Refs #197)", () => {
+  it("renders the current active row (100% + tag + image sha + deployed) and Rollback buttons for prior Cloud Run revisions (Refs #197)", () => {
     const html = renderBackendRollbackBlock(
       compat([
         {
           backend_repo: "ippoan/rust-alc-api",
           current_image: "rust-alc-api-00042-abc",
           current_tag: "v1.4.2",
+          deployed_at: "2026-05-29T09:30:00Z",
           deploy_history: [
             { image: "rust-alc-api-00042-abc", tag: "v1.4.2", became_active_at: "2026-05-29T09:30:00Z" },
             { image: "rust-alc-api-00041-xyz", tag: "v1.4.1", became_active_at: "2026-05-28T11:37:00Z" },
@@ -453,27 +454,102 @@ describe("renderBackendRollbackBlock", () => {
         },
       ]),
     );
-    expect(html).toContain("Backend rollback (Cloud Run revision)");
+    expect(html).toContain("Backend traffic / rollback (Cloud Run revision)");
+    // 現 active 行: 100% badge + tag (ver) + image sha (full は title) + deployed。
+    expect(html).toContain(">100%</span>");
+    expect(html).toContain("v1.4.2");
+    expect(html).toContain('title="rust-alc-api-00042-abc"'); // image full は hover
+    expect(html).toContain("05-29 09:30"); // deployed (UTC, MM-DD HH:mm)
+    // rollback 行: 過去 revision へのボタン。
     expect(html).toContain("/api/release-wave/backend-rollback");
     expect(html).toContain('name="image" value="rust-alc-api-00041-xyz"');
     expect(html).toContain("Rollback to v1.4.1");
-    // 現 active (00042) への rollback ボタンは出さない。
+    // 現 active (00042) への rollback ボタン (input) は出さない。
     expect(html).not.toContain('name="image" value="rust-alc-api-00042-abc"');
   });
 
-  it("returns empty string when no backend has rollback candidates", () => {
+  it("shows the current active row even without rollback candidates (deploy 直後で履歴 1 件)", () => {
+    // 過去 active が無くても image sha / tag / 100% / deployed は出す。従来はここで
+    // "" を返して Cloud Run repo が丸ごと不可視だった (ver も sha も traffic も
+    // 見えない、が今回の修正動機)。
     const html = renderBackendRollbackBlock(
       compat([
         {
           backend_repo: "ippoan/rust-alc-api",
-          current_image: "cur",
+          current_image: "c1b3e5146b15deadbeef",
           current_tag: null,
-          deploy_history: [{ image: "cur", tag: null, became_active_at: "t" }],
+          deployed_at: "2026-06-03T15:00:00Z",
+          deploy_history: [
+            { image: "c1b3e5146b15deadbeef", tag: null, became_active_at: "2026-06-03T15:00:00Z" },
+          ],
+          matrix: [],
+        },
+      ]),
+    );
+    expect(html).toContain("Backend traffic / rollback (Cloud Run revision)");
+    expect(html).toContain(">100%</span>");
+    expect(html).toContain("c1b3e5146b15"); // image sha short 表示 (12 文字)
+    expect(html).toContain('title="c1b3e5146b15deadbeef"'); // full は hover
+    expect(html).toContain("06-03 15:00"); // deployed (UTC)
+    // 過去 revision が無いので rollback ボタンは出さない。
+    expect(html).not.toContain("/api/release-wave/backend-rollback");
+  });
+
+  it("renders — for deployed_at when the record has no timestamp", () => {
+    const html = renderBackendRollbackBlock(
+      compat([
+        {
+          backend_repo: "ippoan/x",
+          current_image: "img-1",
+          current_tag: "v0.1.0",
+          deployed_at: null,
+          deploy_history: [],
+          matrix: [],
+        },
+      ]),
+    );
+    expect(html).toContain(">100%</span>");
+    expect(html).toContain("v0.1.0");
+    expect(html).toContain("—"); // deployed_at 無し → "—"
+  });
+
+  it("returns empty string when a backend record has no current_image", () => {
+    const html = renderBackendRollbackBlock(
+      compat([
+        {
+          backend_repo: "ippoan/rust-alc-api",
+          current_image: null,
+          current_tag: null,
+          deployed_at: null,
+          deploy_history: [],
           matrix: [],
         },
       ]),
     );
     expect(html).toBe("");
+  });
+
+  it("escapes repo names, tags and image ids", () => {
+    const html = renderBackendRollbackBlock(
+      compat([
+        {
+          backend_repo: 'a/<b>"&',
+          current_image: "<img>",
+          current_tag: "<tag>",
+          deployed_at: "2026-06-03T15:00:00Z",
+          deploy_history: [
+            { image: "<img>", tag: "<tag>", became_active_at: "2026-06-03T15:00:00Z" },
+          ],
+          matrix: [],
+        },
+      ]),
+    );
+    expect(html).not.toContain("<b>");
+    expect(html).toContain("&lt;b&gt;");
+    expect(html).not.toContain("<img>");
+    expect(html).toContain("&lt;img&gt;");
+    expect(html).not.toContain("<tag>");
+    expect(html).toContain("&lt;tag&gt;");
   });
 });
 


### PR DESCRIPTION
## 概要

`/release-wave` の backend (GCP / Cloud Run) 表示を改善する。従来は rollback 候補 (過去 revision) を持つ repo しか出さず、deploy 直後で `deploy_history` が 1 件の Cloud Run repo は **image sha も tag も traffic も見えなかった**。frontend の「Traffic (version split)」と対称な表示に揃える。

Refs #256

## 変更

- `WaveBackendCompat` に `deployed_at` を追加 (`backend::<repo>.deployed_at` 由来)。
- 「Backend rollback (Cloud Run revision)」→「**Backend traffic / rollback (Cloud Run revision)**」に拡張:
  - 各 backend に **現 active 行**を常に表示
    - `%` … `100%` (緑 badge)。Cloud Run は最新 ready revision に 100% flip 運用 (canary % 配分なし) なので現 active = 100% traffic
    - `Tag / Image (sha)` … git tag を `<strong>`、image sha を `<code>` (short 12 文字 / full は hover) に分離。どれが ver でどれが sha か一目で分かる
    - `Deployed (UTC)` … `deployed_at`
  - **rollback 行**は過去 revision (`deploy_history` の現 active 以外) がある時のみ従来どおり出す

## Before / After (表示イメージ)

**Before**

| Backend repo | Current | Rollback to (過去 revision) |
|---|---|---|
| rust-alc-api | `c1b3e5146b15…` | 候補無しなら **行ごと非表示** |

**After**

| Backend repo | % | Tag / Image (sha) | Deployed (UTC) |
|---|---|---|---|
| rust-alc-api | `100%` | `c1b3e5146b15…` (full は hover) | 06-03 15:00 |
| | | Rollback to … (過去 revision があれば) | |

## 補足

実 traffic % split (canary 90/10 等) は Cloud Run backend が 100% flip 運用のため出さない。実 `status.traffic[]` が必要になった場合は release-wave-gcp の `/cloudrun/stage-check` (GetService) 経由で取得 → backend report に載せる追加配線が別途必要 (本 PR の scope 外)。

## テスト

- `npm run typecheck` ✅
- `npm test` ✅ (40 files / 669 passed)。`renderBackendRollbackBlock` の describe を更新 (現 active 行 / rollback 候補無しでも表示 / image sha full title / escape)。

https://claude.ai/code/session_01P4o2JFAwvEQNcWXUsEttnM

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4o2JFAwvEQNcWXUsEttnM)_