### PR TITLE
feat(release-wave): backend (Cloud Run) の実 traffic split (status.traffic[]) の受け皿を追加

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import {
   handleBackendCurrentImageWebhook,
   handlePendingReleaseWebhook,
   handleTrafficReportWebhook,
+  handleBackendTrafficReportWebhook,
 } from "./release-wave/webhook";
 import {
   handleCompatibility,
@@ -252,6 +253,12 @@ app.post("/webhooks/release-wave/pending-release", (c) =>
 // percentage) を報告する。Compatibility グラフ下に 100%/0% version を出す用。
 app.post("/webhooks/release-wave/traffic-report", (c) =>
   handleTrafficReportWebhook(c.req.raw, c.env),
+);
+// release-wave-handler の cloudrun flip/rollback 後に Cloud Run の実 traffic
+// split (status.traffic[]) を service 単位で報告する。backend 表示を GCP の
+// 実態 (Flip 前の 旧100%+新pending0% 含む) に追従させる。Refs #256。
+app.post("/webhooks/release-wave/backend-traffic-report", (c) =>
+  handleBackendTrafficReportWebhook(c.req.raw, c.env),
 );
 // 認証付き read (CF Access が bypass する /webhooks/* 配下)。frontend CI が
 // 現 prod backend image を解決する用 — CF Access 下の /backend-current-image は

--- a/src/release-wave/backend-traffic.ts
+++ b/src/release-wave/backend-traffic.ts
@@ -1,0 +1,134 @@
+/**
+ * Cloud Run backend の「実 traffic split」(status.traffic[]) の KV 永続化。
+ *
+ * release-wave-handler の cloudrun flip / rollback 後に release-wave-gcp の
+ * `/cloudrun/stage-check` (GetService) で取得した実 traffic を報告し、
+ * `backend-traffic::<repo>` として COMPAT_KV に保存する。/release-wave の backend
+ * 表示で「今 GCP で各 revision が何 % traffic を持つか」を実態ベースで出す。
+ *
+ * これが要るのは、Cloud Run の release-wave 運用が **tag push → `--no-traffic`
+ * deploy (新 revision 0%) → Flip (新 100%)** だから。Flip 前は常に「旧 revision
+ * 100% + 新 pending revision 0%」の 2 revision 状態になり、報告値ベースの
+ * `backend::<repo>.current_image` (= flip 後の target_tag) だけでは pending
+ * revision (0%) が Traffic 表示に出ない。GCP の `status.traffic[]` を映すことで
+ * frontend の `traffic::<repo>` (Cloudflare Workers の version split) と対称になる。
+ *
+ * frontend (`traffic.ts`) は 1 repo = 1 worker だが、backend は 1 repo = N service
+ * (例 rust-alc-api 本体 + gateway) なので **service 単位**で traffic を持つ。
+ *
+ * KV namespace は COMPAT_KV (CI_STATUS と同一 namespace、prefix で分離)。
+ * `backend-traffic::` prefix は `frontend::` / `backend::` / `traffic::` /
+ * `pending-release::` と衝突しない。
+ */
+
+const BACKEND_TRAFFIC_PREFIX = "backend-traffic::";
+
+/** 現行 schema version (破壊的変更時に bump)。 */
+const SCHEMA_VERSION = 1 as const;
+
+/** Cloud Run 1 revision の traffic 配分。 */
+export interface BackendRevisionTraffic {
+  /** short revision name (例 `rust-alc-api-00042-abc`)。 */
+  revision: string;
+  /** traffic 配分 % (0〜100)。 */
+  percent: number;
+  /**
+   * Cloud Run revision tag (例 `pending-v1-4-3`、`v1.4.2` 等)。
+   * `status.traffic[].tag` 由来。無ければ null。
+   */
+  tag: string | null;
+}
+
+/** 1 Cloud Run service の traffic 配分。 */
+export interface BackendServiceTraffic {
+  /** Cloud Run service 名 (例 `rust-alc-api`)。 */
+  service: string;
+  /** revision 配分。percent 降順 (100% を上に) で並ぶ。 */
+  revisions: BackendRevisionTraffic[];
+}
+
+/** `backend-traffic::<repo>` value。repo ごとに最新の service 別 traffic を保持 (upsert)。 */
+export interface BackendTrafficRecord {
+  schema_version: number;
+  /** "owner/name"。 */
+  repo: string;
+  /** service 別の traffic split。service 名昇順で並ぶ。 */
+  services: BackendServiceTraffic[];
+  /** 報告を受けた UTC ISO。 */
+  reported_at: string;
+}
+
+function backendTrafficKey(repo: string): string {
+  return `${BACKEND_TRAFFIC_PREFIX}${repo}`;
+}
+
+/**
+ * 報告された service 別 traffic で record を置き換える (upsert、最新報告で全置換)。
+ *
+ * 各 service の revisions は percent 降順 (同率は revision 名昇順) に、service は
+ * service 名昇順に整列して保存する。報告は flip/rollback callback で全 service を
+ * まとめて 1 回送る前提なので read-modify-write の merge はしない (frontend の
+ * `traffic.ts` と違い tag の蓄積も不要 — tag は GCP の `status.traffic[]` が常に
+ * 最新を返す)。
+ */
+export async function recordBackendTraffic(
+  kv: KVNamespace,
+  input: {
+    repo: string;
+    services: BackendServiceTraffic[];
+    now: string;
+  },
+): Promise<BackendTrafficRecord> {
+  const services = input.services
+    .map((s) => ({
+      service: s.service,
+      revisions: [...s.revisions].sort((a, b) => {
+        if (b.percent !== a.percent) return b.percent - a.percent;
+        // 同 percent は revision 名昇順で安定させる。
+        return a.revision < b.revision ? -1 : a.revision > b.revision ? 1 : 0;
+      }),
+    }))
+    .sort((a, b) =>
+      a.service < b.service ? -1 : a.service > b.service ? 1 : 0,
+    );
+
+  const record: BackendTrafficRecord = {
+    schema_version: SCHEMA_VERSION,
+    repo: input.repo,
+    services,
+    reported_at: input.now,
+  };
+  await kv.put(backendTrafficKey(input.repo), JSON.stringify(record));
+  return record;
+}
+
+/** 単一 repo の backend traffic を取得 (無ければ / schema 不一致は null)。 */
+export async function getBackendTraffic(
+  kv: KVNamespace,
+  repo: string,
+): Promise<BackendTrafficRecord | null> {
+  const v = await kv.get<BackendTrafficRecord>(backendTrafficKey(repo), "json");
+  if (!v || v.schema_version !== SCHEMA_VERSION) return null;
+  return v;
+}
+
+/**
+ * 指定 repo 群の backend traffic を repo→record の Map で返す (record 無しは含めない)。
+ * compat グラフに出る backend だけ引きたいので個別 get を並列で叩く。
+ */
+export async function getBackendTrafficForRepos(
+  kv: KVNamespace,
+  repos: Iterable<string>,
+): Promise<Map<string, BackendTrafficRecord>> {
+  const list = [...new Set(repos)];
+  const entries = await Promise.all(
+    list.map(
+      async (repo) => [repo, await getBackendTraffic(kv, repo)] as const,
+    ),
+  );
+  const out = new Map<string, BackendTrafficRecord>();
+  for (const [repo, rec] of entries) {
+    if (rec) out.set(repo, rec);
+  }
+  return out;
+}

--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -27,6 +27,10 @@ import {
   type WaveCompatibility,
   type WaveBackendCompat,
 } from "./compat";
+import {
+  getBackendTrafficForRepos,
+  type BackendTrafficRecord,
+} from "./backend-traffic";
 import { parseTaglessRepos } from "../tagless-repos";
 import {
   getTrafficForRepos,
@@ -396,30 +400,39 @@ function renderTrafficRollbackRow(repo: string, rec: TrafficRecord): string {
 }
 
 /**
- * Compatibility グラフに出ている backend repo の Cloud Run revision 状態 +
- * rollback ボタンを HTML で返す (Refs #197)。
+ * Compatibility グラフに出ている backend repo の Cloud Run traffic 状態 +
+ * rollback ボタンを HTML で返す (Refs #197 / #256)。
  *
  * frontend の「Traffic (version split)」と対称に、各 backend について:
- *   - **現 active 行**: 100% badge + git tag (ver) + image sha (full は hover) +
- *     deploy 日時。Cloud Run backend は「最新 ready revision に 100% flip」運用
- *     (canary % 配分なし) なので、現 active = 100% traffic として出す。これで
- *     ver / image sha / traffic が一目で分かる。従来は rollback 候補 (過去
- *     revision) が無い backend を丸ごと隠していたため、deploy 直後で履歴 1 件の
- *     Cloud Run repo は image sha も tag も traffic も見えなかった。それを解消する。
+ *   - **traffic 行**: `backend-traffic::<repo>` に GCP の実 traffic split
+ *     (`status.traffic[]`) があれば、service × revision ごとに percent badge +
+ *     revision sha (full は hover) + revision tag を出す。Cloud Run は tag push →
+ *     `--no-traffic` deploy (新 0%) → Flip (新 100%) 運用なので、Flip 前は
+ *     「旧 100% + 新 pending 0%」が実態として並ぶ。
+ *   - 実 traffic 報告がまだ無い backend は **fallback 行** (`backend::<repo>.
+ *     current_image` を 100% と仮定: tag + image sha + deploy 日時)。実 traffic を
+ *     報告する配線 (release-wave-handler の cloudrun flip/rollback) が回り始める
+ *     までの暫定表示。
  *   - **rollback 行**: `deploy_history` のうち「現 active 以外」(= 過去に active
  *     だった revision) があれば各候補に `Rollback to <tag/sha>` ボタンを出す。
- *     frontend の Traffic rollback と方針を揃える (任意の過去 revision を即 100%)。
  *
- * backend record (`backend::<repo>`) を持ち current_image が分かる repo は必ず
- * 現 active 行を出す (rollback 候補の有無に依らない)。current_image 不明 (稀) な
- * repo だけ skip。1 行も出せなければ ""。
+ * backend record (`backend::<repo>`) を持つ repo は traffic 行 or fallback 行を
+ * 必ず出す (traffic も current_image も無い稀な record だけ skip)。1 行も出せ
+ * なければ ""。
  */
-export function renderBackendRollbackBlock(compat: WaveCompatibility): string {
+export function renderBackendRollbackBlock(
+  compat: WaveCompatibility,
+  trafficByRepo?: Map<string, BackendTrafficRecord>,
+): string {
   const rows = compat.backends
     .map((b) => {
-      const active = renderBackendActiveRow(b);
-      if (!active) return ""; // current_image 不明な record は出さない
-      return active + renderBackendRollbackRow(b);
+      const traffic = trafficByRepo?.get(b.backend_repo);
+      // 実 traffic split (GCP 実態) があれば優先。無ければ current_image fallback。
+      const head = hasBackendTraffic(traffic)
+        ? renderBackendTrafficRows(b.backend_repo, traffic!)
+        : renderBackendActiveRow(b);
+      if (!head) return ""; // traffic も current_image も無い record は出さない
+      return head + renderBackendRollbackRow(b);
     })
     .filter((r) => r !== "")
     .join("");
@@ -429,13 +442,58 @@ export function renderBackendRollbackBlock(compat: WaveCompatibility): string {
   return `
     <div style="margin-top:10px">
       <strong class="meta">Backend traffic / rollback (Cloud Run revision)</strong>
-      <p class="meta" style="margin:4px 0">Cloud Run backend は現 active revision に 100% traffic
-        (canary % 配分なし)。image sha は hover で full、tag は git release tag。</p>
+      <p class="meta" style="margin:4px 0">Cloud Run の実 traffic split (status.traffic[])。
+        tag push → no-traffic deploy (新 0%) → Flip (新 100%) 運用なので、Flip 前は
+        「旧 100% + 新 pending 0%」が並ぶ。revision / image sha は hover で full。</p>
       <table style="margin-top:6px">
-        <thead><tr><th>Backend repo</th><th>%</th><th>Tag / Image (sha)</th><th>Deployed (UTC)</th></tr></thead>
+        <thead><tr><th>Backend repo</th><th>%</th><th>Revision / Image / Tag</th><th>When (UTC)</th></tr></thead>
         <tbody>${rows}</tbody>
       </table>
     </div>`;
+}
+
+/** backend に実 traffic split (revision 1 件以上) があるか。 */
+function hasBackendTraffic(t: BackendTrafficRecord | undefined): boolean {
+  return !!t && t.services.some((s) => s.revisions.length > 0);
+}
+
+/**
+ * 1 backend の実 traffic 行群 (GCP `status.traffic[]` ベース)。service × revision
+ * を percent 降順 (record 側で整列済み) で並べ、各行に percent badge + revision
+ * sha (full は hover) + revision tag を出す。repo 名は最初の行だけ。複数 service
+ * の repo は service 名も前置する。GCP の traffic には deploy 日時が無いので
+ * When 列は "—"。
+ */
+function renderBackendTrafficRows(
+  repo: string,
+  traffic: BackendTrafficRecord,
+): string {
+  const multiService = traffic.services.length > 1;
+  const flat = traffic.services.flatMap((svc) =>
+    svc.revisions.map((rev) => ({ service: svc.service, rev })),
+  );
+  return flat
+    .map(({ service, rev }, i) => {
+      // 100% = 緑 / 0% = 灰 / その他 (canary 等) = 黄。
+      const color =
+        rev.percent >= 100 ? GREEN : rev.percent <= 0 ? GRAY : AMBER;
+      const pctBadge = `<span class="badge" style="background:${color}">${rev.percent}%</span>`;
+      const svcPart = multiService
+        ? `<span class="meta">${escapeHtml(service)}</span> `
+        : "";
+      const revCode = `<code title="${escapeHtml(rev.revision)}">${escapeHtml(shortId(rev.revision))}</code>`;
+      const tagPart = rev.tag
+        ? ` <span class="meta">${escapeHtml(rev.tag)}</span>`
+        : "";
+      return `
+            <tr>
+              <td>${i === 0 ? escapeHtml(repo) : ""}</td>
+              <td>${pctBadge}</td>
+              <td>${svcPart}${revCode}${tagPart}</td>
+              <td><span class="meta">—</span></td>
+            </tr>`;
+    })
+    .join("");
 }
 
 /**
@@ -570,8 +628,17 @@ export async function handleReleaseWaveListPageWithRepoStatus(
       const trafficByRepo = await getTrafficForRepos(env.COMPAT_KV, repos);
       const trafficBlock = renderTrafficVersionsBlock(repos, trafficByRepo);
 
-      // backend (Cloud Run) revision の rollback ボタンをグラフ下に出す (Refs #197)。
-      const backendRollbackBlock = renderBackendRollbackBlock(compat);
+      // backend (Cloud Run) の実 traffic split + rollback ボタンをグラフ下に出す。
+      // 実 traffic (backend-traffic::) があれば GCP 実態を、無ければ current_image
+      // ベースの fallback を表示する (Refs #197 / #256)。
+      const backendTrafficByRepo = await getBackendTrafficForRepos(
+        env.COMPAT_KV,
+        repos,
+      );
+      const backendRollbackBlock = renderBackendRollbackBlock(
+        compat,
+        backendTrafficByRepo,
+      );
 
       // traffic → backend rollback → Tag Release ボタンの順で 1 回で注入する。
       html = injectCompatTagReleaseButtons(

--- a/src/release-wave/webhook.ts
+++ b/src/release-wave/webhook.ts
@@ -23,6 +23,10 @@ import type { WaveState } from "./types";
 import { recordFrontendTest, recordBackendDeploy, getBackendCurrent } from "./compat";
 import { recordPendingRelease } from "./pending-release";
 import { recordTraffic } from "./traffic";
+import {
+  recordBackendTraffic,
+  type BackendServiceTraffic,
+} from "./backend-traffic";
 
 // ----------------------------------------------------------------------------
 // Common helpers
@@ -447,6 +451,82 @@ export async function handleTrafficReportWebhook(
       created_on: x.created_on ?? null,
       tag: x.tag ?? null,
     })),
+    now: new Date().toISOString(),
+  });
+  return jsonResponse(200, { ok: true, record });
+}
+
+// ----------------------------------------------------------------------------
+// /webhooks/release-wave/backend-traffic-report  (Cloud Run 実 traffic、Refs #256)
+// ----------------------------------------------------------------------------
+
+/**
+ * release-wave-handler の cloudrun flip / rollback 後に、release-wave-gcp の
+ * `/cloudrun/stage-check` (GetService) で取得した Cloud Run の **実 traffic split**
+ * (`status.traffic[]`) を service 単位で報告する。ci-dashboard 側で
+ * `backend-traffic::<repo>` に upsert し、/release-wave の backend 表示を GCP の
+ * 実態 (Flip 前の `旧 100% + 新 pending 0%` 含む) に追従させる。
+ *
+ * frontend の `/traffic-report` (Cloudflare Workers の version split) と対称だが、
+ * backend は 1 repo = N service なので service 配列で受ける。
+ *
+ * body:
+ *   {
+ *     "repo": "ippoan/rust-alc-api",
+ *     "services": [
+ *       {
+ *         "service": "rust-alc-api",
+ *         "revisions": [
+ *           { "revision": "rust-alc-api-00042-abc", "percent": 100, "tag": "v1.4.2" },
+ *           { "revision": "rust-alc-api-00043-xyz", "percent": 0,   "tag": "pending-v1-4-3" }
+ *         ]
+ *       }
+ *     ]
+ *   }
+ */
+const backendTrafficReportSchema = z.object({
+  repo: z.string().min(1),
+  services: z
+    .array(
+      z.object({
+        service: z.string().min(1),
+        // traffic 未設定 (revision 0 件) の service も許容する。
+        revisions: z.array(
+          z.object({
+            revision: z.string().min(1),
+            percent: z.number().min(0).max(100),
+            // null / undefined / 省略すべて許容 (tag の無い revision がある)。
+            tag: z.string().min(1).nullish(),
+          }),
+        ),
+      }),
+    )
+    .min(1),
+});
+
+export async function handleBackendTrafficReportWebhook(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  const v = await validateAndAuth(request, env, backendTrafficReportSchema);
+  if (!v.ok) return v.response;
+  if (!env.COMPAT_KV) {
+    return jsonResponse(500, {
+      code: "KV_NOT_CONFIGURED",
+      error: "COMPAT_KV is not bound",
+    });
+  }
+  const services: BackendServiceTraffic[] = v.data.services.map((s) => ({
+    service: s.service,
+    revisions: s.revisions.map((r) => ({
+      revision: r.revision,
+      percent: r.percent,
+      tag: r.tag ?? null,
+    })),
+  }));
+  const record = await recordBackendTraffic(env.COMPAT_KV, {
+    repo: v.data.repo,
+    services,
     now: new Date().toISOString(),
   });
   return jsonResponse(200, { ok: true, record });

--- a/test/release-wave/backend-traffic.test.ts
+++ b/test/release-wave/backend-traffic.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import {
+  recordBackendTraffic,
+  getBackendTraffic,
+  getBackendTrafficForRepos,
+} from "../../src/release-wave/backend-traffic";
+
+/** in-memory KV (backend-traffic:: の read/write 検証用)。 */
+function memKv(seed: Record<string, unknown> = {}): KVNamespace {
+  const store = new Map<string, string>(
+    Object.entries(seed).map(([k, v]) => [k, JSON.stringify(v)]),
+  );
+  return {
+    async get(key: string, type?: string) {
+      const raw = store.get(key);
+      if (raw === undefined) return null;
+      return type === "json" ? JSON.parse(raw) : raw;
+    },
+    async put(key: string, value: string) {
+      store.set(key, value);
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+    async list({ prefix = "" }: { prefix?: string } = {}) {
+      const keys = [...store.keys()]
+        .filter((k) => k.startsWith(prefix))
+        .map((name) => ({ name }));
+      return { keys, list_complete: true, cacheStatus: null };
+    },
+  } as unknown as KVNamespace;
+}
+
+describe("recordBackendTraffic / getBackendTraffic", () => {
+  it("stores service traffic and sorts revisions by percent desc", async () => {
+    const kv = memKv();
+    await recordBackendTraffic(kv, {
+      repo: "ippoan/rust-alc-api",
+      services: [
+        {
+          service: "rust-alc-api",
+          revisions: [
+            // わざと 0% を先に渡す → 100% が先頭に並ぶことを確認。
+            { revision: "rust-alc-api-00043-xyz", percent: 0, tag: "pending-v1-4-3" },
+            { revision: "rust-alc-api-00042-abc", percent: 100, tag: "v1.4.2" },
+          ],
+        },
+      ],
+      now: "2026-06-04T00:00:00Z",
+    });
+    const rec = await getBackendTraffic(kv, "ippoan/rust-alc-api");
+    expect(rec).not.toBeNull();
+    expect(rec!.repo).toBe("ippoan/rust-alc-api");
+    expect(rec!.reported_at).toBe("2026-06-04T00:00:00Z");
+    const revs = rec!.services[0]!.revisions;
+    expect(revs[0]!.percent).toBe(100);
+    expect(revs[0]!.revision).toBe("rust-alc-api-00042-abc");
+    expect(revs[0]!.tag).toBe("v1.4.2");
+    expect(revs[1]!.percent).toBe(0);
+    expect(revs[1]!.tag).toBe("pending-v1-4-3");
+  });
+
+  it("sorts services by name asc", async () => {
+    const kv = memKv();
+    await recordBackendTraffic(kv, {
+      repo: "ippoan/x",
+      services: [
+        { service: "z-gateway", revisions: [{ revision: "z-1", percent: 100, tag: null }] },
+        { service: "a-api", revisions: [{ revision: "a-1", percent: 100, tag: null }] },
+      ],
+      now: "t",
+    });
+    const rec = await getBackendTraffic(kv, "ippoan/x");
+    expect(rec!.services.map((s) => s.service)).toEqual(["a-api", "z-gateway"]);
+  });
+
+  it("upsert replaces the previous record (latest report wins)", async () => {
+    const kv = memKv();
+    await recordBackendTraffic(kv, {
+      repo: "ippoan/x",
+      services: [{ service: "x", revisions: [{ revision: "old", percent: 100, tag: null }] }],
+      now: "t1",
+    });
+    await recordBackendTraffic(kv, {
+      repo: "ippoan/x",
+      services: [{ service: "x", revisions: [{ revision: "new", percent: 100, tag: null }] }],
+      now: "t2",
+    });
+    const rec = await getBackendTraffic(kv, "ippoan/x");
+    expect(rec!.services[0]!.revisions[0]!.revision).toBe("new");
+    expect(rec!.reported_at).toBe("t2");
+  });
+
+  it("returns null for a missing repo", async () => {
+    expect(await getBackendTraffic(memKv(), "ippoan/none")).toBeNull();
+  });
+
+  it("returns null for a schema mismatch", async () => {
+    const kv = memKv({
+      "backend-traffic::ippoan/x": {
+        schema_version: 99,
+        repo: "ippoan/x",
+        services: [],
+        reported_at: "t",
+      },
+    });
+    expect(await getBackendTraffic(kv, "ippoan/x")).toBeNull();
+  });
+});
+
+describe("getBackendTrafficForRepos", () => {
+  it("returns only repos that have a record", async () => {
+    const kv = memKv();
+    await recordBackendTraffic(kv, {
+      repo: "ippoan/a",
+      services: [{ service: "a", revisions: [{ revision: "a-1", percent: 100, tag: null }] }],
+      now: "t",
+    });
+    const map = await getBackendTrafficForRepos(kv, ["ippoan/a", "ippoan/b"]);
+    expect(map.has("ippoan/a")).toBe(true);
+    expect(map.has("ippoan/b")).toBe(false);
+    expect(map.size).toBe(1);
+  });
+
+  it("dedupes repeated repos", async () => {
+    const kv = memKv();
+    await recordBackendTraffic(kv, {
+      repo: "ippoan/a",
+      services: [{ service: "a", revisions: [{ revision: "a-1", percent: 100, tag: null }] }],
+      now: "t",
+    });
+    const map = await getBackendTrafficForRepos(kv, ["ippoan/a", "ippoan/a"]);
+    expect(map.size).toBe(1);
+  });
+
+  it("returns an empty map when no repo has a record", async () => {
+    const map = await getBackendTrafficForRepos(memKv(), ["ippoan/a"]);
+    expect(map.size).toBe(0);
+  });
+});

--- a/test/release-wave/repo-status-section.test.ts
+++ b/test/release-wave/repo-status-section.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../../src/release-wave/repo-status-section";
 import type { TrafficRecord } from "../../src/release-wave/traffic";
 import type { WaveCompatibility } from "../../src/release-wave/compat";
+import type { BackendTrafficRecord } from "../../src/release-wave/backend-traffic";
 import type { RepoReleaseStatus } from "../../src/release-wave/repo-release-status";
 import type { Env } from "../../src/index";
 
@@ -550,6 +551,99 @@ describe("renderBackendRollbackBlock", () => {
     expect(html).toContain("&lt;img&gt;");
     expect(html).not.toContain("<tag>");
     expect(html).toContain("&lt;tag&gt;");
+  });
+
+  it("renders the real traffic split (100% active + pending 0%) when backend-traffic exists", () => {
+    const trafficByRepo = new Map<string, BackendTrafficRecord>([
+      [
+        "ippoan/rust-alc-api",
+        {
+          schema_version: 1,
+          repo: "ippoan/rust-alc-api",
+          services: [
+            {
+              service: "rust-alc-api",
+              revisions: [
+                { revision: "rust-alc-api-00042-abc", percent: 100, tag: "v1.4.2" },
+                { revision: "rust-alc-api-00043-xyz", percent: 0, tag: "pending-v1-4-3" },
+              ],
+            },
+          ],
+          reported_at: "2026-06-04T00:00:00Z",
+        },
+      ],
+    ]);
+    const html = renderBackendRollbackBlock(
+      compat([
+        {
+          backend_repo: "ippoan/rust-alc-api",
+          current_image: "v1.4.2",
+          current_tag: "v1.4.2",
+          deployed_at: "2026-06-03T00:00:00Z",
+          deploy_history: [],
+          matrix: [],
+        },
+      ]),
+      trafficByRepo,
+    );
+    // 実 traffic split: 100% active + 0% pending の 2 revision が並ぶ。
+    expect(html).toContain(">100%</span>");
+    expect(html).toContain(">0%</span>");
+    expect(html).toContain('title="rust-alc-api-00042-abc"'); // revision full は hover
+    expect(html).toContain('title="rust-alc-api-00043-xyz"');
+    expect(html).toContain("pending-v1-4-3"); // revision tag
+  });
+
+  it("prefixes the service name when a repo has multiple services", () => {
+    const trafficByRepo = new Map<string, BackendTrafficRecord>([
+      [
+        "ippoan/rust-alc-api",
+        {
+          schema_version: 1,
+          repo: "ippoan/rust-alc-api",
+          services: [
+            { service: "rust-alc-api", revisions: [{ revision: "api-1", percent: 100, tag: null }] },
+            { service: "rust-alc-api-gateway", revisions: [{ revision: "gw-1", percent: 100, tag: null }] },
+          ],
+          reported_at: "t",
+        },
+      ],
+    ]);
+    const html = renderBackendRollbackBlock(
+      compat([
+        {
+          backend_repo: "ippoan/rust-alc-api",
+          current_image: "x",
+          current_tag: null,
+          deployed_at: null,
+          deploy_history: [],
+          matrix: [],
+        },
+      ]),
+      trafficByRepo,
+    );
+    expect(html).toContain("rust-alc-api-gateway"); // 複数 service は service 名を前置
+    expect(html).toContain("api-1");
+    expect(html).toContain("gw-1");
+  });
+
+  it("falls back to the current_image row when no backend-traffic is given", () => {
+    // trafficByRepo を渡さない → current_image を 100% で表示 (PR #258 の挙動)。
+    const html = renderBackendRollbackBlock(
+      compat([
+        {
+          backend_repo: "ippoan/rust-alc-api",
+          current_image: "c1b3e5146b15deadbeef",
+          current_tag: "v1.4.2",
+          deployed_at: "2026-06-03T15:00:00Z",
+          deploy_history: [],
+          matrix: [],
+        },
+      ]),
+    );
+    expect(html).toContain(">100%</span>");
+    expect(html).toContain('title="c1b3e5146b15deadbeef"');
+    expect(html).toContain("v1.4.2");
   });
 });
 

--- a/test/release-wave/webhook.test.ts
+++ b/test/release-wave/webhook.test.ts
@@ -4,9 +4,11 @@ import {
   handleFlipReportWebhook,
   handlePendingReleaseWebhook,
   handleTrafficReportWebhook,
+  handleBackendTrafficReportWebhook,
 } from "../../src/release-wave/webhook";
 import { getPendingRelease } from "../../src/release-wave/pending-release";
 import { getTraffic } from "../../src/release-wave/traffic";
+import { getBackendTraffic } from "../../src/release-wave/backend-traffic";
 import type { Env } from "../../src/index";
 import type { ReleaseWaveHub } from "../../src/release-wave/do";
 
@@ -615,6 +617,143 @@ describe("handleTrafficReportWebhook", () => {
         body: {
           repo: "ippoan/auth-worker",
           versions: [{ version_id: "a", percentage: 100 }],
+        },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(401);
+  });
+});
+
+// ============================================================================
+// /webhooks/release-wave/backend-traffic-report
+// ============================================================================
+
+const BACKEND_TRAFFIC_URL =
+  "https://ci-dashboard.ippoan.org/webhooks/release-wave/backend-traffic-report";
+
+describe("handleBackendTrafficReportWebhook", () => {
+  it("records service traffic sorted by percent desc (ok=true)", async () => {
+    const kv = memKv();
+    const { env } = fakeEnv({ compatKv: kv });
+    const resp = await handleBackendTrafficReportWebhook(
+      jsonRequest({
+        url: BACKEND_TRAFFIC_URL,
+        secret: "expected-secret",
+        body: {
+          repo: "ippoan/rust-alc-api",
+          services: [
+            {
+              service: "rust-alc-api",
+              revisions: [
+                { revision: "rust-alc-api-00043-xyz", percent: 0, tag: "pending-v1-4-3" },
+                { revision: "rust-alc-api-00042-abc", percent: 100, tag: "v1.4.2" },
+              ],
+            },
+          ],
+        },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(200);
+    const rec = await getBackendTraffic(kv, "ippoan/rust-alc-api");
+    expect(rec).not.toBeNull();
+    expect(rec!.services[0]!.revisions[0]!.percent).toBe(100);
+    expect(rec!.services[0]!.revisions[0]!.revision).toBe("rust-alc-api-00042-abc");
+    expect(rec!.services[0]!.revisions[1]!.percent).toBe(0);
+    expect(rec!.services[0]!.revisions[1]!.tag).toBe("pending-v1-4-3");
+  });
+
+  it("defaults a missing revision tag to null", async () => {
+    const kv = memKv();
+    const { env } = fakeEnv({ compatKv: kv });
+    const resp = await handleBackendTrafficReportWebhook(
+      jsonRequest({
+        url: BACKEND_TRAFFIC_URL,
+        secret: "expected-secret",
+        body: {
+          repo: "ippoan/x",
+          services: [{ service: "x", revisions: [{ revision: "x-1", percent: 100 }] }],
+        },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(200);
+    const rec = await getBackendTraffic(kv, "ippoan/x");
+    expect(rec!.services[0]!.revisions[0]!.tag).toBeNull();
+  });
+
+  it("accepts a service with an empty revisions array (traffic 未設定)", async () => {
+    const kv = memKv();
+    const { env } = fakeEnv({ compatKv: kv });
+    const resp = await handleBackendTrafficReportWebhook(
+      jsonRequest({
+        url: BACKEND_TRAFFIC_URL,
+        secret: "expected-secret",
+        body: { repo: "ippoan/x", services: [{ service: "x", revisions: [] }] },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(200);
+  });
+
+  it("rejects an empty services array with 400", async () => {
+    const kv = memKv();
+    const { env } = fakeEnv({ compatKv: kv });
+    const resp = await handleBackendTrafficReportWebhook(
+      jsonRequest({
+        url: BACKEND_TRAFFIC_URL,
+        secret: "expected-secret",
+        body: { repo: "ippoan/x", services: [] },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(400);
+  });
+
+  it("rejects a percent out of range with 400", async () => {
+    const kv = memKv();
+    const { env } = fakeEnv({ compatKv: kv });
+    const resp = await handleBackendTrafficReportWebhook(
+      jsonRequest({
+        url: BACKEND_TRAFFIC_URL,
+        secret: "expected-secret",
+        body: {
+          repo: "ippoan/x",
+          services: [{ service: "x", revisions: [{ revision: "r", percent: 150 }] }],
+        },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(400);
+  });
+
+  it("returns 500 when COMPAT_KV is unbound", async () => {
+    const { env } = fakeEnv({ compatKv: undefined });
+    const resp = await handleBackendTrafficReportWebhook(
+      jsonRequest({
+        url: BACKEND_TRAFFIC_URL,
+        secret: "expected-secret",
+        body: {
+          repo: "ippoan/x",
+          services: [{ service: "x", revisions: [{ revision: "r", percent: 100 }] }],
+        },
+      }),
+      env,
+    );
+    expect(resp.status).toBe(500);
+  });
+
+  it("rejects a bad webhook secret with 401", async () => {
+    const kv = memKv();
+    const { env } = fakeEnv({ compatKv: kv });
+    const resp = await handleBackendTrafficReportWebhook(
+      jsonRequest({
+        url: BACKEND_TRAFFIC_URL,
+        secret: "wrong-secret",
+        body: {
+          repo: "ippoan/x",
+          services: [{ service: "x", revisions: [{ revision: "r", percent: 100 }] }],
         },
       }),
       env,


### PR DESCRIPTION
## 概要

実 traffic % split 表示の **push 型実装の 1/2（ci-dashboard 受け皿）**。

PR #258 は `backend::<repo>.current_image` を 100% と仮定して backend を表示していた。だが Cloud Run の release-wave 運用は **tag push → `--no-traffic` deploy（新 0%）→ Flip（新 100%）** で、rust-alc-api では `verify-no-traffic` job が「tag release は traffic を flip してはいけない」を強制している。なので **Flip 前は常に「旧 100% + 新 pending 0%」の 2 revision 状態**になる。これを GCP の実態（`status.traffic[]`）ベースで表示できるよう、ci-dashboard 側に受け皿を用意する。

Refs #256

## 変更

- **`backend-traffic.ts`（新規）**: `backend-traffic::<repo>` KV 層。frontend の `traffic.ts` と対称だが backend は 1 repo = N service（本体 + gateway 等）なので service 配列で持つ。`recordBackendTraffic` / `getBackendTraffic` / `getBackendTrafficForRepos`。
- **`webhook.ts` + `index.ts`**: `POST /webhooks/release-wave/backend-traffic-report` + `handleBackendTrafficReportWebhook`。frontend の `/traffic-report` と対称、shared secret 認証。
- **`repo-status-section.ts`**: 「Backend traffic / rollback」テーブルで、実 traffic（`backend-traffic::`）があれば service × revision の split（100% active + pending 0% 等）を表示。無ければ `current_image` fallback（PR #258 の挙動）に degrade。

## push 型・段階移行

報告側の配線（ci-workflows の `report-backend-traffic-split` composite action + `release-wave-handler.yml` の cloudrun flip/rollback callback に追加）は **後続 PR**。release-wave-gcp の `/cloudrun/stage-check`（`GetService`）が既に `status.traffic[]` を返すので、**release-wave-gcp 側の変更は不要**。

受け皿が先に main に入っても、報告が来るまでは fallback（current_image）表示のままなので無害。

## テスト

- `npm run typecheck` ✅
- `npm test` ✅（42 files / 692 passed）。新規 `backend-traffic.test.ts`（9）+ `webhook.test.ts` の backend-traffic handler（7）+ `repo-status-section.test.ts` の traffic 分岐（3）。

https://claude.ai/code/session_01P4o2JFAwvEQNcWXUsEttnM

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4o2JFAwvEQNcWXUsEttnM)_