### PR TITLE
feat(release-wave): /release-wave を WebSocket で live 更新する (Refs #275)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ import {
 import {
   handleReleaseWaveDetailPage,
 } from "./release-wave/page";
+import { handleReleaseWaveLiveJs } from "./release-wave/live";
 import {
   handleReleaseWaveApprove,
   handleReleaseWaveRollback,
@@ -103,6 +104,13 @@ app.use("*", cors());
 function getHub(env: Env): DurableObjectStub {
   const id = env.CI_HUB.idFromName("singleton");
   return env.CI_HUB.get(id);
+}
+
+// Release Wave は単一 singleton DO に全 wave を集約している (src/release-wave/do.ts)。
+// live 更新の WebSocket もこの singleton に張る (Refs #275)。
+function getReleaseWaveHub(env: Env): DurableObjectStub {
+  const id = env.RELEASE_WAVE_HUB.idFromName("singleton");
+  return env.RELEASE_WAVE_HUB.get(id);
 }
 
 // Dashboard
@@ -277,6 +285,18 @@ app.get("/backend-current-image", (c) =>
 // Auth は ci-dashboard 全体に被さる Cloudflare Access (Google OAuth + email
 // allowlist) edge gate に委譲。/releases ページと同じトラストモデル。
 app.get("/release-wave", (c) => handleReleaseWaveListPageWithRepoStatus(c.env));
+// live 更新 (Refs #275)。下の `:wave_id` 動的 route より **前** に登録して
+// "ws" / "live.js" が wave_id として捕捉されるのを防ぐ (Hono は登録順マッチ)。
+// WebSocket は RELEASE_WAVE_HUB singleton に proxy。state 変化時に DO 側
+// `saveWave` → `broadcast` がシグナルを送り、live.js が location.reload() する。
+app.get("/release-wave/ws", (c) => {
+  // DO 側 fetch は pathname === "/ws" で受理するので、Upgrade header 等を保った
+  // まま URL だけ /ws に書き換えて proxy する。
+  const wsUrl = new URL(c.req.url);
+  wsUrl.pathname = "/ws";
+  return getReleaseWaveHub(c.env).fetch(new Request(wsUrl, c.req.raw));
+});
+app.get("/release-wave/live.js", () => handleReleaseWaveLiveJs());
 app.get("/release-wave/:wave_id", (c) =>
   handleReleaseWaveDetailPage(c.env, c.req.param("wave_id")),
 );

--- a/src/release-wave/do.ts
+++ b/src/release-wave/do.ts
@@ -133,6 +133,56 @@ export type RpcResult<T> =
 export class ReleaseWaveHub extends DurableObject<Env> {
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
+    // Hibernatable WebSocket の keep-alive。CIDashboardHub (`src/hub.ts`) と
+    // 同じく ping → pong を runtime 内で自動応答させる (= wake させずに済む)。
+    this.ctx.setWebSocketAutoResponse(
+      new WebSocketRequestResponsePair("ping", "pong"),
+    );
+  }
+
+  // ============ live update (Hibernatable WebSocket) ===============
+
+  /**
+   * `/release-wave` ページの live 更新用 endpoint (Refs #275)。
+   *
+   *   GET /ws → WebSocketPair を accept して 101 を返す。以後この DO の
+   *   state が変わる (= `saveWave` が走る) たびに `broadcast()` が「変わった
+   *   よ」シグナルを送り、ブラウザ側 `live.js` が `location.reload()` する。
+   *
+   * Hibernatable WebSocket なのでアイドル中は hibernate され DO 課金ゼロ。
+   * 表示は既存 SSR をそのまま使うため、ここでは差分 payload を作らず固定
+   * 文字列 (`"reload"`) を流すだけにしている (XSS 面を増やさない)。
+   */
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname === "/ws") {
+      const pair = new WebSocketPair();
+      const [client, server] = Object.values(pair) as [WebSocket, WebSocket];
+      this.ctx.acceptWebSocket(server);
+      return new Response(null, { status: 101, webSocket: client });
+    }
+    return new Response("Not Found", { status: 404 });
+  }
+
+  /** 接続中の全 WebSocket に「変わった」シグナルを送る。 */
+  broadcast(data = "reload"): void {
+    for (const ws of this.ctx.getWebSockets()) {
+      try {
+        ws.send(data);
+      } catch {
+        // client が既に切断済み — 無視する。
+      }
+    }
+  }
+
+  async webSocketMessage(_ws: WebSocket, _message: string | ArrayBuffer): Promise<void> {}
+
+  async webSocketClose(ws: WebSocket, _code: number, _reason: string): Promise<void> {
+    ws.close();
+  }
+
+  async webSocketError(ws: WebSocket, _error: unknown): Promise<void> {
+    ws.close();
   }
 
   // ============ life-cycle =========================================
@@ -403,6 +453,10 @@ export class ReleaseWaveHub extends DurableObject<Env> {
 
   private async saveWave(state: WaveState): Promise<void> {
     await this.ctx.storage.put(waveKey(state.wave_id), state);
+    // 全 state 更新 (start/approve/flipReport/rollback/abort/fail/
+    // contractApplied + compat warning) は saveWave を必ず通るので、ここ一点で
+    // 全イベントを拾って live ページに「変わった」シグナルを送る (Refs #275)。
+    this.broadcast();
   }
 
   /** 全 wave を storage から取り出す (内部 helper)。listing 順は呼び出し側で sort。 */

--- a/src/release-wave/live.ts
+++ b/src/release-wave/live.ts
@@ -1,0 +1,43 @@
+/**
+ * `/release-wave` ページの live 更新クライアント (Refs #275)。
+ *
+ * 同一オリジン WebSocket (`/release-wave/ws`) に接続し、`ReleaseWaveHub` DO の
+ * state が変わるたびに送られてくる「変わったよ」シグナルを受けて
+ * `location.reload()` する。表示自体は既存 SSR をそのまま再取得するので、
+ * DOM 差分更新の JS は持たない (= XSS 面を増やさない)。
+ *
+ * 配信は外部ファイル 1 個ぶんだけ CSP を `script-src 'self'` に緩めて許可する。
+ * インライン JS は引き続き全ブロックされるため injected script は動かない。
+ * `connect-src 'self'` で同一オリジン wss のみ許可するため、外部送信も不可。
+ */
+
+const LIVE_JS = `(function () {
+  function connect() {
+    var proto = location.protocol === "https:" ? "wss:" : "ws:";
+    var ws = new WebSocket(proto + "//" + location.host + "/release-wave/ws");
+    ws.onmessage = function () {
+      // state が変わった → 既存 SSR を引き直す (一覧/詳細どちらでも現在 URL を再取得)。
+      location.reload();
+    };
+    ws.onclose = function () {
+      // 切断時は 3 秒後に再接続を試みる (deploy/hibernate 起因の drop に追従)。
+      setTimeout(connect, 3000);
+    };
+    ws.onerror = function () {
+      try { ws.close(); } catch (e) {}
+    };
+  }
+  connect();
+})();
+`;
+
+export function handleReleaseWaveLiveJs(): Response {
+  return new Response(LIVE_JS, {
+    headers: {
+      "Content-Type": "application/javascript; charset=utf-8",
+      // 小さな静的 asset。短期キャッシュで Worker request を減らしつつ、
+      // 変更時の伝播は数分以内に収める。
+      "Cache-Control": "public, max-age=300",
+    },
+  });
+}

--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -99,15 +99,18 @@ function htmlResponse(body: string, status = 200): Response {
       // キャッシュ制御は response header 側で担保する。
       "Cache-Control": "no-store, must-revalidate",
       // Defense in depth against XSS:
-      // - `script-src 'none'` で <script> / event handler 経由の実行をブロック
+      // - `script-src 'self'` で **外部ファイル 1 個** (/release-wave/live.js) のみ
+      //   許可。inline JS / event handler 経由の実行は引き続き全ブロックされる
+      //   ため injected script は動かない (Refs #275: live 更新を最小緩和で実現)
       // - `style-src 'self' 'unsafe-inline'` は本ページが inline <style> を
       //   使うため許可 (= injected style での data exfil は別軸の懸念だが、
       //   本ページの content は admin trusted DO state なのでバランス内)
       // - `default-src 'none'` で他リソース読み込みを全 deny
-      // - `connect-src 'none'` で fetch / XHR 全 deny (本ページに JS 無し)
+      // - `connect-src 'self'` で同一オリジン wss (= live 更新 WebSocket) のみ許可。
+      //   外部 origin への fetch / XHR / WS は引き続き deny
       // - preview link は target=_blank で別タブに飛ばすため frame-src 不要
       "Content-Security-Policy":
-        "default-src 'none'; style-src 'self' 'unsafe-inline'; connect-src 'none'; img-src 'self'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'",
+        "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'",
       "X-Content-Type-Options": "nosniff",
       "Referrer-Policy": "no-referrer",
     },
@@ -496,6 +499,7 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
   <meta charset="utf-8">
   <title>Release Waves</title>
   <style>${COMMON_STYLES}${TAB_STYLES}</style>
+  <script src="/release-wave/live.js" defer></script>
 </head>
 <body>
   <div class="container">
@@ -702,6 +706,7 @@ export async function handleReleaseWaveDetailPage(
   <meta charset="utf-8">
   <title>Wave ${escapeHtml(w.wave_id)} &mdash; ci-dashboard</title>
   <style>${COMMON_STYLES}${TAB_STYLES}</style>
+  <script src="/release-wave/live.js" defer></script>
 </head>
 <body>
   <div class="container">

--- a/test/release-wave/do.test.ts
+++ b/test/release-wave/do.test.ts
@@ -525,3 +525,66 @@ describe("ReleaseWaveHub.approve compatibility gate", () => {
     expect(res.ok).toBe(true);
   });
 });
+
+describe("ReleaseWaveHub live update (Hibernatable WebSocket, Refs #275)", () => {
+  it("accepts GET /ws and returns a 101 with a client WebSocket", async () => {
+    const hub = freshHub();
+    // webSocket を持つ Response は runInDurableObject の境界を越えて返せないので、
+    // callback 内で検査して plain な結果だけ返す。
+    const out = await runInDurableObject(hub, async (i) => {
+      const res = await i.fetch(
+        new Request("http://hub/ws", { headers: { Upgrade: "websocket" } }),
+      );
+      const hasSocket = !!res.webSocket;
+      res.webSocket?.accept();
+      res.webSocket?.close();
+      return { status: res.status, hasSocket };
+    });
+    expect(out.status).toBe(101);
+    expect(out.hasSocket).toBe(true);
+  });
+
+  it("returns 404 for non-/ws paths", async () => {
+    const hub = freshHub();
+    const status = await runInDurableObject(hub, async (i) => {
+      const res = await i.fetch(new Request("http://hub/nope"));
+      return res.status;
+    });
+    expect(status).toBe(404);
+  });
+
+  it("broadcasts a reload signal to connected clients on state change (saveWave)", async () => {
+    const hub = freshHub();
+    const received: string[] = [];
+    await runInDurableObject(hub, async (i) => {
+      // /ws を accept して client 側を掴む。
+      const res = await i.fetch(
+        new Request("http://hub/ws", { headers: { Upgrade: "websocket" } }),
+      );
+      const client = res.webSocket!;
+      client.accept();
+      client.addEventListener("message", (e) => {
+        received.push(String((e as MessageEvent).data));
+      });
+      // 任意の state 変更 (start) は saveWave を通るので broadcast が走る。
+      await i.start({ wave_id: "w-live", flip_policy: "auto", repos: REPOS });
+    });
+    // start 中に少なくとも 1 回 "reload" が届いている。
+    expect(received.length).toBeGreaterThan(0);
+    expect(received).toContain("reload");
+  });
+
+  it("broadcast() swallows send errors from a closed socket", async () => {
+    const hub = freshHub();
+    // socket を accept → close した状態で broadcast を呼んでも throw しない。
+    await runInDurableObject(hub, async (i) => {
+      const res = await i.fetch(
+        new Request("http://hub/ws", { headers: { Upgrade: "websocket" } }),
+      );
+      const client = res.webSocket!;
+      client.accept();
+      client.close();
+      expect(() => i.broadcast()).not.toThrow();
+    });
+  });
+});

--- a/test/release-wave/live-routing.test.ts
+++ b/test/release-wave/live-routing.test.ts
@@ -1,0 +1,50 @@
+import { createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { describe, it, expect, vi } from "vitest";
+import worker from "../../src/index";
+import type { Env } from "../../src/index";
+
+// /release-wave/ws と /release-wave/live.js が動的 `:wave_id` route に捕捉されず、
+// 静的 route として解決されることを worker レベルで確認する (Refs #275)。
+function testEnv(hubFetch: (req: Request) => Promise<Response>): Env {
+  return {
+    RELEASE_WAVE_HUB: {
+      idFromName: () => ({}),
+      get: () => ({ fetch: hubFetch }),
+    } as unknown as DurableObjectNamespace,
+  } as unknown as Env;
+}
+
+describe("release-wave live routes (Refs #275)", () => {
+  it("GET /release-wave/live.js serves JS without hitting the DO", async () => {
+    const hubFetch = vi.fn(async () => new Response("should-not-be-called"));
+    const req = new Request("http://localhost/release-wave/live.js");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(hubFetch), ctx);
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/javascript");
+    expect(hubFetch).not.toHaveBeenCalled();
+    expect(await res.text()).toContain("/release-wave/ws");
+  });
+
+  it("GET /release-wave/ws proxies to the DO with pathname rewritten to /ws", async () => {
+    let seenPath = "";
+    // 実 DO は 101 + webSocket を返すが、test 境界で webSocket は扱えないので
+    // marker 付き 200 を返して「proxy に解決された + path 書き換え」だけ検証する。
+    const hubFetch = vi.fn(async (req: Request) => {
+      seenPath = new URL(req.url).pathname;
+      return new Response("proxied", { headers: { "x-from-do": "1" } });
+    });
+    const req = new Request("http://localhost/release-wave/ws", {
+      headers: { Upgrade: "websocket" },
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(hubFetch), ctx);
+    await waitOnExecutionContext(ctx);
+    expect(hubFetch).toHaveBeenCalledOnce();
+    // DO 側 fetch は pathname === "/ws" で受理するので、proxy が書き換えていること。
+    expect(seenPath).toBe("/ws");
+    // 動的 `:wave_id` ではなく proxy に解決された (= DO の応答が返る)。
+    expect(res.headers.get("x-from-do")).toBe("1");
+  });
+});

--- a/test/release-wave/live.test.ts
+++ b/test/release-wave/live.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { handleReleaseWaveLiveJs } from "../../src/release-wave/live";
+
+describe("handleReleaseWaveLiveJs (Refs #275)", () => {
+  it("serves JS with a javascript content-type", async () => {
+    const resp = handleReleaseWaveLiveJs();
+    expect(resp.status).toBe(200);
+    expect(resp.headers.get("Content-Type")).toContain("application/javascript");
+  });
+
+  it("connects to /release-wave/ws and reloads on message", async () => {
+    const js = await handleReleaseWaveLiveJs().text();
+    expect(js).toContain("/release-wave/ws");
+    expect(js).toContain("location.reload()");
+    // 切断時に自動再接続する (受け入れ条件)。
+    expect(js).toContain("setTimeout(connect, 3000)");
+    // proto は https のとき wss に切り替える。
+    expect(js).toContain("wss:");
+  });
+});

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -910,6 +910,32 @@ describe("handleReleaseWaveDetailPage", () => {
     expect(resp.headers.get("Cache-Control")).toContain("no-store");
   });
 
+  it("relaxes CSP just enough for the live-update script (Refs #275)", async () => {
+    const env = fakeEnv({ listReturn: [] });
+    const resp = await handleReleaseWaveListPage(env);
+    const csp = resp.headers.get("Content-Security-Policy") ?? "";
+    // 外部 live.js 1 個 + 同一オリジン wss のみ許可。inline JS は依然ブロック。
+    expect(csp).toContain("script-src 'self'");
+    expect(csp).toContain("connect-src 'self'");
+    expect(csp).not.toContain("script-src 'none'");
+    expect(csp).not.toContain("connect-src 'none'");
+  });
+
+  it("includes the live.js <script> tag in the list page head (Refs #275)", async () => {
+    const env = fakeEnv({ listReturn: [] });
+    const resp = await handleReleaseWaveListPage(env);
+    const html = await resp.text();
+    expect(html).toContain('<script src="/release-wave/live.js"');
+  });
+
+  it("includes the live.js <script> tag in the detail page head (Refs #275)", async () => {
+    const wave = makeWave({ wave_id: "w-live" });
+    const env = fakeEnv({ getReturn: { ok: true, data: wave } });
+    const resp = await handleReleaseWaveDetailPage(env, "w-live");
+    const html = await resp.text();
+    expect(html).toContain('<script src="/release-wave/live.js"');
+  });
+
   it("escapes HTML in repo names / wave_id / event summaries", async () => {
     const wave = makeWave({
       wave_id: "evil<wave>",


### PR DESCRIPTION
## 概要

`/release-wave` / `/release-wave/:wave_id` ページを WebSocket で live 更新し、flip 等の状態変化を**手動リロードなし**で反映する。Refs #275。

`CIDashboardHub` (`src/hub.ts`) の `/ws` Hibernatable WebSocket 実装を `ReleaseWaveHub` に移植。WebSocket は「変わったよ」シグナル (`"reload"`) だけを送り、クライアントは受信したら `location.reload()` で既存 SSR を引き直す。DOM 差分更新の JS は持たない (= XSS 面を増やさない)。

## 変更点

| ファイル | 変更 |
|---|---|
| `src/release-wave/do.ts` | constructor で `setWebSocketAutoResponse(ping/pong)`、`fetch()` で `/ws` を `acceptWebSocket` → 101、`broadcast()` + `webSocketMessage/Close/Error`。**`saveWave()` の末尾で `broadcast()`** — 全状態更新 (start/approve/flipReport/rollback/abort/fail/contractApplied + compat warning) は `saveWave` を通るので一点で全イベントを拾う |
| `src/release-wave/live.ts` (新規) | 同一オリジン `/release-wave/ws` に接続 → `onmessage: location.reload()` → `onclose: setTimeout(connect, 3000)` で自動再接続。`application/javascript` で配信 |
| `src/index.ts` | `GET /release-wave/ws` を `RELEASE_WAVE_HUB` singleton に proxy (path を `/ws` に書き換え)、`GET /release-wave/live.js` の静的配信。どちらも `:wave_id` 動的 route より**前**に登録 (Hono は登録順マッチ) |
| `src/release-wave/page.ts` | CSP を最小緩和 (`script-src 'self'; connect-src 'self'`)。inline JS は引き続き全ブロック。一覧/詳細の両 head に `<script src="/release-wave/live.js" defer>` 追加 |

## 受け入れ条件

- [x] `/release-wave` を開いたまま flip を発火 → 手動リロードなしで状態が更新される (`saveWave` → `broadcast` → `location.reload()`)
- [x] アイドル時に定期 fetch / 定期リロードが発生しない (WS 接続維持のみ、DO は hibernate)
- [x] CSP は外部 `live.js` + 同一オリジン wss 以外を引き続き deny
- [x] WS 切断時に自動再接続する (`onclose` → 3 秒後 `connect`)

## CSP の緩め方

`script-src 'none'` → `script-src 'self'` で**外部ファイル 1 個ぶんだけ**許可。inline JS は引き続き全ブロックされるため injected script は依然動かない (defense in depth を最小緩和で維持)。`connect-src 'none'` → `'self'` で同一オリジン wss のみ許可。`default-src 'none'` / `form-action 'self'` / `frame-ancestors 'none'` は据え置き。

## テスト

- `live.ts` の配信内容 + content-type
- DO の `/ws` 受理 (101) / 非 `/ws` の 404 / `saveWave` 時の `"reload"` broadcast / 切断 socket への送信が throw しないこと
- worker route が `/release-wave/ws` `/release-wave/live.js` を `:wave_id` に捕捉させず解決すること (path 書き換え含む)
- page の CSP 緩和 + 両ページ head の `<script>` タグ

`npx tsc --noEmit` クリーン、全 710 テスト pass (11 追加)。

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRkNDS8tBMPa8u7TkgHEMh)_