### PR TITLE
fix(release-wave): Frontends 除外を Cloud Run backend だけに限定（CF Worker は残す）

### DIFF
--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -432,22 +432,12 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
 
   // frontend (repo) 単位の追跡 (全 wave から導出)。各 repo の現 live deploy
   // (traffic 100%) も併記するため、traffic 取得対象にこの repo 群も足す。
-  // Frontends セクションは frontend repo だけを出す。wave には backend
-  // (例: rust-alc-api = Cloud Run) も混ざるが、それは frontend ではないので除外。
-  // backend の判定は compat の `backend::` record (= globalCompat.backends) を
-  // source of truth にする。globalCompat 未取得 (COMPAT_KV 未 bind) 時は判別不能
-  // なので全件出す (degrade)。
-  const backendRepos = new Set(
-    (globalCompat?.backends ?? []).map((b) => b.backend_repo),
-  );
-  const frontendTracks = computeFrontendTracks(waves).filter(
-    (t) => !backendRepos.has(t.repo),
-  );
+  const allTracks = computeFrontendTracks(waves);
 
-  // compat グラフに出る repo (backend + frontend) + pending repo + frontend
-  // 追跡 repo の version traffic を引く。グラフの frontend ノード hover に「現
-  // active version の % / id」を出す用 + Pending releases の単一真実導出用 +
-  // Frontends セクションの「Current (live)」列用 (Refs #237)。
+  // compat グラフに出る repo (backend + frontend) + pending repo + 追跡 repo の
+  // version traffic を引く。グラフの frontend ノード hover に「現 active version の
+  // % / id」を出す用 + Pending releases の単一真実導出用 + Frontends セクションの
+  // 「Current (live)」列 + frontend/backend 判定用 (Refs #237 / #268)。
   let trafficByRepo: Map<string, TrafficRecord> = new Map();
   if (env.COMPAT_KV) {
     const repos = new Set<string>();
@@ -458,13 +448,27 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
       }
     }
     for (const r of pendingReleases) repos.add(r.repo);
-    for (const t of frontendTracks) repos.add(t.repo);
+    for (const t of allTracks) repos.add(t.repo);
     try {
       trafficByRepo = await getTrafficForRepos(env.COMPAT_KV, repos);
     } catch {
       trafficByRepo = new Map();
     }
   }
+
+  // Frontends セクションは frontend (= CF Worker) repo だけを出す。wave には
+  // backend も混ざるが、**Cloud Run backend (例: rust-alc-api) は除外**する。
+  // ただし CF Worker は compat 上 `backend::` を持っていても (auth-worker 等)
+  // frontend として残す。判定軸は #268 と同じ: CF Worker は version traffic
+  // (`traffic::` = trafficByRepo) を持ち、Cloud Run backend は持たない。
+  // => 除外条件 = 「`backend::` を持ち、かつ traffic:: が無い (= Cloud Run)」。
+  // globalCompat 未取得 (COMPAT_KV 未 bind) 時は判別不能なので全件出す (degrade)。
+  const backendRepos = new Set(
+    (globalCompat?.backends ?? []).map((b) => b.backend_repo),
+  );
+  const frontendTracks = allTracks.filter(
+    (t) => !backendRepos.has(t.repo) || trafficByRepo.has(t.repo),
+  );
   // Pending releases は単一真実 (Refs #237): workers=traffic:: の no-traffic
   // version / cloudrun=pending-release:: を統合し、Traffic セクションと一致させる。
   // compat section の「Staged previews」内 ⚡ Flip all ボタンの出し分けに件数を使う

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -360,6 +360,75 @@ describe("handleReleaseWaveListPage", () => {
     expect(html).not.toContain('title="traffic 100% で live');
   });
 
+  it("keeps a CF Worker backend (has backend:: AND traffic::) in the Frontends section", async () => {
+    // auth-worker は compat 上 backend:: を持つが CF Worker (traffic:: あり) なので
+    // frontend として残す。rust-alc-api は backend:: + traffic:: 無し (Cloud Run)
+    // なので除外する (#268 と同じ判定軸)。
+    const mkRepo = (repo: string) => ({
+      repo,
+      target_tag: "v1",
+      head_sha: "abc1234",
+      require_compatibility: false,
+      stage_status: "done",
+      preview_url: null,
+      stage_error: null,
+      flip_status: "pending",
+      flip_error: null,
+      flip_from_revision: null,
+      rolled_back_to_revision: null,
+    });
+    const env = fakeEnv({
+      listReturn: [
+        makeWave({
+          wave_id: "w-mix",
+          state: "failed",
+          repos: [mkRepo("ippoan/auth-worker"), mkRepo("ippoan/rust-alc-api")],
+        }),
+      ],
+      compatKv: memKv({
+        // 両方とも backend:: を持つ
+        "backend::ippoan/auth-worker": {
+          schema_version: 1,
+          repo: "ippoan/auth-worker",
+          current_image: "aw-img",
+          deployed_at: "2026-06-01T00:00:00Z",
+          deployed_by: "ci",
+          wave_id: null,
+        },
+        "backend::ippoan/rust-alc-api": {
+          schema_version: 1,
+          repo: "ippoan/rust-alc-api",
+          current_image: "cur-img",
+          deployed_at: "2026-06-01T00:00:00Z",
+          deployed_by: "ci",
+          wave_id: null,
+        },
+        // auth-worker だけ CF Worker の version traffic を持つ
+        "traffic::ippoan/auth-worker": {
+          schema_version: 3,
+          repo: "ippoan/auth-worker",
+          versions: [
+            {
+              version_id: "aw-live",
+              percentage: 100,
+              created_on: "2026-06-03T00:00:00Z",
+              tag: "v0.2.52",
+            },
+          ],
+          reported_at: "2026-06-03T00:01:00Z",
+        },
+      }),
+    });
+    const html = await (await handleReleaseWaveListPage(env)).text();
+    const frontendsHtml = html.slice(
+      html.indexOf("Frontends (per-repo tracking)"),
+    );
+    // CF Worker backend (auth-worker) は残る
+    expect(frontendsHtml).toContain("<td>ippoan/auth-worker</td>");
+    // Cloud Run backend (rust-alc-api) は除外
+    expect(frontendsHtml).not.toContain("<td>ippoan/rust-alc-api</td>");
+  });
+
   it("excludes backend repos (backend:: record) from the Frontends section", async () => {
     // wave に frontend (auth-worker) と backend (rust-alc-api) が混在。
     // backend:: record を持つ rust-alc-api は frontend ではないので除外する。


### PR DESCRIPTION
## 背景

#283 で「`backend::` record を持つ repo を Frontends から除外」したが、**auth-worker は CF Worker ながら compat 上は backend 扱い**（frontend に consume される backend）のため、Frontends からも消えてしまった（「auth-worker がきえた」）。

除外すべきは **Cloud Run backend（rust-alc-api）だけ**で、CF Worker（auth-worker / nuxt-notify / nuxt-trouble 等）は frontend として残すべき。

## 変更内容

除外条件を `#268` と同じ frontend/backend 判定軸に揃える:

- **CF Worker は version traffic（`traffic::`）を持ち、Cloud Run backend は持たない**
- 除外条件 = 「`backend::` を持ち、**かつ `traffic::` が無い**（= Cloud Run）」
- → auth-worker（backend:: + traffic:: あり）は残る、rust-alc-api（backend:: + traffic:: 無し）は除外

実装上、traffic 取得を frontend 判定より前に移動し、その結果（`trafficByRepo`）で `frontendTracks` を絞る。`COMPAT_KV` 未 bind 時は判別不能なので全件出す（degrade）。

## テスト

`page.test.ts`:
- CF Worker backend（auth-worker、backend:: + traffic:: あり）→ Frontends に残る
- Cloud Run backend（rust-alc-api、backend:: のみ）→ 除外（既存テスト）

全 716 tests green、`tsc --noEmit` clean。

Refs #137

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1TLqB96rea6TTguip8GJv)_