### PR TITLE
feat(releases): surface cross-repo refs on the shipping repo's card

### DIFF
--- a/src/release-close-batch.ts
+++ b/src/release-close-batch.ts
@@ -11,10 +11,19 @@ import { invalidateIssue } from "./release-cache";
 // to attribute each "Closed by release <tag>" comment to the right tag, then
 // closes the issues.
 //
+// Cross-repo rows (an issue that lives in a DIFFERENT repo but was shipped by a
+// PR in this card's repo — e.g. a cdp-relay PR carrying
+// `Refs ippoan/mcp-cf-workers#28`) encode the home repo into the pair as
+// `pair=<tag>:<owner>/<name>#<issue>`, and we close them against that repo
+// instead of the card's repo. Refs ippoan/ci-dashboard#292.
+//
 // Single-tag close still lives at POST /api/release-close (used by the
 // detail page) — that handler's payload shape is the older `tag` + `issue[]`
 // form and we keep it for backward compatibility.
 
+// `<tag>:<owner>/<name>#<issue>` — cross-repo. Checked first (more specific).
+const CROSS_RE = /^(.+):([\w.-]+\/[\w.-]+)#(\d+)$/;
+// `<tag>:<issue>` — same repo as the card.
 const PAIR_RE = /^(.+):(\d+)$/;
 
 export async function handleReleaseCloseBatch(
@@ -35,67 +44,90 @@ export async function handleReleaseCloseBatch(
     return new Response("Missing repo", { status: 400 });
   }
 
-  // Parse `tag:issue` pairs; silently drop anything malformed.
-  const grouped = new Map<string, number[]>();
-  for (const raw of rawPairs) {
-    const m = raw.match(PAIR_RE);
-    if (!m) continue;
-    const tag = m[1]!;
-    const n = Number(m[2]);
-    if (!Number.isInteger(n) || n <= 0) continue;
-    const list = grouped.get(tag);
-    if (list) list.push(n);
-    else grouped.set(tag, [n]);
-  }
+  // Resolve a token once per distinct owner (cross-repo ops may span repos).
+  const tokenByOwner = new Map<string, Promise<string>>();
+  const tokenFor = (owner: string): Promise<string> => {
+    let p = tokenByOwner.get(owner);
+    if (!p) {
+      p = tokenForOrg(env, owner);
+      tokenByOwner.set(owner, p);
+    }
+    return p;
+  };
 
-  // Nothing selected → bounce straight back to /releases without spamming
-  // GitHub. This is the "user submitted an empty form" path.
-  if (grouped.size === 0) {
-    return redirect("/releases");
-  }
-
-  let owner: string, name: string, token: string;
+  // Validate the card repo's org up front: a disallowed / malformed card repo is
+  // a 400 (operator-facing config error), not a silent per-issue failure. Also
+  // primes the token cache for the common same-repo ops. Cross-repo targets are
+  // validated lazily inside the close loop (a single bad cross-repo ref should
+  // only fail that one row, not the whole batch).
   try {
-    ({ owner, repo: name } = parseRepo(repoParam));
-    token = await tokenForOrg(env, owner);
+    const { owner: cardOwner } = parseRepo(repoParam);
+    await tokenFor(cardOwner);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return new Response(`Bad repo: ${msg}`, { status: 400 });
   }
 
-  // Flatten the grouped map into one operation list so failures per issue
-  // can be tracked back to the right number for the flash query.
-  type Operation = { tag: string; issue: number };
+  // Parse pairs into operations. Each op carries its target repo: the card's
+  // repo by default, or the cross-repo target embedded in the pair. Malformed
+  // pairs are silently dropped.
+  type Operation = { repo: string; tag: string; issue: number };
   const ops: Operation[] = [];
-  for (const [tag, issues] of grouped) {
-    for (const issue of issues) ops.push({ tag, issue });
+  for (const raw of rawPairs) {
+    const cm = raw.match(CROSS_RE);
+    if (cm) {
+      const n = Number(cm[3]);
+      if (Number.isInteger(n) && n > 0) ops.push({ repo: cm[2]!, tag: cm[1]!, issue: n });
+      continue;
+    }
+    const m = raw.match(PAIR_RE);
+    if (!m) continue;
+    const n = Number(m[2]);
+    if (Number.isInteger(n) && n > 0) ops.push({ repo: repoParam, tag: m[1]!, issue: n });
   }
 
+  // Nothing selected → bounce straight back to /releases without spamming
+  // GitHub. This is the "user submitted an empty form" path.
+  if (ops.length === 0) {
+    return redirect("/releases");
+  }
+
+  // Close in parallel; per-issue failures (including a bad repo) don't sink the
+  // whole batch — they surface in the `failed` flash.
   const settled = await Promise.allSettled(
-    ops.map(async ({ tag, issue }) => {
+    ops.map(async (op) => {
+      const { owner, repo: name } = parseRepo(op.repo);
+      const token = await tokenFor(owner);
       await githubApi(
         token, "POST",
-        `/repos/${owner}/${name}/issues/${issue}/comments`,
-        { body: `Closed by release ${tag}` },
+        `/repos/${owner}/${name}/issues/${op.issue}/comments`,
+        { body: `Closed by release ${op.tag}` },
       );
       await githubApi(
         token, "PATCH",
-        `/repos/${owner}/${name}/issues/${issue}`,
+        `/repos/${owner}/${name}/issues/${op.issue}`,
         { state: "closed", state_reason: "completed" },
       );
-      return issue;
+      return op;
     }),
   );
 
   const closed: number[] = [];
   const failed: number[] = [];
   const failedReasons: Array<{ n: number; reason: string }> = [];
+  // Track successful closes per repo so cache invalidation + hub recompute hit
+  // the right repo (the card repo AND any cross-repo targets).
+  const closedByRepo = new Map<string, number[]>();
   settled.forEach((r, i) => {
-    if (r.status === "fulfilled") closed.push(r.value);
-    else {
-      const n = ops[i]!.issue;
-      failed.push(n);
-      failedReasons.push({ n, reason: formatCloseFailureReason(r.reason) });
+    const op = ops[i]!;
+    if (r.status === "fulfilled") {
+      closed.push(op.issue);
+      const list = closedByRepo.get(op.repo);
+      if (list) list.push(op.issue);
+      else closedByRepo.set(op.repo, [op.issue]);
+    } else {
+      failed.push(op.issue);
+      failedReasons.push({ n: op.issue, reason: formatCloseFailureReason(r.reason) });
     }
   });
 
@@ -103,20 +135,28 @@ export async function handleReleaseCloseBatch(
   // newly-closed state instead of the 60s-stale "open" row.
   if (env.CI_STATUS) {
     await Promise.all(
-      closed.map((n) => invalidateIssue(env.CI_STATUS, owner, name, n)),
+      [...closedByRepo].flatMap(([repo, nums]) => {
+        try {
+          const { owner, repo: name } = parseRepo(repo);
+          return nums.map((n) => invalidateIssue(env.CI_STATUS, owner, name, n));
+        } catch {
+          return [];
+        }
+      }),
     );
   }
 
-  // Kick Hub to recompute alert state for this repo when at least one close
-  // succeeded. Same waitUntil pattern as release-close.ts so the redirect
-  // stays snappy and the dashboard banner updates asynchronously.
-  if (hub && closed.length > 0) {
-    const recompute = hub.fetch(new Request("http://hub/release-alert-recompute", {
-      method: "POST",
-      body: JSON.stringify({ repo: repoParam }),
-    }));
-    if (ctx) ctx.waitUntil(recompute);
-    else { void recompute; }
+  // Kick Hub to recompute alert state for each repo that had a successful close.
+  // Same waitUntil pattern as release-close.ts so the redirect stays snappy.
+  if (hub && closedByRepo.size > 0) {
+    for (const repo of closedByRepo.keys()) {
+      const recompute = hub.fetch(new Request("http://hub/release-alert-recompute", {
+        method: "POST",
+        body: JSON.stringify({ repo }),
+      }));
+      if (ctx) ctx.waitUntil(recompute);
+      else { void recompute; }
+    }
   }
 
   const params = new URLSearchParams({ repo: repoParam });

--- a/src/release-helpers.ts
+++ b/src/release-helpers.ts
@@ -39,6 +39,39 @@ export function extractRefIssues(
   return [...out];
 }
 
+// Cross-repo refs: `Refs <owner>/<name>#N` where `<owner>/<name>` is a DIFFERENT
+// repo than `currentRepo`. extractRefIssues drops these (to avoid mixing another
+// repo's issue numbers into the current card); this returns exactly those dropped
+// refs so the /releases index can surface an issue under the repo whose PR shipped
+// the work even though the issue lives elsewhere (e.g. a cdp-relay PR carrying
+// `Refs ippoan/mcp-cf-workers#28`). Refs ippoan/ci-dashboard#292.
+export function extractCrossRepoRefs(
+  text: string,
+  currentRepo: { owner: string; name: string },
+): Array<{ owner: string; name: string; number: number }> {
+  if (!text) return [];
+  const wantOwner = currentRepo.owner.toLowerCase();
+  const wantName = currentRepo.name.toLowerCase();
+  const seen = new Set<string>();
+  const out: Array<{ owner: string; name: string; number: number }> = [];
+  for (const m of text.matchAll(REF_PATTERN)) {
+    const crossRepo = m[1]; // optional `<owner>/<name>`
+    if (!crossRepo) continue; // bare `#N` = same repo, not a cross-repo ref
+    const slash = crossRepo.indexOf("/");
+    const owner = crossRepo.slice(0, slash);
+    const name = crossRepo.slice(slash + 1);
+    if (owner.toLowerCase() === wantOwner && name.toLowerCase() === wantName) {
+      continue; // owner/name spelled out but it IS the current repo
+    }
+    const number = Number(m[2]);
+    const key = `${owner.toLowerCase()}/${name.toLowerCase()}#${number}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ owner, name, number });
+  }
+  return out;
+}
+
 // Squash-merge commits land on main with their PR number trailing the subject,
 // e.g. "feat(x): do thing (#42)". Pull that out so we can re-fetch the PR for
 // its `head.ref` (branch name) and body, which carry additional Refs and the

--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -2,6 +2,7 @@ import { parseRepo, tokenForOrg, GitHubApiError } from "./github-api";
 import type { AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
 import {
   extractRefIssues,
+  extractCrossRepoRefs,
   extractPrNumber,
   extractBranchIssue,
   sortSemverDesc,
@@ -245,7 +246,7 @@ async function loadRepoView(
     // return empty as before so we don't accidentally promote a regular
     // auto-merge repo into the synthetic path mid-release.
     if (useSynthetic) {
-      const block = await loadSyntheticBlock(token, owner, name, kv);
+      const block = await loadSyntheticBlock(env, token, owner, name, kv);
       return {
         repo: `${owner}/${name}`,
         tagBlocks: block ? [block] : [],
@@ -319,7 +320,7 @@ async function loadRepoView(
   // Refs ippoan/ci-dashboard#147 (cross-repo Refs 修正) + #145 (TAGLESS 追加)。
   if (useSynthetic) {
     const latestTag = sorted[0]!;
-    const unreleased = await loadSyntheticBlock(token, owner, name, kv, latestTag);
+    const unreleased = await loadSyntheticBlock(env, token, owner, name, kv, latestTag);
     if (unreleased) tagBlocks.unshift(unreleased);
   }
 
@@ -359,6 +360,7 @@ interface RepoMeta {
 }
 
 async function loadSyntheticBlock(
+  env: AuthClientWorkerEnv,
   token: string,
   owner: string,
   name: string,
@@ -401,8 +403,19 @@ async function loadSyntheticBlock(
 
   const repoCtx = { owner, name };
   const refs = new Set<number>();
+  // Cross-repo refs (`Refs <otherOwner>/<otherName>#N`): the issue lives in a
+  // different repo but the work shipped via THIS repo's PR/commit. extractRefIssues
+  // drops them; we collect them separately and surface them on this card, closable
+  // against their home repo. Keyed by `owner/name#n` for dedupe. Refs #292.
+  const crossRefs = new Map<string, { owner: string; name: string; number: number }>();
+  const addCross = (text: string) => {
+    for (const x of extractCrossRepoRefs(text, repoCtx)) {
+      crossRefs.set(`${x.owner.toLowerCase()}/${x.name.toLowerCase()}#${x.number}`, x);
+    }
+  };
   for (const c of commits) {
     for (const n of extractRefIssues(c.commit.message, repoCtx)) refs.add(n);
+    addCross(c.commit.message);
   }
 
   // PR follow-up pass. A squash-merge subject keeps only the `(#PR)` suffix and
@@ -437,22 +450,52 @@ async function loadSyntheticBlock(
       if (fromBranch !== null) refs.add(fromBranch);
       if (pr.body) {
         for (const ref of extractRefIssues(pr.body, repoCtx)) refs.add(ref);
+        // Cross-repo refs most often live in the PR body (squash drops them from
+        // the merge subject) — e.g. cdp-relay PRs carrying
+        // `Refs ippoan/mcp-cf-workers#28`. Collect them here too. Refs #292.
+        addCross(pr.body);
       }
     } catch { /* ignore per-PR failure — best-effort enrichment */ }
   }));
 
-  if (refs.size === 0) {
+  // Hydrate cross-repo issues from their home repo (own token + cache), capped
+  // like the PR pass. Built into rows tagged with `repo` so render + close target
+  // the right repo. Refs #292.
+  const crossRows: IssueRow[] = [];
+  await Promise.all([...crossRefs.values()].slice(0, MAX_PR_FOLLOWUP).map(async (x) => {
+    try {
+      const xToken = await tokenForOrg(env, x.owner);
+      const issue = await cachedIssue(xToken, kv, x.owner, x.name, x.number);
+      if (issue.pull_request) return; // a PR, not an issue
+      const labels = issue.labels.map((l) => l.name);
+      crossRows.push({
+        number: issue.number,
+        title: issue.title,
+        state: issue.state,
+        labels,
+        assignees: issue.assignees.map((a) => a.login),
+        url: issue.html_url,
+        updated_at: issue.updated_at,
+        warnings: computeWarnings({ state: issue.state, labels }),
+        repo: `${x.owner}/${x.name}`,
+      });
+    } catch { /* ignore per-issue failure — best-effort cross-repo enrichment */ }
+  }));
+
+  if (refs.size === 0 && crossRows.length === 0) {
     // No referenced issues in the recent window — nothing to confirm. Skipping
     // the block (vs. returning an empty one) keeps the repo off the landing
     // page entirely, matching the tag path's behavior.
     return null;
   }
 
-  const issues = await fetchIssuesByNumbers(token, owner, name, refs, kv);
+  const issues = refs.size > 0
+    ? await fetchIssuesByNumbers(token, owner, name, refs, kv)
+    : [];
   // Keep both open and closed referenced issues (was open-only): a tag-less /
   // direct-push repo whose refs are all closed should still surface its card
   // with the closed history collapsed into a <details>. Refs #224.
-  const rows: IssueRow[] = issues
+  const sameRepoRows: IssueRow[] = issues
     .filter((i) => !i.pull_request)
     .map((i) => {
       const labels = i.labels.map((l) => l.name);
@@ -468,6 +511,11 @@ async function loadSyntheticBlock(
       };
     })
     .sort((a, b) => a.number - b.number);
+
+  // Same-repo rows first (by number), then cross-repo rows (by repo, then number)
+  // so a card reads "own issues, then issues this release closed elsewhere".
+  crossRows.sort((a, b) => a.repo!.localeCompare(b.repo!) || a.number - b.number);
+  const rows = [...sameRepoRows, ...crossRows];
 
   if (rows.length === 0) return null;
 
@@ -509,6 +557,11 @@ interface IssueRow {
   url: string;
   updated_at: string;
   warnings: string[];
+  // Set only for cross-repo rows: the `owner/name` of the repo the issue lives
+  // in, when it differs from the card's repo (e.g. a cdp-relay PR's
+  // `Refs ippoan/mcp-cf-workers#28` surfaces mcp-cf-workers#28 on cdp-relay's
+  // card). Drives the cross-repo checkbox encoding + close target. Refs #292.
+  repo?: string;
 }
 
 async function loadRelease(
@@ -963,9 +1016,18 @@ function renderTagBlock(repo: string, block: TagBlock): string {
 function renderIndexRow(tag: string, r: IssueRow): string {
   const hasWarn = r.warnings.length > 0;
   const checked = hasWarn ? "" : " checked";
-  const pair = `${tag}:${r.number}`;
+  // Cross-repo rows (r.repo set) encode the home repo into the pair so the batch
+  // close handler closes against it, not the card's repo: `<tag>:<owner>/<name>#<n>`.
+  // Same-repo rows keep the legacy `<tag>:<n>`. Refs #292.
+  const pair = r.repo ? `${tag}:${r.repo}#${r.number}` : `${tag}:${r.number}`;
   const warnIcon = hasWarn
     ? `<span class="warn" title="${escapeHtml(r.warnings.join(", "))}">⚠️</span>`
+    : "";
+  // Prefix the number cell with the foreign repo for cross-repo rows so it's
+  // obvious the issue lives elsewhere (e.g. `ippoan/mcp-cf-workers#28`).
+  const numLabel = r.repo ? `${escapeHtml(r.repo)}#${r.number}` : `#${r.number}`;
+  const crossMarker = r.repo
+    ? ` <span class="cross-repo-marker" title="cross-repo: lives in ${escapeHtml(r.repo)}, shipped by a PR here">cross-repo</span>`
     : "";
   const labelChips = r.labels.length > 0
     ? `<div class="labels">${r.labels
@@ -976,8 +1038,8 @@ function renderIndexRow(tag: string, r: IssueRow): string {
 
   return `<tr>
     <td class="col-check"><input type="checkbox" name="pair" value="${escapeHtml(pair)}"${checked}></td>
-    <td class="num"><a href="${escapeHtml(r.url)}" target="_blank" rel="noopener">#${r.number}</a></td>
-    <td class="title">${warnIcon}<a href="${escapeHtml(r.url)}" target="_blank" rel="noopener">${escapeHtml(r.title)}</a></td>
+    <td class="num"><a href="${escapeHtml(r.url)}" target="_blank" rel="noopener">${numLabel}</a></td>
+    <td class="title">${warnIcon}<a href="${escapeHtml(r.url)}" target="_blank" rel="noopener">${escapeHtml(r.title)}</a>${crossMarker}</td>
     <td>${stateChip}</td>
     <td>${labelChips}</td>
   </tr>`;

--- a/test/release-close-batch.test.ts
+++ b/test/release-close-batch.test.ts
@@ -95,6 +95,36 @@ describe("POST /api/release-close-batch", () => {
     expect(bodies.filter((b) => b === "Closed by release v1.1.0").length).toBe(1);
   });
 
+  it("closes a cross-repo pair against its home repo, not the card repo", async () => {
+    const { calls } = stubCloseFlow();
+    const req = new Request("http://localhost/api/release-close-batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formBody([
+        ["repo", "ippoan/cdp-relay"],
+        // same-repo row (closes against card repo) …
+        ["pair", "main@abc1234:5"],
+        // … cross-repo row: issue lives in ippoan/mcp-cf-workers, shipped by a
+        // cdp-relay PR. Must close against mcp-cf-workers, not cdp-relay.
+        ["pair", "main@abc1234:ippoan/mcp-cf-workers#28"],
+      ]),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(303);
+    const location = res.headers.get("Location") ?? "";
+    const closedNums = decodeURIComponent(location.match(/closed=([^&]+)/)![1]!).split(",").sort();
+    expect(closedNums).toEqual(["28", "5"]);
+
+    // same-repo close hits cdp-relay
+    expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/repos/ippoan/cdp-relay/issues/5"))).toBe(true);
+    // cross-repo close hits mcp-cf-workers (NOT cdp-relay)
+    expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/repos/ippoan/mcp-cf-workers/issues/28"))).toBe(true);
+    expect(calls.some((c) => c.url.endsWith("/repos/ippoan/cdp-relay/issues/28"))).toBe(false);
+  });
+
   it("partitions partial failures into closed= and failed=", async () => {
     const { calls } = stubCloseFlow({ failIssue: 5 });
     const req = new Request("http://localhost/api/release-close-batch", {

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -944,6 +944,69 @@ describe("GET /releases", () => {
     expect(html).toContain("npm 401 時の local file: フォールバック hook");
   });
 
+  // cross-repo ref: 実装は cdp-relay (本 repo) の PR、issue は別 repo
+  // (mcp-cf-workers) に居る。`Refs ippoan/mcp-cf-workers#28` を本 repo の card に
+  // surface し、close は mcp-cf-workers に対して行えるよう pair に repo を埋める。
+  // Refs ippoan/ci-dashboard#292。
+  it("surfaces a cross-repo issue on the shipping repo's card with repo-tagged pair", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
+      const url = typeof req === "string" ? req : (req as Request).url;
+
+      if (url.includes("/contents/wt-direct-push/config/direct-push-ok.txt")) {
+        return Response.json({ content: btoa(""), encoding: "base64" });
+      }
+
+      // 本 repo (relay-repo) は tag 無し → no-sinceTag synthetic パス
+      if (url.includes("/repos/ippoan/relay-repo/tags")) {
+        return Response.json([]);
+      }
+      if (url.match(/\/repos\/ippoan\/relay-repo(\?|$)/)) {
+        return Response.json({ default_branch: "main" });
+      }
+      // commit は PR 番号のみ
+      if (url.includes("/repos/ippoan/relay-repo/commits")) {
+        return Response.json([
+          { sha: "c0ffee00000000000", commit: { message: "feat: cdp-relay 初回実装 (#1)" } },
+        ]);
+      }
+      // PR 本文に cross-repo ref
+      if (url.endsWith("/repos/ippoan/relay-repo/pulls/1")) {
+        return Response.json({
+          number: 1,
+          head: { ref: "claude/initial-impl" },
+          body: "初回実装。\n\nRefs ippoan/mcp-cf-workers#28\n",
+        });
+      }
+      // cross-repo issue を home repo から hydrate
+      if (url.endsWith("/repos/ippoan/mcp-cf-workers/issues/28")) {
+        return Response.json({
+          number: 28, title: "[引継ぎ] cdp-relay 設計", state: "open",
+          labels: [], assignees: [],
+          html_url: "https://github.com/ippoan/mcp-cf-workers/issues/28",
+          updated_at: "2026-06-05T00:19:48Z",
+        });
+      }
+
+      return new Response(`not stubbed: ${url}`, { status: 500 });
+    });
+
+    const e = testEnv({ tagless: ["ippoan/relay-repo"] });
+    const req = new Request("http://localhost/releases");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, e, ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+
+    // cross-repo issue が relay-repo の card に出る
+    expect(html).toContain("ippoan/mcp-cf-workers#28");
+    expect(html).toContain("[引継ぎ] cdp-relay 設計");
+    expect(html).toContain("cross-repo");
+    // checkbox の pair が home repo を埋め込んでいる (close が mcp-cf-workers を叩く)
+    expect(html).toContain("main@c0ffee0:ippoan/mcp-cf-workers#28");
+  });
+
   // archived repo は GitHub API で issue close ができない (403 read-only) ため、
   // /releases から一切除外する。Refs ippoan/ci-dashboard#155
   // (ippoan/github-mcp-server-rs が monorepo 化で archive されたが Refs を


### PR DESCRIPTION
## 背景

あなたの指摘どおり、`mcp-cf-workers#28` には **merged PR が 7 本ある**（cdp-relay の PR #1〜#6, #34 がすべて本文に `Refs ippoan/mcp-cf-workers#28`）。しかし /releases に出ていなかった。先に「PR が無い」と誤って説明したことをお詫びします。

## 根本原因

`/releases` の `extractRefIssues` は、別 repo を指す **cross-repo ref**（`Refs <otherOwner>/<otherName>#N`）を「他 repo の issue 番号混入」防止のため**意図的に捨てて**いた。その結果:
- 実装した側（cdp-relay）の card にも出ない（cross-repo ref が drop される）
- issue の home（mcp-cf-workers）の card にも出ない（mcp-cf-workers 自身の commit/PR は #28 を参照していない）

→ 「実装は repo A・issue は repo B」の cross-repo handoff issue がどこにも surface しなかった。

## 修正（cross-repo 対応）

実装した側の repo の card に cross-repo issue を出し、**home repo に対して close** できるようにする:

- **`extractCrossRepoRefs`** — `currentRepo` と異なる `owner/name` の `Refs` を抽出（従来 drop していたもの）
- **`loadSyntheticBlock`** — commit / PR 本文から cross-repo ref を集め、**home repo の token** で issue を hydrate。`IssueRow.repo` にタグ付けして同じ card に表示
- **`renderIndexRow`** — cross-repo 行は checkbox を `<tag>:<owner>/<name>#<n>` でエンコードし、番号セルに repo を前置（`ippoan/mcp-cf-workers#28`）+ `cross-repo` マーカー
- **`release-close-batch`** — cross-repo pair を解釈し、**home repo に対して** comment+close（owner 別に token 解決。card repo の事前検証=400 は維持）

スコープは synthetic パス（cdp-relay 等の tagless repo がここを通る）。tag-compare パスは対象外（今回のケースは全て tagless repo の PR 由来のため）。

## 効果

- **cdp-relay の card に mcp-cf-workers#28 が出る** → チェックして close すると mcp-cf-workers#28 が閉じる

## テスト

- 新規: cross-repo issue が shipping repo の card に repo-tagged pair で出る（releases-page）
- 新規: cross-repo pair が home repo に対して close される（release-close-batch）
- **全 720 件 pass / `tsc --noEmit` green**

Refs ippoan/mcp-cf-workers#28

---
_Generated by [Claude Code](https://claude.ai/code/session_012D38bzLYVn6odJ9sNcyG1i)_