### PR TITLE
feat(release-wave): help-tip 化を Repo リリース状況 / Backend traffic にも拡張

### DIFF
--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -186,7 +186,7 @@ const COMMON_STYLES = `
  * ツールチップ表示する。説明は rich HTML (code / strong / a) を保持できる。
  * 従来 <h2> 直下に <p class="meta"> で出していた説明をここに畳む用途。
  */
-function helpMark(html: string): string {
+export function helpMark(html: string): string {
   return `<span class="help-tip" tabindex="0" role="note"
     aria-label="説明"><span aria-hidden="true">?</span><span class="help-pop">${html}</span></span>`;
 }

--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -17,7 +17,7 @@
  */
 
 import type { Env } from "../index";
-import { handleReleaseWaveListPage } from "./page";
+import { handleReleaseWaveListPage, helpMark } from "./page";
 import {
   getRepoReleaseStatuses,
   type RepoReleaseStatus,
@@ -138,11 +138,12 @@ export function renderRepoReleaseStatusSection(
 
   return `
     <div class="section">
-      <h2>Repo リリース状況</h2>
-      <p class="meta">監視対象 repo の tag 有無と main HEAD からの乖離 (tagless repo は除外)。
+      <h2>Repo リリース状況${helpMark(
+        `監視対象 repo の tag 有無と main HEAD からの乖離 (tagless repo は除外)。
         <span class="badge" style="background:${GREEN}">緑 = tag あり</span>
         <span class="badge" style="background:${RED}">赤 = 未tag</span>
-        の repo を直接 Tag Release できる (tag 採番は各 repo の tag-release.yml)。</p>
+        の repo を直接 Tag Release できる (tag 採番は各 repo の tag-release.yml)。`,
+      )}</h2>
       <div style="margin:8px 0">${summary}</div>
       ${tableOrEmpty}
     </div>`;
@@ -484,10 +485,11 @@ export function renderBackendRollbackBlock(
 
   return `
     <div style="margin-top:10px">
-      <strong class="meta">Backend traffic / rollback (Cloud Run revision)</strong>
-      <p class="meta" style="margin:4px 0">Cloud Run の実 traffic split (status.traffic[])。
+      <strong class="meta">Backend traffic / rollback (Cloud Run revision)</strong>${helpMark(
+        `Cloud Run の実 traffic split (status.traffic[])。
         tag push → no-traffic deploy (新 0%) → Flip (新 100%) 運用なので、Flip 前は
-        「旧 100% + 新 pending 0%」が並ぶ。revision / image sha は hover で full。</p>
+        「旧 100% + 新 pending 0%」が並ぶ。revision / image sha は hover で full。`,
+      )}
       <table style="margin-top:6px">
         <thead><tr><th>Backend repo</th><th>%</th><th>Revision / Image / Tag</th><th>When (UTC)</th><th>Rollback</th></tr></thead>
         <tbody>${rows}</tbody>


### PR DESCRIPTION
## 概要

PR #280 で導入した「?」hover ツールチップ (`helpMark`) を、残りの 2 セクションにも適用した。見出し直下の `<p class="meta">` 説明を畳む。

## 対象

- **Repo リリース状況** (`repo-status-section.ts`) — tag 有無 / main 乖離の説明 + 緑赤 badge 凡例を `?` に畳む
- **Backend traffic / rollback (Cloud Run revision)** (`repo-status-section.ts`) — `<strong>` 見出し形式なので strong 直後に `?` を付与し、Cloud Run traffic split の説明を畳む

## 実装

- `helpMark` を `page.ts` から `export` し、`repo-status-section.ts` で import 再利用（CSS / 仕組みは #280 のものをそのまま流用）
- inline script なし（CSS の `:hover` / `:focus` / `:focus-within`）

## 検証

- `npx tsc --noEmit` ✓
- `vitest run test/release-wave/repo-status-section.test.ts test/release-wave/page.test.ts` → 108 passed

Refs #137


---
_Generated by [Claude Code](https://claude.ai/code/session_01Tazz8w9663ESmkySCaNX2g)_