### PR TITLE
fix(releases): recover pure-tagless issues referenced only in PR body

### DIFF
--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -345,6 +345,14 @@ async function loadRepoView(
 // supported for these tags — `renderTagBlock` skips the link.
 const SYNTHETIC_COMMIT_WINDOW = 100;
 
+// Cap on how many `(#PR)` follow-up fetches the synthetic block does per repo.
+// The PR pass recovers issues whose `Refs #N` only live in the PR body (squash
+// drops them from the merge subject), but a 100-commit window across ~13 tagless
+// repos would otherwise fan out a PR fetch per commit and blow the Worker
+// subrequest budget. We keep the most-recent N (issues merged recently are the
+// ones still likely open / actionable); PRs are cached so warm loads are cheap.
+const MAX_PR_FOLLOWUP = 20;
+
 interface RepoMeta {
   default_branch: string;
   archived?: boolean;
@@ -393,35 +401,45 @@ async function loadSyntheticBlock(
 
   const repoCtx = { owner, name };
   const refs = new Set<number>();
-  const prNumbers = new Set<number>();
   for (const c of commits) {
     for (const n of extractRefIssues(c.commit.message, repoCtx)) refs.add(n);
-    const pr = extractPrNumber(c.commit.message);
-    if (pr !== null) prNumbers.add(pr);
   }
 
-  // PR follow-up pass (Unreleased zone only). A squash-merge subject keeps just
-  // the `(#PR)` suffix and drops the PR body's `Refs #N` trailer — e.g.
-  // ci-dashboard#272 merged as "…統合 (#272)" with `Refs #271` only in the body,
-  // so the commit-message scan above harvests PR #272 (a pull_request, filtered
-  // out) but never issue #271, and the card collapses to "all closed". The
+  // PR follow-up pass. A squash-merge subject keeps only the `(#PR)` suffix and
+  // drops the PR body's `Refs #N` trailer — e.g. ci-dashboard#272 merged as
+  // "…統合 (#272)" with `Refs #271` only in the body, or claude-hooks#13 merged
+  // as "… (#13)" with `Refs #12` only in the body. The commit-message scan above
+  // then harvests the PR number (a pull_request, filtered out) but never the
+  // underlying issue, so the card collapses to "no referenced issues". The
   // tag-compare detail path already recovers these via collectIssueNumbersForRange;
-  // mirror that here so the index's Unreleased block surfaces them too. Scoped to
-  // the `sinceTag` (latest tag → HEAD) range, which is naturally small + behind
-  // the moving-compare cache, so we don't fan out a PR fetch per commit on the
-  // 100-commit pure-tagless path. Refs ippoan/ci-dashboard#290.
-  if (sinceTag) {
-    await Promise.all([...prNumbers].map(async (n) => {
-      try {
-        const pr = await cachedPullRequest(token, kv, owner, name, n);
-        const fromBranch = extractBranchIssue(pr.head.ref);
-        if (fromBranch !== null) refs.add(fromBranch);
-        if (pr.body) {
-          for (const ref of extractRefIssues(pr.body, repoCtx)) refs.add(ref);
-        }
-      } catch { /* ignore per-PR failure — best-effort enrichment */ }
-    }));
+  // mirror it here for BOTH synthetic paths — the Unreleased zone (sinceTag) and
+  // the pure-tagless window (no tags at all, e.g. claude-hooks / mcp-cf-workers,
+  // which only carry `dev-*` tags). Capped to the most-recent MAX_PR_FOLLOWUP so
+  // the 100-commit window doesn't fan out a fetch per commit. Refs #290, #291.
+  //
+  // Ordering: cachedCommits (no sinceTag) is newest-first; cachedCompare
+  // (sinceTag) is oldest-first. Normalize to newest-first so the cap keeps the
+  // freshest PRs (the ones whose issues are most likely still open).
+  const recentFirst = sinceTag ? [...commits].reverse() : commits;
+  const prNumbers: number[] = [];
+  const seenPr = new Set<number>();
+  for (const c of recentFirst) {
+    const pr = extractPrNumber(c.commit.message);
+    if (pr !== null && !seenPr.has(pr)) {
+      seenPr.add(pr);
+      prNumbers.push(pr);
+    }
   }
+  await Promise.all(prNumbers.slice(0, MAX_PR_FOLLOWUP).map(async (n) => {
+    try {
+      const pr = await cachedPullRequest(token, kv, owner, name, n);
+      const fromBranch = extractBranchIssue(pr.head.ref);
+      if (fromBranch !== null) refs.add(fromBranch);
+      if (pr.body) {
+        for (const ref of extractRefIssues(pr.body, repoCtx)) refs.add(ref);
+      }
+    } catch { /* ignore per-PR failure — best-effort enrichment */ }
+  }));
 
   if (refs.size === 0) {
     // No referenced issues in the recent window — nothing to confirm. Skipping

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -881,6 +881,69 @@ describe("GET /releases", () => {
     expect(html).toContain("rollback UI を version 行と統合する");
   });
 
+  // pure-tagless repo (semver tag ゼロ、`dev-*` のみ等: claude-hooks /
+  // mcp-cf-workers) は no-sinceTag synthetic パス (default branch の最近 commit)
+  // を通る。ここでも squash で本文 `Refs #N` が落ちた issue を PR follow-up で
+  // 回収する。Refs ippoan/ci-dashboard#291。
+  it("recovers a pure-tagless issue referenced only in the PR body (no-sinceTag path)", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
+      const url = typeof req === "string" ? req : (req as Request).url;
+
+      if (url.includes("/contents/wt-direct-push/config/direct-push-ok.txt")) {
+        return Response.json({ content: btoa(""), encoding: "base64" });
+      }
+
+      // semver tag 無し (`dev-*` のみ) → isSemverTag で全部弾かれ no-sinceTag パス
+      if (url.includes("/repos/ippoan/hooks-repo/tags")) {
+        return Response.json([{ name: "dev-0.0.4", commit: { sha: "dddddddd" } }]);
+      }
+
+      if (url.match(/\/repos\/ippoan\/hooks-repo(\?|$)/)) {
+        return Response.json({ default_branch: "main" });
+      }
+
+      // default branch の最近 commit (cachedCommits): PR 番号だけ、Refs 無し
+      if (url.includes("/repos/ippoan/hooks-repo/commits")) {
+        return Response.json([
+          { sha: "b21f5ee0000000000", commit: { message: "feat: add npm-ippoan-local-fallback hook (#13)" } },
+        ]);
+      }
+
+      // PR follow-up: 本文に `Refs #12`
+      if (url.endsWith("/repos/ippoan/hooks-repo/pulls/13")) {
+        return Response.json({
+          number: 13,
+          head: { ref: "claude/release-wave-e2e-testing-bJ6wU" },
+          body: "## 目的 (Refs #12)\n\n…file: フォールバック hook。\n\nRefs #12\n",
+        });
+      }
+
+      if (url.endsWith("/repos/ippoan/hooks-repo/issues/12")) {
+        return Response.json({
+          number: 12, title: "npm 401 時の local file: フォールバック hook", state: "open",
+          labels: [], assignees: [],
+          html_url: "https://github.com/ippoan/hooks-repo/issues/12",
+          updated_at: "2026-06-04T08:59:01Z",
+        });
+      }
+
+      return new Response(`not stubbed: ${url}`, { status: 500 });
+    });
+
+    const e = testEnv({ tagless: ["ippoan/hooks-repo"] });
+    const req = new Request("http://localhost/releases");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, e, ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    // 無 tag の synthetic block (label は `<branch>@<sha7>`) に issue #12 が出る
+    expect(html).toContain("main@b21f5ee");
+    expect(html).toContain("npm 401 時の local file: フォールバック hook");
+  });
+
   // archived repo は GitHub API で issue close ができない (403 read-only) ため、
   // /releases から一切除外する。Refs ippoan/ci-dashboard#155
   // (ippoan/github-mcp-server-rs が monorepo 化で archive されたが Refs を


### PR DESCRIPTION
## 症状

`/releases` で **pure-tagless な repo**（semver tag が無く `dev-*` 等だけ持つ／全く tag が無い repo: `claude-hooks`, `mcp-cf-workers` など）の card に、merge 済みだが未 close の open issue が surface しない。

例: `claude-hooks#12`（npm 401 fallback hook）は PR #13 で実装・merge 済みだが、`/releases` の claude-hooks card に出ず close 操作できない。

## 根本原因

#290 で `loadSyntheticBlock` の **Unreleased（`sinceTag`）パス限定**で PR follow-up（PR 本文の `Refs #N` 回収）を入れたが、tag が 1 つも無い repo は **no-sinceTag synthetic パス**（default branch の最近 commit）を通るため対象外だった。

- `claude-hooks` … tag 0 個 → no-sinceTag パス
- `mcp-cf-workers` … `dev-0.0.x` のみ（`isSemverTag` で全部弾かれる）→ no-sinceTag パス

これらの commit は squash で `(#PR)` だけが残り本文の `Refs #N` が落ちているので、commit-message scan では PR 番号（pull_request、除外）しか拾えず issue が永久に出ない。

## 修正

PR follow-up pass を **両方の synthetic パス**（Unreleased + pure-tagless）に適用:

- commit から `(#PR)` を抽出 → `cachedPullRequest` で PR 本文の `Refs #N` / branch prefix の issue 番号を回収
- 100-commit window × 多数の tagless repo での fan-out を抑えるため、**最新 `MAX_PR_FOLLOWUP`(=20) PR に cap**（最新 commit 優先で並べ替え。PR は cache 済みなので warm load は安価）

## 補足（今回の修正対象外）

ユーザーが挙げた `mcp-cf-workers(2)` の 2 件（#44 = protect_hostname 実行タスク、#28 = cdp-relay 設計引継ぎ doc）は **どちらも紐づく merged PR が無い task/handoff issue** なので、本修正後も `/releases` には出ない（"release が close した issue" の対象外。手動 close する性質の issue）。同様に `claude-hooks#8`（テスト手動タスク）/ `#2`（CI fixture, "Do not close"）も対象外。

## テスト

- 新規回帰テスト: semver tag 無し（`dev-*` のみ）の repo で、commit に `Refs` が無く PR 本文だけに `Refs #12` がある場合に no-sinceTag synthetic block へ issue #12 が surface することを assert
- **全 718 件 pass / `tsc --noEmit` green**

Refs #12

---
_Generated by [Claude Code](https://claude.ai/code/session_012D38bzLYVn6odJ9sNcyG1i)_