### PR TITLE
fix(releases): recover Unreleased issues referenced only in PR body

### DIFF
--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -2,6 +2,8 @@ import { parseRepo, tokenForOrg, GitHubApiError } from "./github-api";
 import type { AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
 import {
   extractRefIssues,
+  extractPrNumber,
+  extractBranchIssue,
   sortSemverDesc,
   isSemverTag,
   previousTag,
@@ -16,6 +18,7 @@ import {
   cachedCompare,
   cachedCommits,
   cachedRepoMeta,
+  cachedPullRequest,
   cachedIssue,
   TTL_MOVING_COMPARE,
 } from "./release-cache";
@@ -388,10 +391,38 @@ async function loadSyntheticBlock(
   }
   if (commits.length === 0) return null;
 
+  const repoCtx = { owner, name };
   const refs = new Set<number>();
+  const prNumbers = new Set<number>();
   for (const c of commits) {
-    for (const n of extractRefIssues(c.commit.message, { owner, name })) refs.add(n);
+    for (const n of extractRefIssues(c.commit.message, repoCtx)) refs.add(n);
+    const pr = extractPrNumber(c.commit.message);
+    if (pr !== null) prNumbers.add(pr);
   }
+
+  // PR follow-up pass (Unreleased zone only). A squash-merge subject keeps just
+  // the `(#PR)` suffix and drops the PR body's `Refs #N` trailer — e.g.
+  // ci-dashboard#272 merged as "…統合 (#272)" with `Refs #271` only in the body,
+  // so the commit-message scan above harvests PR #272 (a pull_request, filtered
+  // out) but never issue #271, and the card collapses to "all closed". The
+  // tag-compare detail path already recovers these via collectIssueNumbersForRange;
+  // mirror that here so the index's Unreleased block surfaces them too. Scoped to
+  // the `sinceTag` (latest tag → HEAD) range, which is naturally small + behind
+  // the moving-compare cache, so we don't fan out a PR fetch per commit on the
+  // 100-commit pure-tagless path. Refs ippoan/ci-dashboard#290.
+  if (sinceTag) {
+    await Promise.all([...prNumbers].map(async (n) => {
+      try {
+        const pr = await cachedPullRequest(token, kv, owner, name, n);
+        const fromBranch = extractBranchIssue(pr.head.ref);
+        if (fromBranch !== null) refs.add(fromBranch);
+        if (pr.body) {
+          for (const ref of extractRefIssues(pr.body, repoCtx)) refs.add(ref);
+        }
+      } catch { /* ignore per-PR failure — best-effort enrichment */ }
+    }));
+  }
+
   if (refs.size === 0) {
     // No referenced issues in the recent window — nothing to confirm. Skipping
     // the block (vs. returning an empty one) keeps the repo off the landing

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -813,6 +813,74 @@ describe("GET /releases", () => {
     expect(html).toContain("ippoan/mixed-repo");
   });
 
+  // squash-merge の subject は `(#PR)` だけを残し、PR 本文の `Refs #N` trailer を
+  // 落とす (例: ci-dashboard#272 が "…統合 (#272)" として merge され `Refs #271`
+  // は本文のみ)。一覧の Unreleased block は commit message だけ見ていたため、
+  // commit から拾えるのは PR #272 (= pull_request、除外される) のみで issue #271
+  // が永久に出ず、card が "全部 closed" に潰れていた。Unreleased zone でも detail
+  // ページ同様に PR 本文 / branch から ref を回収するようにした回帰ガード。
+  // Refs ippoan/ci-dashboard#290。
+  it("recovers an Unreleased issue referenced only in the PR body (squash dropped Refs)", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
+      const url = typeof req === "string" ? req : (req as Request).url;
+
+      if (url.includes("/contents/wt-direct-push/config/direct-push-ok.txt")) {
+        return Response.json({ content: btoa(""), encoding: "base64" });
+      }
+
+      if (url.includes("/repos/ippoan/squash-repo/tags")) {
+        return Response.json([{ name: "v1.0.0", commit: { sha: "tag1aaaa" } }]);
+      }
+
+      if (url.match(/\/repos\/ippoan\/squash-repo(\?|$)/)) {
+        return Response.json({ default_branch: "main" });
+      }
+
+      // Unreleased zone: 唯一の commit は PR 番号だけ (Refs trailer 無し)
+      if (url.includes("/repos/ippoan/squash-repo/compare/v1.0.0...main")) {
+        return Response.json({
+          commits: [
+            { sha: "f7d92dc0000000000", commit: { message: "feat: rollback UI を統合 (#272)" } },
+          ],
+        });
+      }
+
+      // PR follow-up: 本文に `Refs #271`、branch は issue prefix を持たない
+      if (url.endsWith("/repos/ippoan/squash-repo/pulls/272")) {
+        return Response.json({
+          number: 272,
+          head: { ref: "claude/admiring-bell-dar5v" },
+          body: "## 概要\n\n…統合する。\n\nRefs #271\n",
+        });
+      }
+
+      // PR 本文経由で初めて拾われる open issue
+      if (url.endsWith("/repos/ippoan/squash-repo/issues/271")) {
+        return Response.json({
+          number: 271, title: "rollback UI を version 行と統合する", state: "open",
+          labels: [], assignees: [],
+          html_url: "https://github.com/ippoan/squash-repo/issues/271",
+          updated_at: "2026-06-04T09:09:27Z",
+        });
+      }
+
+      return new Response(`not stubbed: ${url}`, { status: 500 });
+    });
+
+    const e = testEnv({ tagless: ["ippoan/squash-repo"] });
+    const req = new Request("http://localhost/releases");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, e, ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    // commit には Refs が無いのに、PR 本文経由で issue #271 が候補に出る
+    expect(html).toContain("Unreleased (main@f7d92dc)");
+    expect(html).toContain("rollback UI を version 行と統合する");
+  });
+
   // archived repo は GitHub API で issue close ができない (403 read-only) ため、
   // /releases から一切除外する。Refs ippoan/ci-dashboard#155
   // (ippoan/github-mcp-server-rs が monorepo 化で archive されたが Refs を


### PR DESCRIPTION
## 症状

`/releases` で ci-dashboard の card が「✅ 50 closed issues (released)」のコンパクト表示になり、merge 済みだが未 close の open issue（#271 / #266 など）が出てこず、release 確認 UI から close できない。

## 根本原因

1. `/releases` 一覧の Unreleased ブロック（`loadSyntheticBlock` の `sinceTag` パス = latest tag → HEAD）は **commit メッセージから `Refs|Related to|Part of #N` だけ**を harvest していた（`release-helpers.ts` の `REF_PATTERN`）。sub-request 削減のため PR 本文は読まない設計。
2. しかし squash-merge の subject は PR 本文の `Refs #N` trailer を落とし、`(#PR)` だけが残る。実例:
   - commit `878a647 feat(release-wave): rollback UI を version 行と同じ行に統合 (#272)` — `Refs #271` 無し
   - PR #272 の**本文には** `Refs #271` がある
3. `(#272)` は **PR**（pull_request）に解決され除外されるため、issue #271 は一度も拾われない → 非表示。
4. Unreleased 範囲で `Refs` 付きの #275/#268 は両方 closed のため、harvest 結果が全 closed → card がコンパクトに潰れる。

## 修正

`loadSyntheticBlock` の **`sinceTag`（Unreleased）パス限定**で、detail ページの `collectIssueNumbersForRange` と同じ PR follow-up pass を追加:

- commit から `(#PR)` を抽出（`extractPrNumber`）
- 各 PR を `cachedPullRequest` で取得し、**本文の `Refs #N`** と **branch prefix の issue 番号**（`extractBranchIssue`）を ref に回収

これで squash で `Refs` が落ちても、PR 本文経由で issue が Unreleased ブロックに surface する。

範囲は latest tag → HEAD の小さな moving-range（moving-compare キャッシュ + per-PR キャッシュ配下）に限定。pure-tagless の 100-commit パス（`sinceTag` 無し）は fan-out 抑制のため対象外。

## テスト

- 新規回帰テスト: commit に `Refs` が無く PR 本文だけに `Refs #271` がある repo で、Unreleased ブロックに issue #271 が surface することを assert
- 既存 `releases-page` テスト含め **全 717 件 pass**、`tsc --noEmit` green

Refs #271, #266

---
_Generated by [Claude Code](https://claude.ai/code/session_012D38bzLYVn6odJ9sNcyG1i)_