### PR TITLE
refactor(release-wave): rollback UI を list + button の選択形式にしてコンパクト化

### DIFF
--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -373,19 +373,13 @@ function renderTrafficRollbackRow(repo: string, rec: TrafficRecord): string {
   // だった version へ戻す」rollback 専用。戻し先が無ければ行を出さない。
   if (candidates.length === 0) return "";
 
-  const buttons = candidates
+  // 候補が増えると button 横並びが画面を埋めるので、select で 1 つ選んで 1 ボタンで
+  // 戻す list + button 形式にコンパクト化 (戻し先候補は最新が先頭になるよう降順)。
+  const options = candidates
     .map((e) => {
       const label = e.tag ? escapeHtml(e.tag) : escapeHtml(shortId(e.version_id));
       const when = escapeHtml(shortWhen(e.became_active_at));
-      return `
-            <form method="post" action="/api/release-wave/traffic-rollback" style="margin:0 6px 4px 0;display:inline-block">
-              <input type="hidden" name="repo" value="${escapeHtml(repo)}">
-              <input type="hidden" name="version_id" value="${escapeHtml(e.version_id)}">
-              <button type="submit" class="danger"
-                title="${escapeHtml(repo)} を ${escapeHtml(e.version_id)} に即 100% で戻す (wrangler versions deploy ${escapeHtml(e.version_id)}@100%)">
-                Rollback to ${label} <span class="meta">(${when})</span>
-              </button>
-            </form>`;
+      return `<option value="${escapeHtml(e.version_id)}" title="${escapeHtml(e.version_id)}">${label} (${when})</option>`;
     })
     .join("");
 
@@ -393,8 +387,16 @@ function renderTrafficRollbackRow(repo: string, rec: TrafficRecord): string {
             <tr>
               <td></td>
               <td colspan="3">
-                <span class="meta">Rollback to (過去の deployed version):</span>
-                <div style="margin-top:4px">${buttons}</div>
+                <form method="post" action="/api/release-wave/traffic-rollback"
+                  style="margin:0;display:flex;gap:6px;align-items:center;flex-wrap:wrap">
+                  <input type="hidden" name="repo" value="${escapeHtml(repo)}">
+                  <span class="meta">Rollback to:</span>
+                  <select name="version_id" style="max-width:280px">${options}</select>
+                  <button type="submit" class="danger"
+                    title="${escapeHtml(repo)} を選択した version に即 100% で戻す (wrangler versions deploy <id>@100%)">
+                    Rollback
+                  </button>
+                </form>
               </td>
             </tr>`;
 }
@@ -536,19 +538,13 @@ function renderBackendRollbackRow(b: WaveBackendCompat): string {
   const candidates = history.filter((e) => e.image !== b.current_image);
   if (candidates.length === 0) return "";
 
-  const buttons = candidates
+  // frontend の Traffic rollback と対称に、候補を select で 1 つ選んで 1 ボタンで
+  // 戻す list + button 形式にコンパクト化する。
+  const options = candidates
     .map((e) => {
       const label = e.tag ? escapeHtml(e.tag) : escapeHtml(shortId(e.image));
       const when = escapeHtml(shortWhen(e.became_active_at));
-      return `
-            <form method="post" action="/api/release-wave/backend-rollback" style="margin:0 6px 4px 0;display:inline-block">
-              <input type="hidden" name="repo" value="${escapeHtml(b.backend_repo)}">
-              <input type="hidden" name="image" value="${escapeHtml(e.image)}">
-              <button type="submit" class="danger"
-                title="${escapeHtml(b.backend_repo)} の Cloud Run traffic を ${escapeHtml(e.image)} に即 100% で戻す">
-                Rollback to ${label} <span class="meta">(${when})</span>
-              </button>
-            </form>`;
+      return `<option value="${escapeHtml(e.image)}" title="${escapeHtml(e.image)}">${label} (${when})</option>`;
     })
     .join("");
 
@@ -556,8 +552,16 @@ function renderBackendRollbackRow(b: WaveBackendCompat): string {
             <tr>
               <td></td>
               <td colspan="3">
-                <span class="meta">Rollback to (過去 revision):</span>
-                <div style="margin-top:4px">${buttons}</div>
+                <form method="post" action="/api/release-wave/backend-rollback"
+                  style="margin:0;display:flex;gap:6px;align-items:center;flex-wrap:wrap">
+                  <input type="hidden" name="repo" value="${escapeHtml(b.backend_repo)}">
+                  <span class="meta">Rollback to:</span>
+                  <select name="image" style="max-width:340px">${options}</select>
+                  <button type="submit" class="danger"
+                    title="${escapeHtml(b.backend_repo)} の Cloud Run traffic を選択した revision に即 100% で戻す">
+                    Rollback
+                  </button>
+                </form>
               </td>
             </tr>`;
 }

--- a/test/release-wave/repo-status-section.test.ts
+++ b/test/release-wave/repo-status-section.test.ts
@@ -383,10 +383,12 @@ describe("renderTrafficVersionsBlock", () => {
     };
     const html = renderTrafficVersionsBlock(["ippoan/auth-worker"], new Map([["ippoan/auth-worker", r]]));
     expect(html).toContain("/api/release-wave/traffic-rollback");
-    expect(html).toContain('name="version_id" value="prev"');
-    expect(html).toContain("Rollback to v0.2.49");
-    // 現 active (cur) への rollback ボタンは出さない。
-    expect(html).not.toContain('name="version_id" value="cur"');
+    // list + button 形式: select の option に過去 version、ボタンは 1 つ。
+    expect(html).toContain('<select name="version_id"');
+    expect(html).toContain('<option value="prev"');
+    expect(html).toContain("v0.2.49 (");
+    // 現 active (cur) は戻し先候補にしない (option に出さない)。
+    expect(html).not.toContain('value="cur"');
   });
 
   it("renders no Rollback button when deploy_history has only the active version", () => {
@@ -461,12 +463,13 @@ describe("renderBackendRollbackBlock", () => {
     expect(html).toContain("v1.4.2");
     expect(html).toContain('title="rust-alc-api-00042-abc"'); // image full は hover
     expect(html).toContain("05-29 09:30"); // deployed (UTC, MM-DD HH:mm)
-    // rollback 行: 過去 revision へのボタン。
+    // rollback 行: list + button 形式 (select の option に過去 revision)。
     expect(html).toContain("/api/release-wave/backend-rollback");
-    expect(html).toContain('name="image" value="rust-alc-api-00041-xyz"');
-    expect(html).toContain("Rollback to v1.4.1");
-    // 現 active (00042) への rollback ボタン (input) は出さない。
-    expect(html).not.toContain('name="image" value="rust-alc-api-00042-abc"');
+    expect(html).toContain('<select name="image"');
+    expect(html).toContain('<option value="rust-alc-api-00041-xyz"');
+    expect(html).toContain("v1.4.1 (");
+    // 現 active (00042) は戻し先候補にしない (option value に出さない)。
+    expect(html).not.toContain('value="rust-alc-api-00042-abc"');
   });
 
   it("shows the current active row even without rollback candidates (deploy 直後で履歴 1 件)", () => {


### PR DESCRIPTION
Refs #266

## 概要

`/release-wave` の rollback UI を **list (select) + button** の選択形式にしてコンパクト化する。

### Before

frontend (traffic-rollback) / backend (backend-rollback) の rollback 行は、戻し先候補を 1 つずつ `<button>` として横並びに出していたため、revision 履歴が増えると `Rollback to d6ac3ecf07c9…` `Rollback to e6ad458fa047…` … が大量に並んで画面を大きく占有していた。

### After

候補を `<select>` の `<option>` に列挙し、選んで 1 つの **Rollback** ボタンで戻す形に変更。1 行に収まる。

- option ラベルは `<tag or short-id> (MM-DD HH:mm)`、`title` に full の version_id / image を残し hover で確認可能。
- POST 先 (`/api/release-wave/traffic-rollback` / `/api/release-wave/backend-rollback`) と field 名 (`version_id` / `image`) は不変 → API ハンドラ側の変更は不要。

### 変更ファイル

- `src/release-wave/repo-status-section.ts` — `renderTrafficRollbackRow` / `renderBackendRollbackRow` を select 形式に
- `test/release-wave/repo-status-section.test.ts` — markup アサーションを select/option に合わせて更新

> 注: CCoW コンテナは GitHub Packages token を持ち込めず `npm install` が 401 になるため、ローカルでの vitest 実行は不可。検証は CI (frontend-ci の typecheck + test) に委ねる。

---
_Generated by [Claude Code](https://claude.ai/code/session_011Fd665LzuyFSsdSAMGnFGc)_