### PR TITLE
feat(release-wave): 一覧で古い wave を畳む + frontend 単位の preview 追跡

### DIFF
--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -168,6 +168,174 @@ function hubStub(env: Env): DurableObjectStub<ReleaseWaveHub> {
 }
 
 // ----------------------------------------------------------------------------
+// Wave 一覧の絞り込み + frontend 単位の追跡
+// ----------------------------------------------------------------------------
+
+/** in-progress (= 常に一覧に出す) state。terminal はそれ以外。 */
+const ACTIVE_STATES: ReadonlySet<WaveStateName> = new Set([
+  "staging",
+  "pending-approval",
+  "flipping",
+]);
+
+/**
+ * 一覧に出す wave を絞る。
+ *
+ * - active (staging / pending-approval / flipping) は常に表示。
+ * - terminal (flipped / failed / aborted / rolled-back) のうち、最新の成功
+ *   デプロイ (= 最も新しい flipped wave) より **前に started した** wave は隠す。
+ *   成功デプロイが起きるたびに、それ以前の失敗・成功履歴が一覧から畳まれる
+ *   (= 古い fail / stale preview link がいつまでも残らない)。
+ * - flipped wave が 1 つも無ければ cutoff 無し = 全件表示 (deploy 前は隠さない)。
+ *
+ * 隠した wave も DO には残るので `/release-wave/<id>` 直リンクで参照可能。
+ */
+function visibleWaves(waves: WaveState[]): WaveState[] {
+  // 最新の flipped の started_at を cutoff にする (sort 順に依存せず max を取る)。
+  let cutoff: string | null = null;
+  for (const w of waves) {
+    if (w.state === "flipped" && (cutoff === null || w.started_at > cutoff)) {
+      cutoff = w.started_at;
+    }
+  }
+  if (cutoff === null) return waves;
+  const c = cutoff;
+  return waves.filter(
+    (w) => ACTIVE_STATES.has(w.state) || w.started_at >= c,
+  );
+}
+
+/** frontend (repo) 1 つの追跡サマリ。`computeFrontendTracks` が wave 群から導出。 */
+interface FrontendTrack {
+  repo: string;
+  /** この repo を含む最新 wave。 */
+  latestWaveId: string;
+  latestWaveState: WaveStateName;
+  latestAt: string;
+  /** この repo が最後に flip (deploy) された wave。未 deploy なら null。 */
+  lastFlipWaveId: string | null;
+  lastFlipAt: string | null;
+  lastFlipTag: string | null;
+  /** 最新 flip 以降で preview_url を持つ最新 wave のもの (古い preview は隠す)。 */
+  previewUrl: string | null;
+  previewWaveId: string | null;
+  previewSha: string | null;
+}
+
+/**
+ * 全 wave を repo (frontend) 単位に畳んで、各 frontend の「最新 preview URL /
+ * 最後の flip (deploy) / 最新 wave」を導出する。
+ *
+ * preview は各 frontend の **最新 flip より前のものを隠す** (= deploy 済みの
+ * frontend について、その deploy より古い stale preview link を出さない)。
+ * まだ flip されていない frontend は最新の preview をそのまま見せる。
+ */
+function computeFrontendTracks(waves: WaveState[]): FrontendTrack[] {
+  // started_at 降順に揃える (list() は降順だが sort 順に依存しないよう copy-sort)。
+  const sorted = [...waves].sort((a, b) =>
+    a.started_at < b.started_at ? 1 : -1,
+  );
+
+  const tracks = new Map<string, FrontendTrack>();
+
+  // pass 1: 最新 wave (= 最初に出会う) と最後の flip を記録。
+  for (const w of sorted) {
+    for (const r of w.repos) {
+      let t = tracks.get(r.repo);
+      if (!t) {
+        t = {
+          repo: r.repo,
+          latestWaveId: w.wave_id,
+          latestWaveState: w.state,
+          latestAt: w.started_at,
+          lastFlipWaveId: null,
+          lastFlipAt: null,
+          lastFlipTag: null,
+          previewUrl: null,
+          previewWaveId: null,
+          previewSha: null,
+        };
+        tracks.set(r.repo, t);
+      }
+      if (t.lastFlipAt === null && r.flip_status === "done") {
+        t.lastFlipWaveId = w.wave_id;
+        t.lastFlipAt = w.started_at;
+        t.lastFlipTag = r.target_tag;
+      }
+    }
+  }
+
+  // pass 2: 最新 flip 以降で preview を持つ最新 wave を採用 (古い preview は除外)。
+  for (const w of sorted) {
+    for (const r of w.repos) {
+      const t = tracks.get(r.repo);
+      if (!t || t.previewUrl !== null) continue;
+      const safe = safeHttpUrl(r.preview_url);
+      if (!safe) continue;
+      if (t.lastFlipAt !== null && w.started_at < t.lastFlipAt) continue;
+      t.previewUrl = safe;
+      t.previewWaveId = w.wave_id;
+      t.previewSha = r.head_sha ? r.head_sha.slice(0, 7) : null;
+    }
+  }
+
+  return [...tracks.values()].sort((a, b) => (a.repo < b.repo ? -1 : 1));
+}
+
+/**
+ * frontend (repo) 単位の追跡セクション。各 frontend の最新 preview URL と最後に
+ * deploy (flip) された wave を 1 行ずつ出す。preview を wave 行ではなく
+ * frontend 行に分けて持つことで「どの front の preview がどれか」を分離する。
+ */
+function renderFrontendSection(tracks: FrontendTrack[]): string {
+  const rows =
+    tracks.length === 0
+      ? `<tr><td colspan="4" class="empty">No frontends tracked yet.</td></tr>`
+      : tracks
+          .map((t) => {
+            const previewCell = t.previewUrl
+              ? `<a href="${escapeHtml(t.previewUrl)}" target="_blank" rel="noopener noreferrer">preview</a>
+                 ${t.previewSha ? `<span class="meta">${escapeHtml(t.previewSha)}</span>` : ""}
+                 <span class="meta">(${escapeHtml(t.previewWaveId ?? "")})</span>`
+              : `<span class="meta">—</span>`;
+            const deployCell = t.lastFlipWaveId
+              ? `<a href="/release-wave/${encodeURIComponent(t.lastFlipWaveId)}">${escapeHtml(t.lastFlipTag ?? t.lastFlipWaveId)}</a>
+                 <span class="meta">${escapeHtml(t.lastFlipAt ?? "")}</span>`
+              : `<span class="meta">not deployed</span>`;
+            const latestCell = `<a href="/release-wave/${encodeURIComponent(t.latestWaveId)}">${escapeHtml(t.latestWaveId)}</a>
+                <span class="badge" style="background:${stateColor(t.latestWaveState)}">${escapeHtml(t.latestWaveState)}</span>`;
+            return `
+              <tr>
+                <td>${escapeHtml(t.repo)}</td>
+                <td>${previewCell}</td>
+                <td class="meta">${deployCell}</td>
+                <td>${latestCell}</td>
+              </tr>`;
+          })
+          .join("");
+
+  return `
+    <div class="section">
+      <h2>Frontends (per-repo tracking)</h2>
+      <p class="meta">repo (frontend) ごとの最新 preview URL と、最後にデプロイ
+        (flip) された wave。preview は各 frontend の<strong>最新 flip より前のもの
+        を隠す</strong> (= deploy より古い stale preview link は出さない)。
+        まだ deploy 前の frontend は最新の preview をそのまま表示。</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Repo</th>
+            <th>Latest preview</th>
+            <th>Last deploy (flip)</th>
+            <th>Latest wave</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>`;
+}
+
+// ----------------------------------------------------------------------------
 // GET /release-wave  →  全 wave 一覧
 // ----------------------------------------------------------------------------
 
@@ -238,9 +406,14 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
     flipGroup,
   );
 
-  const rows = waves.length === 0
+  // frontend (repo) 単位の追跡セクション (全 wave から導出、wave 絞り込み前)。
+  const frontendSection = renderFrontendSection(computeFrontendTracks(waves));
+
+  // wave 一覧は最新の成功デプロイより前の terminal wave を畳んで出す。
+  const displayWaves = visibleWaves(waves);
+  const rows = displayWaves.length === 0
     ? `<tr><td colspan="6" class="empty">No release waves yet.</td></tr>`
-    : waves
+    : displayWaves
         .map((w) => {
           const repos = w.repos.map((r) => escapeHtml(r.repo)).join(", ");
 
@@ -306,6 +479,10 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
     </p>
     ${compatSection}
     ${pendingReleaseSection}
+    ${frontendSection}
+    <h2>Release waves</h2>
+    <p class="meta">最新の成功デプロイ (flipped) より前に始まった完了 wave は畳んで
+      非表示。直リンク <code>/release-wave/&lt;id&gt;</code> で個別参照は可能。</p>
     <table>
       <thead>
         <tr>

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -280,6 +280,168 @@ describe("handleReleaseWaveListPage", () => {
     expect(formChunk).not.toContain('name="force"');
   });
 
+  it("hides terminal waves older than the latest flipped wave (active always shown)", async () => {
+    const env = fakeEnv({
+      listReturn: [
+        // 最新の成功デプロイ
+        makeWave({
+          wave_id: "w-flip",
+          state: "flipped",
+          started_at: "2026-06-01T00:00:00Z",
+        }),
+        // flip より前の失敗 → 隠す
+        makeWave({
+          wave_id: "w-old-fail",
+          state: "failed",
+          started_at: "2026-05-30T00:00:00Z",
+        }),
+        // flip より前の中止 → 隠す
+        makeWave({
+          wave_id: "w-old-abort",
+          state: "aborted",
+          started_at: "2026-05-29T00:00:00Z",
+        }),
+        // flip より後の失敗 → 残す (まだ次の成功 deploy が無い)
+        makeWave({
+          wave_id: "w-new-fail",
+          state: "failed",
+          started_at: "2026-06-02T00:00:00Z",
+        }),
+        // active は常に表示
+        makeWave({
+          wave_id: "w-active",
+          state: "staging",
+          started_at: "2026-05-01T00:00:00Z",
+        }),
+      ],
+    });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    // cutoff (= w-flip) 自身と、それ以降の terminal、active は表示
+    expect(html).toContain("/release-wave/w-flip");
+    expect(html).toContain("/release-wave/w-new-fail");
+    expect(html).toContain("/release-wave/w-active");
+    // cutoff より前の terminal は一覧から消える
+    expect(html).not.toContain("/release-wave/w-old-fail");
+    expect(html).not.toContain("/release-wave/w-old-abort");
+  });
+
+  it("shows all waves when none has flipped yet (no deploy → no hiding)", async () => {
+    const env = fakeEnv({
+      listReturn: [
+        makeWave({
+          wave_id: "f1",
+          state: "failed",
+          started_at: "2026-05-30T00:00:00Z",
+        }),
+        makeWave({
+          wave_id: "f2",
+          state: "aborted",
+          started_at: "2026-05-29T00:00:00Z",
+        }),
+      ],
+    });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    expect(html).toContain("/release-wave/f1");
+    expect(html).toContain("/release-wave/f2");
+  });
+
+  it("renders a per-frontend tracking section with latest preview + last flip", async () => {
+    const repo = (over: Record<string, unknown>) => ({
+      repo: "ippoan/auth-worker",
+      target_tag: "v1",
+      head_sha: "abc1234",
+      require_compatibility: false,
+      stage_status: "done",
+      preview_url: null,
+      stage_error: null,
+      flip_status: "pending",
+      flip_error: null,
+      flip_from_revision: null,
+      rolled_back_to_revision: null,
+      ...over,
+    });
+    const env = fakeEnv({
+      listReturn: [
+        // 最新 wave: preview あり、まだ flip 前
+        makeWave({
+          wave_id: "w-new",
+          state: "pending-approval",
+          started_at: "2026-06-03T00:00:00Z",
+          repos: [
+            repo({
+              preview_url: "https://preview-auth.ippoan.org/",
+              head_sha: "newsha0",
+              flip_status: "pending",
+            }),
+          ],
+        }),
+        // 過去 wave: ここで flip (deploy) 済み、preview は古い
+        makeWave({
+          wave_id: "w-deployed",
+          state: "flipped",
+          started_at: "2026-06-01T00:00:00Z",
+          repos: [
+            repo({
+              target_tag: "v0.9",
+              preview_url: "https://stale-auth.ippoan.org/",
+              head_sha: "oldsha0",
+              flip_status: "done",
+            }),
+          ],
+        }),
+      ],
+    });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    expect(html).toContain("Frontends (per-repo tracking)");
+    expect(html).toContain("ippoan/auth-worker");
+    // 最新 flip 以降 (w-new) の preview を採用
+    expect(html).toContain('href="https://preview-auth.ippoan.org/"');
+    // 最後の deploy = w-deployed (tag v0.9) へリンク
+    expect(html).toContain("/release-wave/w-deployed");
+    expect(html).toContain("v0.9");
+  });
+
+  it("hides a frontend preview that predates that frontend's last flip", async () => {
+    const repo = (over: Record<string, unknown>) => ({
+      repo: "ippoan/auth-worker",
+      target_tag: "v1",
+      head_sha: "abc1234",
+      require_compatibility: false,
+      stage_status: "done",
+      preview_url: null,
+      stage_error: null,
+      flip_status: "pending",
+      flip_error: null,
+      flip_from_revision: null,
+      rolled_back_to_revision: null,
+      ...over,
+    });
+    const env = fakeEnv({
+      listReturn: [
+        // 最新 wave = flip 済み、preview 無し
+        makeWave({
+          wave_id: "w-deployed",
+          state: "flipped",
+          started_at: "2026-06-02T00:00:00Z",
+          repos: [repo({ preview_url: null, flip_status: "done" })],
+        }),
+        // flip より前の preview → frontend section では隠す
+        makeWave({
+          wave_id: "w-old",
+          state: "aborted",
+          started_at: "2026-06-01T00:00:00Z",
+          repos: [
+            repo({ preview_url: "https://stale-auth.ippoan.org/" }),
+          ],
+        }),
+      ],
+    });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    expect(html).toContain("Frontends (per-repo tracking)");
+    // 古い preview は frontend section に出さない (Latest preview = —)
+    expect(html).not.toContain("https://stale-auth.ippoan.org/");
+  });
+
   it("shows version traffic (100% / 0%) in the compat graph frontend node hover", async () => {
     const env = fakeEnv({
       listReturn: [],


### PR DESCRIPTION
## 背景

`/release-wave` 一覧テーブルが `list()` の全 wave を無制限に描画していたため、古い `failed` / `aborted` wave が **stale な preview link 付きでいつまでも残る**状態だった。「最新のが deploy されたら非表示でいい。いつまでも fail とか残ってて、preview リンクあってもダメ」という要望への対応。

加えて「各 front 毎に track したい / preview url も各 front 分けたい」という要望で、**frontend(repo) 単位の追跡ビュー**を新設する。

## 変更内容

### 1. wave 一覧を最新の成功デプロイより前で畳む

`visibleWaves()` を追加。

- **active** (`staging` / `pending-approval` / `flipping`) は常に表示
- **terminal** (`flipped` / `failed` / `aborted` / `rolled-back`) のうち、最新の成功デプロイ (= 最も新しい `flipped` wave) より**前に started した** wave を非表示
- `flipped` wave が 1 つも無ければ cutoff 無し = 全件表示（deploy 前は隠さない）
- 隠した wave も DO には残るので `/release-wave/<id>` 直リンクで参照可能（完全削除ではない）

### 2. 新規「Frontends (per-repo tracking)」セクション

`computeFrontendTracks()` + `renderFrontendSection()` を追加。全 wave を repo 単位に畳み、各 frontend について 1 行で表示:

| 列 | 内容 |
|---|---|
| Repo | repo 名 |
| Latest preview | 最新 preview URL（各 frontend の**最新 flip より前のものは隠す**） |
| Last deploy (flip) | 最後に flip された wave + tag へのリンク |
| Latest wave | この repo を含む最新 wave + state badge |

preview を wave 行ではなく frontend 行に分けて持つことで「どの front の preview がどれか」を分離。deploy 済みの frontend について、その deploy より古い stale preview link は出さない。まだ deploy 前の frontend は最新 preview をそのまま表示。

## テスト

`test/release-wave/page.test.ts` に 4 件追加:
- 最新 flipped より前の terminal wave を隠す / active は常に表示
- flipped が無ければ全件表示
- per-frontend section の最新 preview + last flip 表示
- frontend の最新 flip より前の preview を隠す

全 698 tests green、`tsc --noEmit` clean。

Refs #137

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1TLqB96rea6TTguip8GJv)_