### PR TITLE
fix(release-wave): Frontends セクションから backend repo を除外

### DIFF
--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -422,7 +422,17 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
 
   // frontend (repo) 単位の追跡 (全 wave から導出)。各 repo の現 live deploy
   // (traffic 100%) も併記するため、traffic 取得対象にこの repo 群も足す。
-  const frontendTracks = computeFrontendTracks(waves);
+  // Frontends セクションは frontend repo だけを出す。wave には backend
+  // (例: rust-alc-api = Cloud Run) も混ざるが、それは frontend ではないので除外。
+  // backend の判定は compat の `backend::` record (= globalCompat.backends) を
+  // source of truth にする。globalCompat 未取得 (COMPAT_KV 未 bind) 時は判別不能
+  // なので全件出す (degrade)。
+  const backendRepos = new Set(
+    (globalCompat?.backends ?? []).map((b) => b.backend_repo),
+  );
+  const frontendTracks = computeFrontendTracks(waves).filter(
+    (t) => !backendRepos.has(t.repo),
+  );
 
   // compat グラフに出る repo (backend + frontend) + pending repo + frontend
   // 追跡 repo の version traffic を引く。グラフの frontend ノード hover に「現

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -360,6 +360,51 @@ describe("handleReleaseWaveListPage", () => {
     expect(html).not.toContain('title="traffic 100% で live');
   });
 
+  it("excludes backend repos (backend:: record) from the Frontends section", async () => {
+    // wave に frontend (auth-worker) と backend (rust-alc-api) が混在。
+    // backend:: record を持つ rust-alc-api は frontend ではないので除外する。
+    const mkRepo = (repo: string) => ({
+      repo,
+      target_tag: "v1",
+      head_sha: "abc1234",
+      require_compatibility: false,
+      stage_status: "done",
+      preview_url: null,
+      stage_error: null,
+      flip_status: "pending",
+      flip_error: null,
+      flip_from_revision: null,
+      rolled_back_to_revision: null,
+    });
+    const env = fakeEnv({
+      listReturn: [
+        makeWave({
+          wave_id: "w-mix",
+          state: "failed",
+          repos: [mkRepo("ippoan/auth-worker"), mkRepo("ippoan/rust-alc-api")],
+        }),
+      ],
+      compatKv: memKv({
+        "backend::ippoan/rust-alc-api": {
+          schema_version: 1,
+          repo: "ippoan/rust-alc-api",
+          current_image: "cur-img",
+          deployed_at: "2026-06-01T00:00:00Z",
+          deployed_by: "ci",
+          wave_id: null,
+        },
+      }),
+    });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    // Frontends セクションの行に rust-alc-api は出ない (backend なので除外)
+    const frontendsIdx = html.indexOf("Frontends (per-repo tracking)");
+    const frontendsHtml = html.slice(frontendsIdx);
+    expect(frontendsHtml).toContain("ippoan/auth-worker");
+    expect(frontendsHtml).not.toContain(
+      "<td>ippoan/rust-alc-api</td>",
+    );
+  });
+
   it("hides a frontend preview that predates that frontend's last flip", async () => {
     const repo = (over: Record<string, unknown>) => ({
       repo: "ippoan/auth-worker",


### PR DESCRIPTION
## 背景

Frontends (per-repo tracking) セクションが wave の**全 repo** を出すため、backend（`ippoan/rust-alc-api` = Cloud Run / Rust API）まで「frontend」として並んでいた。rust-alc-api は frontend ではない。

```
ippoan/rust-alc-api  —  —  not deployed  wave_2026_06_03_1245 failed   ← front じゃない
```

## 変更内容

compat の `backend::` record（= `globalCompat.backends`）を source of truth に、**backend repo を Frontends セクションから除外**する。

- `frontendTracks = computeFrontendTracks(waves).filter(t => !backendRepos.has(t.repo))`
- `COMPAT_KV` 未 bind 等で `globalCompat` が無い時は判別不能なので全件出す（degrade）

backend は引き続き上の **Compatibility (all consumers)** グラフ / **Cloud Run revision** セクション側に出るので、情報は失われない。

## テスト

`page.test.ts`: wave に frontend（auth-worker）と backend（rust-alc-api、`backend::` record あり）が混在する時、Frontends セクションの行に auth-worker は出るが rust-alc-api は出ないことを検証。

全 715 tests green、`tsc --noEmit` clean。

Refs #137

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1TLqB96rea6TTguip8GJv)_