### PR TITLE
fix(release-wave): Cloud Run section から CF Worker backend を除外 (Refs #268)

### DIFF
--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -421,12 +421,21 @@ function renderTrafficRollbackRow(repo: string, rec: TrafficRecord): string {
  * backend record (`backend::<repo>`) を持つ repo は traffic 行 or fallback 行を
  * 必ず出す (traffic も current_image も無い稀な record だけ skip)。1 行も出せ
  * なければ ""。
+ *
+ * **`workerRepos` (CF Workers = `traffic::` を持つ repo) は除外する。** compat の
+ * "backend" は「frontend が互換性テストする対象」であって platform を区別しない
+ * ため、auth-worker のような Cloudflare Workers backend もここに混ざる。CF Workers
+ * は wrangler の version split を `traffic::` で報告し、上の「Traffic (version
+ * split)」section に既に出ているので、Cloud Run revision として二重に出さない
+ * (Refs #268)。platform 規約は「workers=traffic:: / cloudrun=pending-release::」。
  */
 export function renderBackendRollbackBlock(
   compat: WaveCompatibility,
   trafficByRepo?: Map<string, BackendTrafficRecord>,
+  workerRepos?: ReadonlySet<string>,
 ): string {
   const rows = compat.backends
+    .filter((b) => !workerRepos?.has(b.backend_repo))
     .map((b) => {
       const traffic = trafficByRepo?.get(b.backend_repo);
       // 実 traffic split (GCP 実態) があれば優先。無ければ current_image fallback。
@@ -645,9 +654,12 @@ export async function handleReleaseWaveListPageWithRepoStatus(
         env.COMPAT_KV,
         repos,
       );
+      // CF Workers backend (auth-worker 等) は traffic:: を持ち上の version split
+      // に出ているので、Cloud Run revision section からは除外する (Refs #268)。
       const backendRollbackBlock = renderBackendRollbackBlock(
         compat,
         backendTrafficByRepo,
+        new Set(trafficByRepo.keys()),
       );
 
       // traffic → backend rollback → Tag Release ボタンの順で 1 回で注入する。

--- a/test/release-wave/repo-status-section.test.ts
+++ b/test/release-wave/repo-status-section.test.ts
@@ -649,6 +649,56 @@ describe("renderBackendRollbackBlock", () => {
     expect(html).toContain('title="c1b3e5146b15deadbeef"');
     expect(html).toContain("v1.4.2");
   });
+
+  it("excludes CF Workers backends (workerRepos) from the Cloud Run section (Refs #268)", () => {
+    // auth-worker は CF Worker だが compat 上は backend (frontend が互換性テスト
+    // する対象) なので backend record を持つ。Cloud Run revision section には
+    // 出さず、上の version split section に任せる。
+    const html = renderBackendRollbackBlock(
+      compat([
+        {
+          backend_repo: "ippoan/auth-worker",
+          current_image: "v0.2.52",
+          current_tag: "v0.2.52",
+          deployed_at: "2026-06-03T23:52:00Z",
+          deploy_history: [],
+          matrix: [],
+        },
+        {
+          backend_repo: "ippoan/rust-alc-api",
+          current_image: "rust-alc-api-00042-abc",
+          current_tag: "v1.4.2",
+          deployed_at: "2026-06-03T15:00:00Z",
+          deploy_history: [],
+          matrix: [],
+        },
+      ]),
+      undefined,
+      new Set(["ippoan/auth-worker"]),
+    );
+    // Cloud Run backend (rust-alc-api) は出るが、CF Worker (auth-worker) は出ない。
+    expect(html).toContain("ippoan/rust-alc-api");
+    expect(html).not.toContain("ippoan/auth-worker");
+  });
+
+  it("renders the whole block empty when every backend is a CF Worker (Refs #268)", () => {
+    const html = renderBackendRollbackBlock(
+      compat([
+        {
+          backend_repo: "ippoan/auth-worker",
+          current_image: "v0.2.52",
+          current_tag: "v0.2.52",
+          deployed_at: "2026-06-03T23:52:00Z",
+          deploy_history: [],
+          matrix: [],
+        },
+      ]),
+      undefined,
+      new Set(["ippoan/auth-worker"]),
+    );
+    // 全 backend が CF Worker なら section ごと出さない。
+    expect(html).toBe("");
+  });
 });
 
 describe("isUpToDate", () => {


### PR DESCRIPTION
## 概要

`/release-wave` の **Backend traffic / rollback (Cloud Run revision)** セクションに、Cloudflare Workers である `ippoan/auth-worker` が Cloud Run revision として表示されるバグの修正。Refs #268

## 原因

`renderBackendRollbackBlock`（`src/release-wave/repo-status-section.ts`）が `compat.backends` を**無条件で全件** Cloud Run revision として描画していた。

compat の "backend" は「frontend が互換性テストする対象」であって platform を区別しない。`auth-worker` は他リポジトリから consume される backend なので `backend::ippoan/auth-worker` レコードを持ち、このセクションに混入していた。

`auth-worker` は CF Worker なので `/traffic-report` 経由で `traffic::` レコードを持ち、上の **Traffic (version split)** セクションに既に正しく出ている → 二重表示で、Cloud Run 側が誤り。

## 修正

platform 規約「workers=`traffic::` / cloudrun=`pending-release::`」に従い、`traffic::` レコードを持つ repo（= CF Worker）を Cloud Run section から除外する。

- `renderBackendRollbackBlock` に `workerRepos?: ReadonlySet<string>` 引数を追加し、`compat.backends` を `.filter()` で除外。
- 呼び出し側で `new Set(trafficByRepo.keys())`（version split に出ている CF Worker repo 集合）を渡す。

## テスト

- CF Worker backend が Cloud Run section から除外される
- 全 backend が CF Worker なら section ごと空になる

の 2 ケースを追加（`test/release-wave/repo-status-section.test.ts`）。

> 注: ローカルは GitHub Packages (`@ippoan/auth-client-worker`) の認証トークンが CCoW で持ち込めず `npm install` が 401 で失敗するため、typecheck / test は CI に委ねる。


---
_Generated by [Claude Code](https://claude.ai/code/session_01JYZ4pgJeD1bCH6eD24qcbQ)_