### PR TITLE
feat(release-wave): wave 一覧テーブル廃止 + 一括 tag release / 一括 flip

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,10 @@ import { handleRecheck } from "./recheck";
 import { handleSecretGenPage } from "./secret-gen-page";
 import { handleLaunch } from "./launch";
 import { handleTagRelease } from "./tag-release";
-import { handleReleaseWaveTagRelease } from "./release-wave/tag-release-action";
+import {
+  handleReleaseWaveTagRelease,
+  handleReleaseWaveTagReleaseAll,
+} from "./release-wave/tag-release-action";
 import { handleReleaseWaveListPageWithRepoStatus } from "./release-wave/repo-status-section";
 import { handleMcpRequest } from "./mcp/server";
 import {
@@ -192,6 +195,11 @@ app.post("/api/tag-release", (c) => handleTagRelease(c.req.raw, c.env));
 // 303 で /release-wave へ戻す。
 app.post("/api/release-wave/tag-release", (c) =>
   handleReleaseWaveTagRelease(c.req.raw, c.env),
+);
+// Compatibility グラフの「⚡ Tag Release all」: form field `repos` (カンマ区切り)
+// の tag-release.yml をまとめて dispatch する。
+app.post("/api/release-wave/tag-release-all", (c) =>
+  handleReleaseWaveTagReleaseAll(c.req.raw, c.env),
 );
 
 // Recheck

--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -358,15 +358,17 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
       trafficByRepo = new Map();
     }
   }
+  // Pending releases は単一真実 (Refs #237): workers=traffic:: の no-traffic
+  // version / cloudrun=pending-release:: を統合し、Traffic セクションと一致させる。
+  // compat section の「Staged previews」内 ⚡ Flip all ボタンの出し分けに件数を使う
+  // ため、compatSection より先に算出する。
+  const unifiedPending = computeUnifiedPending(trafficByRepo, pendingReleases);
   const compatSection = renderGlobalCompatibilitySection(
     globalCompat,
     buildActiveWaveInfo(waves),
     trafficByRepo,
+    unifiedPending.length,
   );
-
-  // Pending releases は単一真実 (Refs #237): workers=traffic:: の no-traffic
-  // version / cloudrun=pending-release:: を統合し、Traffic セクションと一致させる。
-  const unifiedPending = computeUnifiedPending(trafficByRepo, pendingReleases);
   const pendingReleaseSection = renderPendingReleaseSection(
     unifiedPending,
     flipGroup,
@@ -830,6 +832,7 @@ function renderGlobalCompatibilitySection(
   compat: WaveCompatibility | null,
   active?: ActiveWaveInfo,
   trafficByRepo?: Map<string, TrafficRecord>,
+  pendingFlipCount = 0,
 ): string {
   if (!compat || compat.backends.length === 0) {
     return `
@@ -861,7 +864,7 @@ function renderGlobalCompatibilitySection(
         Refs <a href="https://github.com/ippoan/ci-dashboard/issues/157">#157</a>.</p>
       ${body}
       ${renderGlobalRetestButtons(compat)}
-      ${renderActiveWaveOverlay(active)}
+      ${renderActiveWaveOverlay(active, pendingFlipCount)}
     </div>`;
 }
 
@@ -921,7 +924,10 @@ function renderGlobalRetestButtons(compat: WaveCompatibility): string {
  * active wave が無い時も block 自体は常に描画し、placeholder / disabled ボタンを
  * 出す (= UI affordance を常設して「ここで flip できる」ことを見せる)。
  */
-function renderActiveWaveOverlay(active?: ActiveWaveInfo): string {
+function renderActiveWaveOverlay(
+  active?: ActiveWaveInfo,
+  pendingFlipCount = 0,
+): string {
   const previewEntries = active ? [...active.preview.entries()] : [];
   const pendingFlips = active ? active.pendingFlips : [];
 
@@ -944,16 +950,20 @@ function renderActiveWaveOverlay(active?: ActiveWaveInfo): string {
   // 一括 flip: 全 pending release (no-traffic version) を 100% へ promote する。
   // Pending releases セクションの "⚡ Flip all" と同じ endpoint を叩く (= staged
   // preview を確認した上でここから直接まとめて flip できる affordance)。
-  // pending release が 0 件でも endpoint 側が no-op で安全に返すので常設する。
-  const bulkFlipBtn = `
+  // **flip 対象 (pending release) が 0 件なら出さない** — 「active な wave は
+  // ありません」と矛盾するため (= 何も flip できないのにボタンを出さない)。
+  const bulkFlipBtn =
+    pendingFlipCount > 0
+      ? `
     <form method="post" action="/api/release-wave/pending-release/flip-all"
           style="margin:0 8px 0 0"
-          onsubmit="return confirm('全 pending release (no-traffic version) を一括で 100% flip します。よろしいですか？');">
+          onsubmit="return confirm('${pendingFlipCount} 件の pending release (no-traffic version) を一括で 100% flip します。よろしいですか？');">
       <button type="submit"
         title="全 pending release (no-traffic version) を一括で 100% traffic へ flip">
-        ⚡ Flip all to 100%
+        ⚡ Flip all to 100% (${pendingFlipCount})
       </button>
-    </form>`;
+    </form>`
+      : "";
 
   // pending-approval の wave ごとに Approve & Flip ボタン。一覧 (list page) と
   // 同じく force は付けない (compat gate ブロック時は詳細ページで override)。
@@ -968,11 +978,17 @@ function renderActiveWaveOverlay(active?: ActiveWaveInfo): string {
         </form>`,
     )
     .join("");
-  const flipBlock = `
+
+  // flip 対象も active wave も無ければ actions block 自体を出さない
+  // (空の <div> でボタン枠だけ残るのを防ぐ)。
+  const flipBlock =
+    bulkFlipBtn || flips
+      ? `
     <div class="actions" style="margin-top:10px">
       ${bulkFlipBtn}
       ${flips}
-    </div>`;
+    </div>`
+      : "";
 
   return previewBlock + flipBlock;
 }

--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -168,42 +168,8 @@ function hubStub(env: Env): DurableObjectStub<ReleaseWaveHub> {
 }
 
 // ----------------------------------------------------------------------------
-// Wave 一覧の絞り込み + frontend 単位の追跡
+// frontend 単位の追跡
 // ----------------------------------------------------------------------------
-
-/** in-progress (= 常に一覧に出す) state。terminal はそれ以外。 */
-const ACTIVE_STATES: ReadonlySet<WaveStateName> = new Set([
-  "staging",
-  "pending-approval",
-  "flipping",
-]);
-
-/**
- * 一覧に出す wave を絞る。
- *
- * - active (staging / pending-approval / flipping) は常に表示。
- * - terminal (flipped / failed / aborted / rolled-back) のうち、最新の成功
- *   デプロイ (= 最も新しい flipped wave) より **前に started した** wave は隠す。
- *   成功デプロイが起きるたびに、それ以前の失敗・成功履歴が一覧から畳まれる
- *   (= 古い fail / stale preview link がいつまでも残らない)。
- * - flipped wave が 1 つも無ければ cutoff 無し = 全件表示 (deploy 前は隠さない)。
- *
- * 隠した wave も DO には残るので `/release-wave/<id>` 直リンクで参照可能。
- */
-function visibleWaves(waves: WaveState[]): WaveState[] {
-  // 最新の flipped の started_at を cutoff にする (sort 順に依存せず max を取る)。
-  let cutoff: string | null = null;
-  for (const w of waves) {
-    if (w.state === "flipped" && (cutoff === null || w.started_at > cutoff)) {
-      cutoff = w.started_at;
-    }
-  }
-  if (cutoff === null) return waves;
-  const c = cutoff;
-  return waves.filter(
-    (w) => ACTIVE_STATES.has(w.state) || w.started_at >= c,
-  );
-}
 
 /** frontend (repo) 1 つの追跡サマリ。`computeFrontendTracks` が wave 群から導出。 */
 interface FrontendTrack {
@@ -335,78 +301,6 @@ function renderFrontendSection(tracks: FrontendTrack[]): string {
     </div>`;
 }
 
-/** stage / flip phase の色付きセル。 */
-function phaseCell(s: string): string {
-  return s === "done"
-    ? `<span class="ok">done</span>`
-    : s === "failed"
-    ? `<span class="err">failed</span>`
-    : `<span class="pending">pending</span>`;
-}
-
-/**
- * 1 wave を repo (front) ごとの行に分解して描画する。
- *
- * wave 共通セル (Wave ID / State / Started At / Flip Policy / Actions) は
- * 先頭 repo 行に rowspan=repo数 で持たせ、Repo / Preview / Stage / Flip は front
- * ごとに 1 行ずつ出す。repo が 0 件の wave は 1 行 (front 列は "—")。
- */
-function renderWaveRows(w: WaveState): string {
-  // 一括 flip = Approve & Flip。pending-approval の時だけ有効。
-  // 一覧では force を付けない (compat gate ブロック時は失敗 → 詳細ページで
-  // override する運用)。CSP 上 JS 無しで POST form として動かす。
-  const canApprove = w.state === "pending-approval";
-  const n = Math.max(1, w.repos.length);
-  const flipButton = `
-    <form method="post" action="/api/release-wave/${encodeURIComponent(w.wave_id)}/approve" style="margin:0">
-      <button type="submit" ${canApprove ? "" : "disabled"}
-        title="Approve & flip this wave (enabled only in pending-approval; no compat-gate override here)">
-        Approve &amp; Flip
-      </button>
-    </form>`;
-
-  // 先頭行にだけ出す wave 共通セル (rowspan で全 front 行をまたぐ)。
-  const waveCells = `
-    <td rowspan="${n}"><a href="/release-wave/${encodeURIComponent(w.wave_id)}">${escapeHtml(w.wave_id)}</a></td>
-    <td rowspan="${n}"><span class="badge" style="background:${stateColor(w.state)}">${escapeHtml(w.state)}</span></td>
-    <td rowspan="${n}" class="meta">${escapeHtml(w.started_at)}</td>
-    <td rowspan="${n}" class="meta">${escapeHtml(w.flip_policy)}</td>`;
-  const actionCell = `<td rowspan="${n}" class="actions">${flipButton}</td>`;
-
-  if (w.repos.length === 0) {
-    return `
-      <tr>
-        ${waveCells}
-        <td><span class="meta">—</span></td>
-        <td><span class="meta">—</span></td>
-        <td><span class="meta">—</span></td>
-        <td><span class="meta">—</span></td>
-        ${actionCell}
-      </tr>`;
-  }
-
-  return w.repos
-    .map((r, idx) => {
-      const sha = r.head_sha ? escapeHtml(r.head_sha.slice(0, 7)) : "?";
-      const safe = safeHttpUrl(r.preview_url);
-      // preview は front ごとに分けて出す。link 化できる時は preview リンク +
-      // sha、無ければ sha のみ (image を識別できるよう常に出す)。
-      const previewCell = safe
-        ? `<a href="${escapeHtml(safe)}" target="_blank" rel="noopener noreferrer" title="${escapeHtml(safe)}">preview</a> <span class="meta">${sha}</span>`
-        : `<span class="meta">${sha}</span>`;
-      return `
-        <tr>
-          ${idx === 0 ? waveCells : ""}
-          <td>${escapeHtml(r.repo)}</td>
-          <td class="preview-inline">${previewCell}</td>
-          <td>${phaseCell(r.stage_status)}</td>
-          <td>${phaseCell(r.flip_status)}</td>
-          ${idx === 0 ? actionCell : ""}
-        </tr>`;
-    })
-    .join("");
-}
-
 // ----------------------------------------------------------------------------
 // GET /release-wave  →  全 wave 一覧
 // ----------------------------------------------------------------------------
@@ -478,17 +372,11 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
     flipGroup,
   );
 
-  // frontend (repo) 単位の追跡セクション (全 wave から導出、wave 絞り込み前)。
+  // frontend (repo) 単位の追跡セクション (全 wave から導出)。wave 中心の一覧
+  // テーブルは廃止し、frontend 単位の追跡 + compat グラフ (Tag Release / Staged
+  // previews + 一括 flip) に集約した。完了/失敗した個別 wave は
+  // `/release-wave/<id>` 直リンクで参照可能。
   const frontendSection = renderFrontendSection(computeFrontendTracks(waves));
-
-  // wave 一覧は最新の成功デプロイより前の terminal wave を畳んで出す。
-  // 各 wave の行は repo (front) ごとに分割する: wave 共通セル (Wave ID / State /
-  // Started At / Flip Policy / Actions) を rowspan でまとめ、Repo / Preview /
-  // Stage / Flip は front ごとに 1 行ずつ出す。
-  const displayWaves = visibleWaves(waves);
-  const rows = displayWaves.length === 0
-    ? `<tr><td colspan="9" class="empty">No release waves yet.</td></tr>`
-    : displayWaves.map((w) => renderWaveRows(w)).join("");
 
   const html = `<!doctype html>
 <html lang="ja">
@@ -512,26 +400,6 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
     ${compatSection}
     ${pendingReleaseSection}
     ${frontendSection}
-    <h2>Release waves</h2>
-    <p class="meta">最新の成功デプロイ (flipped) より前に始まった完了 wave は畳んで
-      非表示。直リンク <code>/release-wave/&lt;id&gt;</code> で個別参照は可能。
-      各 wave は front (repo) ごとに 1 行ずつに分けて表示。</p>
-    <table>
-      <thead>
-        <tr>
-          <th>Wave ID</th>
-          <th>State</th>
-          <th>Started At</th>
-          <th>Flip Policy</th>
-          <th>Repo (front)</th>
-          <th>Preview</th>
-          <th>Stage</th>
-          <th>Flip</th>
-          <th>Actions</th>
-        </tr>
-      </thead>
-      <tbody>${rows}</tbody>
-    </table>
   </div>
 </body>
 </html>`;
@@ -1073,9 +941,22 @@ function renderActiveWaveOverlay(active?: ActiveWaveInfo): string {
         : `<p class="meta" style="margin:4px 0 0">active な wave (staging / pending-approval) はありません。</p>`}
     </div>`;
 
+  // 一括 flip: 全 pending release (no-traffic version) を 100% へ promote する。
+  // Pending releases セクションの "⚡ Flip all" と同じ endpoint を叩く (= staged
+  // preview を確認した上でここから直接まとめて flip できる affordance)。
+  // pending release が 0 件でも endpoint 側が no-op で安全に返すので常設する。
+  const bulkFlipBtn = `
+    <form method="post" action="/api/release-wave/pending-release/flip-all"
+          style="margin:0 8px 0 0"
+          onsubmit="return confirm('全 pending release (no-traffic version) を一括で 100% flip します。よろしいですか？');">
+      <button type="submit"
+        title="全 pending release (no-traffic version) を一括で 100% traffic へ flip">
+        ⚡ Flip all to 100%
+      </button>
+    </form>`;
+
   // pending-approval の wave ごとに Approve & Flip ボタン。一覧 (list page) と
   // 同じく force は付けない (compat gate ブロック時は詳細ページで override)。
-  // 対象 wave が無い時は disabled ボタンを 1 つ出して affordance を残す。
   const flips = pendingFlips
     .map(
       (f) => `
@@ -1089,10 +970,8 @@ function renderActiveWaveOverlay(active?: ActiveWaveInfo): string {
     .join("");
   const flipBlock = `
     <div class="actions" style="margin-top:10px">
-      ${flips
-        ? flips
-        : `<button type="button" disabled
-             title="pending-approval の wave がありません">Approve &amp; Flip</button>`}
+      ${bulkFlipBtn}
+      ${flips}
     </div>`;
 
   return previewBlock + flipBlock;

--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -198,6 +198,11 @@ export function renderCompatTagReleaseButtons(
 ): string {
   const list = [...new Set(repos)].filter((r) => !tagless.has(r)).sort();
   if (list.length === 0) return "";
+  // release 可能 (最新でない / status 不明) な repo。一括 tag release の対象。
+  const releasable = list.filter((r) => {
+    const st = statusByRepo?.get(r);
+    return st ? !isUpToDate(st) : true;
+  });
   const buttons = list
     .map((r) => {
       const st = statusByRepo?.get(r);
@@ -217,10 +222,26 @@ export function renderCompatTagReleaseButtons(
         </form>`;
     })
     .join("");
+
+  // 一括 tag release: release 可能な repo の tag-release.yml をまとめて dispatch。
+  // 2 件以上で表示 (1 件なら個別ボタンと同じなので出さない)。最新 repo は除外。
+  const bulkBtn =
+    releasable.length >= 2
+      ? `
+        <form method="post" action="/api/release-wave/tag-release-all"
+              style="margin:0 6px 8px 0;display:inline-block"
+              onsubmit="return confirm('${releasable.length} 件の repo の tag-release.yml をまとめて dispatch します。よろしいですか？');">
+          <input type="hidden" name="repos" value="${escapeHtml(releasable.join(","))}">
+          <button type="submit" title="release 可能な ${releasable.length} repo の tag-release.yml を一括 dispatch する">
+            ⚡ Tag Release all (${releasable.length})
+          </button>
+        </form>`
+      : "";
+
   return `
     <div class="actions" style="margin-top:10px">
       <strong class="meta">Tag Release (compatibility graph の repo)</strong>
-      <div style="margin-top:6px">${buttons}</div>
+      <div style="margin-top:6px">${bulkBtn}${buttons}</div>
     </div>`;
 }
 

--- a/src/release-wave/tag-release-action.ts
+++ b/src/release-wave/tag-release-action.ts
@@ -60,3 +60,76 @@ export async function handleReleaseWaveTagRelease(
     headers: { Location: "/release-wave" },
   });
 }
+
+/**
+ * POST /api/release-wave/tag-release-all  (form field `repos` = カンマ区切り)。
+ *
+ * Compatibility グラフの「⚡ Tag Release all」ボタンから、release 可能な repo の
+ * tag-release.yml をまとめて dispatch する。各 repo の tag 採番は workflow 側。
+ * 1 件でも失敗したら失敗 repo を一覧して報告する (成功分は dispatch 済み)。
+ */
+export async function handleReleaseWaveTagReleaseAll(
+  req: Request,
+  env: Env,
+): Promise<Response> {
+  let reposRaw: string | null = null;
+  const ct = req.headers.get("content-type") ?? "";
+  if (ct.includes("application/x-www-form-urlencoded")) {
+    const body = await req.text();
+    reposRaw = new URLSearchParams(body).get("repos");
+  } else {
+    try {
+      const j = await req.json<{ repos?: string | string[] }>();
+      reposRaw = Array.isArray(j.repos) ? j.repos.join(",") : j.repos ?? null;
+    } catch {
+      reposRaw = null;
+    }
+  }
+
+  const repos = (reposRaw ?? "")
+    .split(",")
+    .map((r) => r.trim())
+    .filter((r) => r.length > 0);
+
+  if (repos.length === 0) {
+    const html = `<!doctype html><html lang="ja"><head><meta charset="utf-8">
+<title>Tag release failed</title></head><body>
+<p>tag-release-all failed: no repos provided</p>
+<p><a href="/release-wave">&larr; Release Wave に戻る</a></p>
+</body></html>`;
+    return new Response(html, {
+      status: 400,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  }
+
+  const failures: string[] = [];
+  for (const repo of repos) {
+    const result = await dispatchTagRelease(env, repo);
+    if (!result.ok) {
+      failures.push(`${repo}: ${result.error ?? "unknown error"}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    const items = failures
+      .map((f) => `<li>${escapeHtml(f)}</li>`)
+      .join("");
+    const html = `<!doctype html><html lang="ja"><head><meta charset="utf-8">
+<title>Tag release partially failed</title></head><body>
+<p>tag-release-all: ${repos.length - failures.length}/${repos.length} dispatched, ${failures.length} failed:</p>
+<ul>${items}</ul>
+<p><a href="/release-wave">&larr; Release Wave に戻る</a></p>
+</body></html>`;
+    return new Response(html, {
+      status: 502,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  }
+
+  // PRG: reload で再 dispatch されないよう 303 で一覧へ戻す。
+  return new Response(null, {
+    status: 303,
+    headers: { Location: "/release-wave" },
+  });
+}

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -1151,32 +1151,57 @@ describe("handleReleaseWaveListPage global compat overlay", () => {
     expect(html).toContain("Staged previews");
   });
 
-  it("always renders the overlay with placeholder + 一括 flip button when no active waves", async () => {
+  /** pending release を 1 件持つ KV seed (= ⚡ Flip all を出す条件)。 */
+  const pendingSeed = {
+    ...compatSeed,
+    "pending-release::ippoan/auth-worker": {
+      schema_version: 1,
+      repo: "ippoan/auth-worker",
+      version_id: "530b908c-5385-451c-b163-747caaedafd3",
+      tag: "v0.2.38",
+      preview_url: "https://abc-auth-worker.example.workers.dev",
+      uploaded_at: "2026-05-28T12:00:00Z",
+    },
+  };
+
+  it("omits the 一括 flip button when there are no pending releases (no contradiction)", async () => {
     const env = fakeEnv({
       listReturn: [makeWave({ wave_id: "w-done", state: "flipped" })],
       compatKv: memKv(compatSeed),
     });
     const html = await (await handleReleaseWaveListPage(env)).text();
-    // block 自体は常に出る
+    // block 自体は常に出る (placeholder)
     expect(html).toContain("Staged previews");
     expect(html).toContain("active な wave");
-    // 具体的な flip 対象 (wave_id 付き Approve & Flip ボタン) は無い
-    expect(html).not.toContain("Approve &amp; Flip: ");
-    // 一括 flip ボタンは常設 (pending-release/flip-all へ POST)
-    expect(html).toContain("⚡ Flip all to 100%");
-    expect(html).toContain(
-      'action="/api/release-wave/pending-release/flip-all"',
-    );
+    // flip 対象 (pending release) が 0 件なら ⚡ Flip all は出さない
+    // (= 「active な wave はありません」との矛盾を防ぐ)
+    expect(html).not.toContain("Flip all to 100%");
   });
 
-  it("renders the 一括 flip button in the Staged previews block", async () => {
+  it("renders the 一括 flip button when there are pending releases (even with no active waves)", async () => {
     const env = fakeEnv({
-      listReturn: [activeWave()],
-      compatKv: memKv(compatSeed),
+      listReturn: [makeWave({ wave_id: "w-done", state: "flipped" })],
+      compatKv: memKv(pendingSeed),
     });
     const html = await (await handleReleaseWaveListPage(env)).text();
     expect(html).toContain("Staged previews");
-    expect(html).toContain("⚡ Flip all to 100%");
+    // pending release が 1 件あるので件数付きで出す
+    expect(html).toContain("⚡ Flip all to 100% (1)");
+    expect(html).toContain(
+      'action="/api/release-wave/pending-release/flip-all"',
+    );
+    // 具体的な flip 対象 (wave_id 付き Approve & Flip ボタン) は無い
+    expect(html).not.toContain("Approve &amp; Flip: ");
+  });
+
+  it("renders the 一括 flip button alongside per-wave Approve & Flip", async () => {
+    const env = fakeEnv({
+      listReturn: [activeWave()],
+      compatKv: memKv(pendingSeed),
+    });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    expect(html).toContain("Staged previews");
+    expect(html).toContain("⚡ Flip all to 100% (1)");
     expect(html).toContain(
       'action="/api/release-wave/pending-release/flip-all"',
     );

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -113,14 +113,17 @@ function makeWave(over: Partial<WaveState> = {}): WaveState {
 // ============================================================================
 
 describe("handleReleaseWaveListPage", () => {
-  it("renders empty state when no waves", async () => {
+  it("renders the page (Frontends placeholder) when no waves", async () => {
     const env = fakeEnv({ listReturn: [] });
     const resp = await handleReleaseWaveListPage(env);
     expect(resp.status).toBe(200);
     expect(resp.headers.get("Content-Type")).toContain("text/html");
     const html = await resp.text();
     expect(html).toContain("Release Waves");
-    expect(html).toContain("No release waves yet");
+    // wave 中心の一覧テーブルは廃止。frontend 単位の追跡セクションに集約。
+    expect(html).toContain("Frontends (per-repo tracking)");
+    expect(html).toContain("No frontends tracked yet");
+    expect(html).not.toContain("<th>Wave ID</th>");
   });
 
   it("renders a hard-reset refresh button on the list page", async () => {
@@ -163,23 +166,6 @@ describe("handleReleaseWaveListPage", () => {
     expect(html).toContain('name="repo" value="ippoan/auth-worker"');
     // safeHttpUrl は new URL().toString() で末尾スラッシュを正規化する
     expect(html).toContain('href="https://abc-auth-worker.example.workers.dev/"');
-  });
-
-  it("lists each wave with state badge + detail link", async () => {
-    const env = fakeEnv({
-      listReturn: [
-        makeWave({ wave_id: "w1", state: "flipped" }),
-        makeWave({ wave_id: "w2", state: "staging" }),
-      ],
-    });
-    const resp = await handleReleaseWaveListPage(env);
-    const html = await resp.text();
-    expect(html).toContain("w1");
-    expect(html).toContain("w2");
-    expect(html).toContain("/release-wave/w1");
-    expect(html).toContain("/release-wave/w2");
-    expect(html).toContain("flipped");
-    expect(html).toContain("staging");
   });
 
   it("escapes HTML special chars in wave_id / repo", async () => {
@@ -247,158 +233,6 @@ describe("handleReleaseWaveListPage", () => {
     });
     const html = await (await handleReleaseWaveListPage(env)).text();
     expect(html).not.toContain("javascript:alert(1)");
-  });
-
-  it("enables the per-wave Approve & Flip button only in pending-approval", async () => {
-    const env = fakeEnv({
-      listReturn: [
-        makeWave({ wave_id: "w-pending", state: "pending-approval" }),
-        makeWave({ wave_id: "w-staging", state: "staging" }),
-      ],
-    });
-    const html = await (await handleReleaseWaveListPage(env)).text();
-    expect(html).toContain("Approve &amp; Flip");
-    // pending-approval wave の form は approve endpoint を向く
-    expect(html).toContain(
-      'action="/api/release-wave/w-pending/approve"',
-    );
-    // staging wave のボタンは disabled
-    const stagingFormIdx = html.indexOf(
-      'action="/api/release-wave/w-staging/approve"',
-    );
-    const stagingButton = html.slice(stagingFormIdx, stagingFormIdx + 200);
-    expect(stagingButton).toContain("disabled");
-  });
-
-  it("does not pass force=true from the list flip button", async () => {
-    const env = fakeEnv({
-      listReturn: [makeWave({ wave_id: "w1", state: "pending-approval" })],
-    });
-    const html = await (await handleReleaseWaveListPage(env)).text();
-    const formIdx = html.indexOf('action="/api/release-wave/w1/approve"');
-    const formChunk = html.slice(formIdx, formIdx + 300);
-    expect(formChunk).not.toContain('name="force"');
-  });
-
-  it("splits a multi-repo wave into one row per front (rowspan on wave cells)", async () => {
-    const mkRepo = (over: Record<string, unknown>) => ({
-      repo: "ippoan/x",
-      target_tag: "v1",
-      head_sha: "deadbee",
-      require_compatibility: false,
-      stage_status: "done",
-      preview_url: null,
-      stage_error: null,
-      flip_status: "pending",
-      flip_error: null,
-      flip_from_revision: null,
-      rolled_back_to_revision: null,
-      ...over,
-    });
-    const env = fakeEnv({
-      listReturn: [
-        makeWave({
-          wave_id: "w-multi",
-          state: "pending-approval",
-          repos: [
-            mkRepo({
-              repo: "ippoan/auth-worker",
-              head_sha: "aaaaaaa",
-              preview_url: "https://preview-auth.ippoan.org/",
-              stage_status: "done",
-              flip_status: "pending",
-            }),
-            mkRepo({
-              repo: "ippoan/nuxt-notify",
-              head_sha: "bbbbbbb",
-              preview_url: null,
-              stage_status: "failed",
-              flip_status: "pending",
-            }),
-          ],
-        }),
-      ],
-    });
-    const html = await (await handleReleaseWaveListPage(env)).text();
-    // wave 共通セルは rowspan=2 (= repo 数) で 1 度だけ出る
-    expect(html).toContain('rowspan="2"');
-    // 各 front が独立した <td> として出る
-    expect(html).toContain("ippoan/auth-worker");
-    expect(html).toContain("ippoan/nuxt-notify");
-    // front ごとの preview / sha
-    expect(html).toContain('href="https://preview-auth.ippoan.org/"');
-    expect(html).toContain("aaaaaaa");
-    expect(html).toContain("bbbbbbb");
-    // front ごとの stage 状態 (nuxt-notify は failed)
-    expect(html).toContain('<span class="err">failed</span>');
-    // Approve & Flip ボタンは wave あたり 1 度だけ (rowspan セル。compat overlay は
-    // COMPAT_KV 未 bind なので出ない)
-    expect(html.match(/Approve &amp; Flip/g)?.length).toBe(1);
-  });
-
-  it("hides terminal waves older than the latest flipped wave (active always shown)", async () => {
-    const env = fakeEnv({
-      listReturn: [
-        // 最新の成功デプロイ
-        makeWave({
-          wave_id: "w-flip",
-          state: "flipped",
-          started_at: "2026-06-01T00:00:00Z",
-        }),
-        // flip より前の失敗 → 隠す
-        makeWave({
-          wave_id: "w-old-fail",
-          state: "failed",
-          started_at: "2026-05-30T00:00:00Z",
-        }),
-        // flip より前の中止 → 隠す
-        makeWave({
-          wave_id: "w-old-abort",
-          state: "aborted",
-          started_at: "2026-05-29T00:00:00Z",
-        }),
-        // flip より後の失敗 → 残す (まだ次の成功 deploy が無い)
-        makeWave({
-          wave_id: "w-new-fail",
-          state: "failed",
-          started_at: "2026-06-02T00:00:00Z",
-        }),
-        // active は常に表示
-        makeWave({
-          wave_id: "w-active",
-          state: "staging",
-          started_at: "2026-05-01T00:00:00Z",
-        }),
-      ],
-    });
-    const html = await (await handleReleaseWaveListPage(env)).text();
-    // cutoff (= w-flip) 自身と、それ以降の terminal、active は表示
-    expect(html).toContain("/release-wave/w-flip");
-    expect(html).toContain("/release-wave/w-new-fail");
-    expect(html).toContain("/release-wave/w-active");
-    // cutoff より前の terminal は一覧から消える
-    expect(html).not.toContain("/release-wave/w-old-fail");
-    expect(html).not.toContain("/release-wave/w-old-abort");
-  });
-
-  it("shows all waves when none has flipped yet (no deploy → no hiding)", async () => {
-    const env = fakeEnv({
-      listReturn: [
-        makeWave({
-          wave_id: "f1",
-          state: "failed",
-          started_at: "2026-05-30T00:00:00Z",
-        }),
-        makeWave({
-          wave_id: "f2",
-          state: "aborted",
-          started_at: "2026-05-29T00:00:00Z",
-        }),
-      ],
-    });
-    const html = await (await handleReleaseWaveListPage(env)).text();
-    expect(html).toContain("/release-wave/f1");
-    expect(html).toContain("/release-wave/f2");
   });
 
   it("renders a per-frontend tracking section with latest preview + last flip", async () => {
@@ -1317,7 +1151,7 @@ describe("handleReleaseWaveListPage global compat overlay", () => {
     expect(html).toContain("Staged previews");
   });
 
-  it("always renders the overlay with placeholder + disabled flip when no active waves", async () => {
+  it("always renders the overlay with placeholder + 一括 flip button when no active waves", async () => {
     const env = fakeEnv({
       listReturn: [makeWave({ wave_id: "w-done", state: "flipped" })],
       compatKv: memKv(compatSeed),
@@ -1326,11 +1160,28 @@ describe("handleReleaseWaveListPage global compat overlay", () => {
     // block 自体は常に出る
     expect(html).toContain("Staged previews");
     expect(html).toContain("active な wave");
-    // 具体的な flip 対象 (wave_id 付きボタン) は無く、disabled ボタンが出る
+    // 具体的な flip 対象 (wave_id 付き Approve & Flip ボタン) は無い
     expect(html).not.toContain("Approve &amp; Flip: ");
-    const idx = html.indexOf("Approve &amp; Flip</button>");
-    expect(idx).toBeGreaterThan(-1);
-    expect(html.slice(Math.max(0, idx - 120), idx)).toContain("disabled");
+    // 一括 flip ボタンは常設 (pending-release/flip-all へ POST)
+    expect(html).toContain("⚡ Flip all to 100%");
+    expect(html).toContain(
+      'action="/api/release-wave/pending-release/flip-all"',
+    );
+  });
+
+  it("renders the 一括 flip button in the Staged previews block", async () => {
+    const env = fakeEnv({
+      listReturn: [activeWave()],
+      compatKv: memKv(compatSeed),
+    });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    expect(html).toContain("Staged previews");
+    expect(html).toContain("⚡ Flip all to 100%");
+    expect(html).toContain(
+      'action="/api/release-wave/pending-release/flip-all"',
+    );
+    // active な pending-approval wave の Approve & Flip も併存する
+    expect(html).toContain("Approve &amp; Flip: w-active");
   });
 
   it("renders a per-untested-consumer Re-test button posting to the wave-independent retest-consumer endpoint", async () => {

--- a/test/release-wave/repo-status-section.test.ts
+++ b/test/release-wave/repo-status-section.test.ts
@@ -169,6 +169,39 @@ describe("renderCompatTagReleaseButtons", () => {
     expect(html.match(/Tag Release: ippoan\/a/g)?.length).toBe(1);
   });
 
+  it("renders a 一括 Tag Release all button for 2+ releasable repos", () => {
+    const html = renderCompatTagReleaseButtons(
+      ["ippoan/a", "ippoan/b", "ippoan/c"],
+      new Set(),
+    );
+    expect(html).toContain("⚡ Tag Release all (3)");
+    expect(html).toContain('action="/api/release-wave/tag-release-all"');
+    // hidden field に release 可能 repo を sort 済みカンマ区切りで載せる
+    expect(html).toContain('name="repos" value="ippoan/a,ippoan/b,ippoan/c"');
+  });
+
+  it("excludes up-to-date repos from the 一括 Tag Release all set", () => {
+    const statusByRepo = new Map([
+      ["ippoan/a", status({ repo: "ippoan/a", hasTag: true, latestTag: "v1", behind: 0 })],
+      ["ippoan/b", status({ repo: "ippoan/b", hasTag: true, latestTag: "v1", behind: 3 })],
+      ["ippoan/c", status({ repo: "ippoan/c", hasTag: true, latestTag: "v1", behind: 5 })],
+    ]);
+    const html = renderCompatTagReleaseButtons(
+      ["ippoan/a", "ippoan/b", "ippoan/c"],
+      new Set(),
+      statusByRepo,
+    );
+    // a は最新なので一括対象から外れ、b/c の 2 件だけ
+    expect(html).toContain("⚡ Tag Release all (2)");
+    expect(html).toContain('name="repos" value="ippoan/b,ippoan/c"');
+  });
+
+  it("omits the 一括 Tag Release all button when only one repo is releasable", () => {
+    const html = renderCompatTagReleaseButtons(["ippoan/only"], new Set());
+    expect(html).not.toContain("Tag Release all");
+    expect(html).toContain("Tag Release: ippoan/only");
+  });
+
   it("returns empty string when every repo is tagless", () => {
     const html = renderCompatTagReleaseButtons(
       ["ippoan/ci-dashboard"],

--- a/test/tag-release.test.ts
+++ b/test/tag-release.test.ts
@@ -85,3 +85,65 @@ describe("POST /api/tag-release", () => {
     fetchSpy.mockRestore();
   });
 });
+
+describe("POST /api/release-wave/tag-release-all (一括 tag release)", () => {
+  function formReq(repos: string): Request {
+    return new Request("http://localhost/api/release-wave/tag-release-all", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ repos }).toString(),
+    });
+  }
+
+  it("dispatches every repo and 303-redirects on full success", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 204 }));
+
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      formReq("ippoan/auth-worker,ippoan/rust-alc-api"),
+      testEnv(),
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(303);
+    expect(res.headers.get("Location")).toBe("/release-wave");
+    // repo ごとに 1 dispatch
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.github.com/repos/ippoan/auth-worker/actions/workflows/tag-release.yml/dispatches",
+      expect.objectContaining({ method: "POST" }),
+    );
+    fetchSpy.mockRestore();
+  });
+
+  it("returns 502 listing failures on partial dispatch failure", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(null, { status: 204 })) // auth-worker ok
+      .mockResolvedValueOnce(new Response("boom", { status: 500 })); // rust-alc-api fail
+
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      formReq("ippoan/auth-worker,ippoan/rust-alc-api"),
+      testEnv(),
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(502);
+    const html = await res.text();
+    expect(html).toContain("1/2 dispatched");
+    expect(html).toContain("ippoan/rust-alc-api");
+    fetchSpy.mockRestore();
+  });
+
+  it("returns 400 when no repos are provided", async () => {
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(formReq(""), testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## 背景

#273 / #274 で frontend 単位の追跡セクション + front 別行分割を入れたが、wave 中心の「Release waves」一覧テーブルは frontend 追跡と情報が重複し冗長だった。テーブルを廃止し、リリース操作を compatibility グラフ周辺に集約する。

## 変更内容

### 1. Release waves テーブルを廃止

- `/release-wave` から wave 中心の一覧テーブルと関連ヘルパー (`visibleWaves` / `renderWaveRows` / `phaseCell` / `ACTIVE_STATES`) を削除
- 一覧は **Frontends (per-repo tracking) セクション** に集約。完了/失敗した個別 wave は `/release-wave/<id>` 直リンクで参照可能（DO には残る）

### 2. ⚡ Tag Release all（一括 tag release）

「**Tag Release (compatibility graph の repo)**」ブロックに一括ボタンを追加。

- release 可能（最新でない）repo が **2 件以上**の時に表示
- 新 endpoint **`POST /api/release-wave/tag-release-all`**（form field `repos` = カンマ区切り）が各 repo の `tag-release.yml` をまとめて dispatch
- 1 件でも失敗したら失敗 repo を一覧して 502、全成功なら 303 で `/release-wave` へ

### 3. ⚡ Flip all to 100%（一括 flip）

「**Staged previews (active waves)**」ブロックに一括 flip ボタンを追加。

- 既存 endpoint **`/api/release-wave/pending-release/flip-all`** を叩いて全 pending release（no-traffic version）を一括 100% flip
- active wave が無くても常設（endpoint 側が no-op で安全）。pending-approval wave の per-wave Approve & Flip も併存

## テスト

- `page.test.ts`: 廃止テーブル依存テストを削除/更新、一括 flip ボタンのテスト追加
- `repo-status-section.test.ts`: ⚡ Tag Release all ボタン（2件以上で表示 / 最新 repo 除外 / 1件で非表示）
- `tag-release.test.ts`: `/api/release-wave/tag-release-all` ハンドラ（全成功 303 / 部分失敗 502 / 空 400）

全 700 tests green、`tsc --noEmit` clean。

Refs #137

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1TLqB96rea6TTguip8GJv)_