### PR TITLE
feat(releases): add ippoan/cdp-relay to TAGLESS_REPOS

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -124,7 +124,7 @@
         // cut release tags: dashboard はこれらの PR merge を mini-release 扱いし、
         // merged PR の `Refs #N` を逆引きして /releases synthetic block + banner に
         // 出す (= stable tag 前でも早期 close 可能)。未掲載 repo は tag-driven flow。
-        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs,ippoan/cc-relay,ippoan/mcp-cf-workers,yhonda-ohishi/claude-hooks,ippoan/claude-skills,ippoan/ci-workflows,ippoan/ref-files-worker,ippoan/claude-hooks"
+        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs,ippoan/cc-relay,ippoan/mcp-cf-workers,yhonda-ohishi/claude-hooks,ippoan/claude-skills,ippoan/ci-workflows,ippoan/ref-files-worker,ippoan/claude-hooks,ippoan/cdp-relay"
       },
       "kv_namespaces": [
         {


### PR DESCRIPTION
## 概要

`https://ci-dashboard.ippoan.org/releases` で `ippoan/cdp-relay` を release 管理できるようにする。

## 背景

`/releases` の watched 集合は **hub の CI run + direct-push allowlist + `TAGLESS_REPOS`** の和。release tag を切らない repo は `TAGLESS_REPOS` に登録しないと `useSynthetic=false` で synthetic block を作らず、tag も無いので何も出ない（`releases-page.ts` の gotcha 通り）。

`cdp-relay` は CDP リレー用の Worker repo で release tag を切らないため未掲載だった。`TAGLESS_REPOS` に追加して、merged PR の `Refs #N` を逆引きする synthetic block を出すようにする。

なお `ci-dashboard` 自身は既に `TAGLESS_REPOS` 登録済み（`b958e87`）。

## 変更

- `wrangler.jsonc` の `env.staging.vars.TAGLESS_REPOS` に `ippoan/cdp-relay` を追加

## 検証

- JSONC parse OK
- 既存テスト（`releases-page.test.ts` / `webhook.test.ts`）は自前で `TAGLESS_REPOS` 値を組み立てており、wrangler の文字列を pin していないため影響なし
- staging auto-deploy 後に `/releases` で確認

Refs #287

---
_Generated by [Claude Code](https://claude.ai/code/session_012D38bzLYVn6odJ9sNcyG1i)_