### PR TITLE
feat(release-wave): Compatibility を左・その他を右の 2 カラムに

### DIFF
--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -181,17 +181,17 @@ const COMMON_STYLES = `
   .help-tip .help-pop a { color: #8ab4f8; }
   .help-tip:hover .help-pop, .help-tip:focus .help-pop,
   .help-tip:focus-within .help-pop { display: block; }
-  /* セクションを縦一列ではなく画面幅に応じて動的に段組みする。
-     compat (横長グラフ) はフル幅で上段に、Frontends (左) と pending リリース
-     (右) は下段で 2 カラムに並べる。狭い画面では auto-fit + minmax により
-     自動で 1 列に折り返す (メディアクエリ不要)。各カラムは内容量で高さが
-     決まるよう align-items:start。gap を使うので子 .section の縦 margin は
+  /* 画面幅に応じて動的に 2 カラムへ段組みする。左カラムに Compatibility
+     (互換グラフ)、右カラムにその他 (リリース状況 / per-repo tracking /
+     no-traffic) を縦積みする。狭い画面では auto-fit + minmax により自動で
+     1 列に折り返す (メディアクエリ不要)。各カラムは内容量で高さが決まるよう
+     align-items:start。min-width:0 で子のテーブル / pre が overflow しても
+     カラムが伸びないようにする。gap を使うので子 .section の縦 margin は
      打ち消す。 */
-  .wave-grid { display: flex; flex-direction: column; gap: 16px; }
-  .wave-grid > .section { margin: 0; }
-  .wave-row { display: grid; gap: 16px; align-items: start;
+  .wave-grid { display: grid; gap: 16px; align-items: start;
     grid-template-columns: repeat(auto-fit, minmax(560px, 1fr)); }
-  .wave-row > .section { margin: 0; }
+  .wave-col { display: flex; flex-direction: column; gap: 16px; min-width: 0; }
+  .wave-col > .section { margin: 0; }
 `;
 
 /**
@@ -513,8 +513,10 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
         title="ページを再取得して最新状態に更新する (ブラウザキャッシュ無視 = ハードリセット)">🔄 更新（ハードリセット）</a>
     </div>
     <div class="wave-grid">
-      ${compatSection}
-      <div class="wave-row">
+      <div class="wave-col">
+        ${compatSection}
+      </div>
+      <div class="wave-col">
         ${frontendSection}
         ${pendingReleaseSection}
       </div>

--- a/src/release-wave/repo-status-section.ts
+++ b/src/release-wave/repo-status-section.ts
@@ -153,15 +153,24 @@ export function renderRepoReleaseStatusSection(
  * レンダリング済み一覧 HTML に section を注入する。
  *
  * 配置優先順:
- *   1. 下段 2 カラム (.wave-row = Frontends / Pending releases) の直前
- *      (= Compatibility section の直後、フル幅)
- *   2. Pending releases section の <div> 直前 (旧 1 列レイアウト互換)
- *   3. h1 (`Release Waves`) 直後
- *   4. </body> 直前
+ *   1. 右カラムの先頭 (= per-repo tracking section の <div> 直前)。
+ *      左カラム = Compatibility / 右カラム = その他、の 2 カラムレイアウト用。
+ *   2. 旧 .wave-row (下段 2 カラム) の直前
+ *   3. Pending releases section の <div> 直前 (旧 1 列レイアウト互換)
+ *   4. h1 (`Release Waves`) 直後
+ *   5. </body> 直前
  */
 export function injectRepoStatusSection(html: string, section: string): string {
-  // 下段 2 カラム (Frontends 左 / Pending releases 右) を grid 化したレイアウトでは、
-  // repo status はフル幅でその上 (= compat の直後) に置く。.wave-row 直前へ入れる。
+  // 左カラム = Compatibility / 右カラム = その他 の 2 カラムレイアウトでは、
+  // repo status は右カラムの先頭 (= per-repo tracking section の直前) に置く。
+  const frontends = html.indexOf("<h2>Frontends");
+  if (frontends !== -1) {
+    const divStart = html.lastIndexOf('<div class="section">', frontends);
+    if (divStart !== -1) {
+      return html.slice(0, divStart) + section + "\n        " + html.slice(divStart);
+    }
+  }
+  // 旧 下段 2 カラム (.wave-row) レイアウト互換: .wave-row 直前へ入れる。
   const row = html.indexOf('<div class="wave-row">');
   if (row !== -1) {
     return html.slice(0, row) + section + "\n      " + html.slice(row);


### PR DESCRIPTION
## 概要

`/release-wave` 一覧ページを **左カラム = Compatibility / 右カラム = その他** の 2 カラムレイアウトに変更した（要望: 「Compatibility (all consumers) を左、その他を右に」）。

## 変更内容

- **2 カラム化**: `.wave-grid` を grid (`auto-fit` + `minmax(560px, 1fr)`) にし、`.wave-col` を 2 つ配置。
  - **左カラム**: `Compatibility (all consumers)` 互換グラフ
  - **右カラム**: `リリース状況` / `Frontends (per-repo tracking)` / `Pending releases (no-traffic)` を縦積み
  - 狭い画面では auto-fit により自動で 1 列に折り返す（メディアクエリ不要）。`min-width:0` で子テーブル / pre の overflow がカラム幅を押し広げないようにした。
- **repo status section の追従**: `injectRepoStatusSection` の注入位置を右カラム先頭（`Frontends` section 直前）に変更。旧レイアウト（`.wave-row` / 1 列）向けフォールバックも残置。

## 検証

- `tsc --noEmit` ✓
- `vitest run` (release-wave) → 15 files / 362 tests passed ✓

Refs #137

---
_Generated by [Claude Code](https://claude.ai/code/session_01TuD5ZJ1uGbZjBJNVYBAuGW)_