### PR TITLE
fix(release-wave): backend traffic の revision 表示から service prefix を剥がす

### DIFF
--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -481,7 +481,13 @@ function renderBackendTrafficRows(
       const svcPart = multiService
         ? `<span class="meta">${escapeHtml(service)}</span> `
         : "";
-      const revCode = `<code title="${escapeHtml(rev.revision)}">${escapeHtml(shortId(rev.revision))}</code>`;
+      // revision 名は <service>-NNNNN-xxx 形式。service prefix を剥がして revision
+      // 番号 (00042-abc) を見せる。先頭 12 文字 truncate だと service 名部分で潰れて
+      // 読めない (= 全 revision が "rust-alc-api…" になる) ため (Refs #256)。
+      const revShort = rev.revision.startsWith(`${service}-`)
+        ? rev.revision.slice(service.length + 1)
+        : shortId(rev.revision);
+      const revCode = `<code title="${escapeHtml(rev.revision)}">${escapeHtml(revShort)}</code>`;
       const tagPart = rev.tag
         ? ` <span class="meta">${escapeHtml(rev.tag)}</span>`
         : "";

--- a/test/release-wave/repo-status-section.test.ts
+++ b/test/release-wave/repo-status-section.test.ts
@@ -590,6 +590,7 @@ describe("renderBackendRollbackBlock", () => {
     expect(html).toContain(">100%</span>");
     expect(html).toContain(">0%</span>");
     expect(html).toContain('title="rust-alc-api-00042-abc"'); // revision full は hover
+    expect(html).toContain(">00042-abc</code>"); // service prefix を剥がした revision 番号 (Refs #256)
     expect(html).toContain('title="rust-alc-api-00043-xyz"');
     expect(html).toContain("pending-v1-4-3"); // revision tag
   });


### PR DESCRIPTION
## 概要

#256 で導入した「Backend traffic」表示の**実害修正**（スクショ報告: rust-alc-api の各 service が `rust-alc-api rust-alc-api…` と潰れて revision 番号が読めない）。

Cloud Run revision 名は `<service>-NNNNN-xxx` 形式（例 `rust-alc-api-00042-abc`）。これを先頭 12 文字で truncate すると **service 名部分（`rust-alc-api`）しか見えず**、全 revision が `rust-alc-api…` になり revision 番号（`-00042-` 等）が消えていた。service 名は別途前置しているので二重表示にもなっていた。

Refs #256

## 変更

`renderBackendTrafficRows` の revision 表示で、**revision が service prefix で始まれば剥がす**:

```ts
const revShort = rev.revision.startsWith(`${service}-`)
  ? rev.revision.slice(service.length + 1)   // rust-alc-api-00042-abc → 00042-abc
  : shortId(rev.revision);
```

full revision は今まで通り `title`（hover）で見える。

### 表示

| 修正前 | 修正後 |
|---|---|
| `rust-alc-api` `rust-alc-api…` | `rust-alc-api` `00042-abc` |

## テスト

- `npm run typecheck` ✅
- `repo-status-section.test.ts` ✅（53 passed）。`renders the real traffic split` に `>00042-abc</code>`（prefix 剥がし後の revision 番号）の assert を追加。

> 補足: スクショの「全 service に 100% + 0% の 2 行」は実装通りの正常状態（`v*` deploy 済み・未 Flip = 現 active 100% + flip 待ち pending 0%）。`When` が `—` なのも仕様（GCP の `status.traffic[]` に日時が無い）。本 PR は revision の**可読性**のみ直す。

https://claude.ai/code/session_01P4o2JFAwvEQNcWXUsEttnM

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4o2JFAwvEQNcWXUsEttnM)_