### PR TITLE
feat(release-wave): preview link を Flip ボタンの右に + repo=short_sha 併記

### DIFF
--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -137,6 +137,8 @@ const COMMON_STYLES = `
   .actions button.danger { background: #d93025; }
   .actions button.warn { background: #f29900; }
   .actions button:disabled { background: #dadce0; cursor: not-allowed; }
+  .preview-inline { font-size: 12px; color: #5f6368; }
+  .preview-inline a { margin-right: 6px; }
   pre { background: #f1f3f4; padding: 12px; border-radius: 4px; overflow: auto;
     font-size: 12px; line-height: 1.5; }
   .section { background: #fff; padding: 16px 20px; margin: 16px 0;
@@ -237,23 +239,27 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
   );
 
   const rows = waves.length === 0
-    ? `<tr><td colspan="7" class="empty">No release waves yet.</td></tr>`
+    ? `<tr><td colspan="6" class="empty">No release waves yet.</td></tr>`
     : waves
         .map((w) => {
           const repos = w.repos.map((r) => escapeHtml(r.repo)).join(", ");
 
-          // preview URL は repo ごとに stage callback で報告される。set 済みの
-          // ものだけ http/https に絞って link 化し、repo 名付きで列挙する。
-          const previewLines = w.repos
-            .map((r) => {
-              const safe = safeHttpUrl(r.preview_url);
-              if (!safe) return null;
-              return `<a href="${escapeHtml(safe)}" target="_blank" rel="noopener noreferrer">${escapeHtml(r.repo)}</a>`;
-            })
-            .filter((x): x is string => x !== null);
-          const previewCell = previewLines.length > 0
-            ? previewLines.join("<br>")
-            : `<span class="meta">—</span>`;
+          // Flip ボタンの右に出す preview リンク。repo が複数 (= front ごとに別 image)
+          // の時に区別できるよう repo 名 + short head_sha を併記する
+          // (例: auth-worker=a1b2c3d nuxt-notify=d4e5f6a)。preview_url がある repo は
+          // link 化、無ければ素の text (sha だけは常に出して image を識別可能にする)。
+          const previewItems = w.repos.map((r) => {
+            const name = escapeHtml(r.repo.split("/").pop() ?? r.repo);
+            const sha = r.head_sha ? escapeHtml(r.head_sha.slice(0, 7)) : "?";
+            const label = `${name}=${sha}`;
+            const safe = safeHttpUrl(r.preview_url);
+            return safe
+              ? `<a href="${escapeHtml(safe)}" target="_blank" rel="noopener noreferrer" title="${escapeHtml(safe)}">${label}</a>`
+              : `<span class="meta">${label}</span>`;
+          });
+          const previewInline = previewItems.length > 0
+            ? `<span class="preview-inline">${previewItems.join(" ")}</span>`
+            : "";
 
           // 一括 flip = Approve & Flip。pending-approval の時だけ有効。
           // 一覧では force を付けない (compat gate ブロック時は失敗 → 詳細ページで
@@ -274,8 +280,7 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
               <td class="meta">${escapeHtml(w.started_at)}</td>
               <td class="meta">${escapeHtml(w.flip_policy)}</td>
               <td class="meta">${repos}</td>
-              <td>${previewCell}</td>
-              <td class="actions">${flipButton}</td>
+              <td class="actions">${flipButton}${previewInline}</td>
             </tr>`;
         })
         .join("");
@@ -309,7 +314,6 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
           <th>Started At</th>
           <th>Flip Policy</th>
           <th>Repos</th>
-          <th>Preview</th>
           <th>Actions</th>
         </tr>
       </thead>


### PR DESCRIPTION
## 目的 (Refs #260)

`/release-wave` の wave 一覧で、preview URL リンクを **Flip ボタンの右**（Actions 列）に出す。さらに repo が複数（front ごとに別 image）のとき区別できるよう **`repo=short_sha`** を併記する。

## 変更

`src/release-wave/page.ts`（wave 一覧テーブル）:

- 独立の **Preview 列を廃止** し、Actions セル（Approve & Flip ボタン）の右に preview を統合。
- 各 preview を **repo 名 + short `head_sha`**（例: `auth-worker=a1b2c3d nuxt-notify=d4e5f6a`）で表示。`preview_url` がある repo は link 化（`title` にフル URL）、無ければ素の text。**sha は常に表示**して image を識別可能に。
- 空状態 `colspan` 7→6、`<th>Preview</th>` 削除、`.preview-inline` スタイル追加。

## 検証

- `npm run typecheck` pass。
- `npm test` **全 692 tests pass**（42 files）。
- 依存は `@ippoan/auth-client-worker` の local copy を `file:` install して検証（CCoW に GitHub Packages token が無いため。この fallback は claude-hooks#13 の hook で今後自動提案される）。

Refs #260

---
_Generated by [Claude Code](https://claude.ai/code/session_019vz4Yn4TAGwYaRr3bE3DdM)_