### PR TITLE
feat(release-wave): Frontends を左・Pending releases を右に下段 2 カラム配置

### DIFF
--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -182,13 +182,16 @@ const COMMON_STYLES = `
   .help-tip:hover .help-pop, .help-tip:focus .help-pop,
   .help-tip:focus-within .help-pop { display: block; }
   /* セクションを縦一列ではなく画面幅に応じて動的に段組みする。
-     auto-fit + minmax により、広い画面 (フル HD 等) では横並び、狭い画面では
+     compat (横長グラフ) はフル幅で上段に、Frontends (左) と pending リリース
+     (右) は下段で 2 カラムに並べる。狭い画面では auto-fit + minmax により
      自動で 1 列に折り返す (メディアクエリ不要)。各カラムは内容量で高さが
-     決まるよう align-items:start。grid の gap を使うので子 .section の
-     縦 margin は打ち消す。 */
-  .wave-grid { display: grid; gap: 16px; align-items: start;
-    grid-template-columns: repeat(auto-fit, minmax(560px, 1fr)); }
+     決まるよう align-items:start。gap を使うので子 .section の縦 margin は
+     打ち消す。 */
+  .wave-grid { display: flex; flex-direction: column; gap: 16px; }
   .wave-grid > .section { margin: 0; }
+  .wave-row { display: grid; gap: 16px; align-items: start;
+    grid-template-columns: repeat(auto-fit, minmax(560px, 1fr)); }
+  .wave-row > .section { margin: 0; }
 `;
 
 /**
@@ -511,8 +514,10 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
     </div>
     <div class="wave-grid">
       ${compatSection}
-      ${pendingReleaseSection}
-      ${frontendSection}
+      <div class="wave-row">
+        ${frontendSection}
+        ${pendingReleaseSection}
+      </div>
     </div>
   </div>
 </body>

--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -153,13 +153,21 @@ export function renderRepoReleaseStatusSection(
  * レンダリング済み一覧 HTML に section を注入する。
  *
  * 配置優先順:
- *   1. Compatibility section の直後 (= Pending releases section の <div> 直前)
- *   2. h1 (`Release Waves`) 直後
- *   3. </body> 直前
+ *   1. 下段 2 カラム (.wave-row = Frontends / Pending releases) の直前
+ *      (= Compatibility section の直後、フル幅)
+ *   2. Pending releases section の <div> 直前 (旧 1 列レイアウト互換)
+ *   3. h1 (`Release Waves`) 直後
+ *   4. </body> 直前
  */
 export function injectRepoStatusSection(html: string, section: string): string {
-  // Pending releases section を起点に、その section の開始 <div> 直前へ入れる。
-  // = Compatibility (all consumers) section の直後。
+  // 下段 2 カラム (Frontends 左 / Pending releases 右) を grid 化したレイアウトでは、
+  // repo status はフル幅でその上 (= compat の直後) に置く。.wave-row 直前へ入れる。
+  const row = html.indexOf('<div class="wave-row">');
+  if (row !== -1) {
+    return html.slice(0, row) + section + "\n      " + html.slice(row);
+  }
+  // 旧 1 列レイアウト互換: Pending releases section を起点に、その section の
+  // 開始 <div> 直前へ入れる (= Compatibility section の直後)。
   const pending = html.indexOf("<h2>Pending releases");
   if (pending !== -1) {
     const divStart = html.lastIndexOf('<div class="section">', pending);


### PR DESCRIPTION
## 概要

`/release-wave` 一覧ページのレイアウトを調整し、**Frontends を左・Pending releases を右** に下段 2 カラムで並べた（スクリーンショットでの「Pending releases を右に」の要望に対応）。

## 変更内容

- **下段 2 カラム化**: compat (横長グラフ) はフル幅で上段に残し、`Frontends (per-repo tracking)` (左) と `Pending releases (no-traffic)` (右) を `.wave-row` (CSS Grid `auto-fit` + `minmax(560px, 1fr)`) で 2 カラムに配置。狭い画面では自動で 1 列に折り返す（メディアクエリ不要）。
- **repo status section の追従**: `injectRepoStatusSection` の注入位置を `.wave-row` 直前（= compat 直後・フル幅）に変更。下段 2 カラム化で `Pending releases` が下段へ移った分の追従。旧 1 列レイアウト向けのフォールバックも残置。
- **テスト誤検出の回避**: CSS コメント内の `Pending releases` 表記が `injectRepoStatusSection` のテスト (`indexOf("Pending releases")`) に誤マッチしないよう言い換え。

## 検証

- `tsc --noEmit` ✓
- `vitest run` (release-wave) → 15 files / 362 tests passed ✓

Refs #137

---
_Generated by [Claude Code](https://claude.ai/code/session_01TuD5ZJ1uGbZjBJNVYBAuGW)_