### PR TITLE
feat(release-wave): compat グラフに release 状態バッジ + 未適用マイグレーション表示 (Refs #172 #173 #249)

### DIFF
--- a/docs/release-wave-compatibility-kv.md
+++ b/docs/release-wave-compatibility-kv.md
@@ -274,6 +274,7 @@ frontend CI の `report-frontend-compat` action が staging 現 image を取り�
 |---|---|---|
 | `frontend::<repo>` | 90 日 (KV expirationTtl) | frontend が 90 日 deploy も test も走っていなければ `tested_against` は古い → 自然減衰 |
 | `backend::<repo>`  | なし (upsert)            | 最新のみで運用、deploy 都度上書き |
+| `pm::<repo>::<base_tag>` | 120 秒 (CI_STATUS) | pending migrations 算出の compare cache。head (default branch) が動くので短命。Refs #173 |
 
 `frontend::<repo>` は write の度に TTL がリセットされる (= putable で
 `expirationTtl: 90 * 24 * 3600` を毎回指定する)。
@@ -355,6 +356,36 @@ gate する」は、frontend → backend の依存マップ (consumed_by) が未
 現状は tested_against の履歴から consumer を逆算しているが、frontend 単独 wave では
 「どの backend の現 image と照合すべきか」を一意に決められない。consumed_by を
 `release-wave-targets.yaml` registry として導入する際に対応する。
+
+## compat グラフの表示拡張 (#172 / #173)
+
+compat 俯瞰グラフ / matrix の backend ノードには、突合 SHA に加えて以下を併記する。
+いずれも **read-only な表示拡張**で KV write 経路 (上記 shape) は変えない。
+
+### release 状態バッジ (#172)
+
+backend ノードに「現 image SHA が `v*` release tag 済みか」を明示する:
+
+- **tagged** — `backend::<repo>.current_tag` がある (= promote 済)
+- **untagged** — `current_tag` が null (= staging dev SHA のみ、まだ `v*` tag 無し)
+
+SHA→tag の track 自体は #197 (`current_tag` / `deploy_history[].tag`) で済んでおり、
+本件はその有無をバッジ化して「もう本番 tag が打たれたか」を一目で分かるようにするだけ。
+
+### 未適用マイグレーション (#173)
+
+backend ノード / matrix h3 に「次の `v*` release で適用される未適用マイグレーション」
+件数を併記する (`pending migrations: N`)。**git ベースで都度算出** (案 1、DB 接続不要):
+
+- base = repo の最新 stable `v*` tag (無ければ `unknown` = 非表示)
+- head = default branch (main)
+- 集合 = GitHub compare `base...head` の `files[]` で `status==="added"` かつ
+  `^migrations/<name>.sql` に一致するもの
+
+算出は `src/release-wave/pending-migrations.ts`。GitHub 依存なので **fail-soft**
+(token 解決不能 / API error 時は migration 行を出さずページ描画は続行)。compare
+結果は `pm::<repo>::<base_tag>` で 120 秒 cache (TTL 表参照)。算出対象は Cloud Run
+backend (= `backend::` を持ち `traffic::` を持たない repo = migrate job を持つ側)。
 
 ## 後続実装 issue
 

--- a/src/mcp/tools/release-wave.ts
+++ b/src/mcp/tools/release-wave.ts
@@ -1,12 +1,14 @@
 /**
- * Release Wave 機構の MCP tools (7 個)。
+ * Release Wave 機構の MCP tools (9 個)。
  *
  * 設計の親 issue: ippoan/ci-dashboard#137
  *
  * 注: stage phase 撤去 (Refs ippoan/ci-workflows#96①) に伴い
  * `release_wave_start` / `release_wave_stage` tool は削除した。wave は Pending
  * releases / flip-all 経路で driven され、本 tool 群は status/approve/flip/
- * rollback/abort/fail/contract_applied の 7 個。
+ * rollback/abort/fail/contract_applied の 7 個 +
+ * operator が flip を起動する pending_flip / pending_flip_all の 2 個 (Refs #249)
+ * = 計 9 個。
  * (`release_wave_fail` = stuck wave を terminal failed に落とす force-clear 経路)
  *
  * 各 tool は ReleaseWaveHub DO の RPC を 1:1 で呼び出す薄い wrapper。

--- a/src/release-wave/page.ts
+++ b/src/release-wave/page.ts
@@ -30,6 +30,10 @@ import {
   type UnifiedPending,
 } from "./pending-release";
 import { getTrafficForRepos, type TrafficRecord } from "./traffic";
+import {
+  computePendingMigrationsForRepos,
+  type RepoPendingMigrations,
+} from "./pending-migrations";
 
 // ----------------------------------------------------------------------------
 // Small HTML helpers
@@ -477,11 +481,23 @@ export async function handleReleaseWaveListPage(env: Env): Promise<Response> {
   // compat section の「Staged previews」内 ⚡ Flip all ボタンの出し分けに件数を使う
   // ため、compatSection より先に算出する。
   const unifiedPending = computeUnifiedPending(trafficByRepo, pendingReleases);
+
+  // 未適用マイグレーションは Cloud Run backend (= backend:: を持ち traffic:: 無し)
+  // についてだけ算出する (= migrate job を持つ repo。CF Worker は除外)。GitHub
+  // 依存なので fail-soft (computePendingMigrationsForRepos が空 Map を返す)。
+  // Refs #173。
+  const migrationRepos = [...backendRepos].filter((r) => !trafficByRepo.has(r));
+  const migrationsByRepo = await computePendingMigrationsForRepos(
+    env,
+    migrationRepos,
+  );
+
   const compatSection = renderGlobalCompatibilitySection(
     globalCompat,
     buildActiveWaveInfo(waves),
     trafficByRepo,
     unifiedPending.length,
+    migrationsByRepo,
   );
   const pendingReleaseSection = renderPendingReleaseSection(
     unifiedPending,
@@ -674,8 +690,16 @@ export async function handleReleaseWaveDetailPage(
 
   // ---- Compatibility matrix (Refs #157 Phase A) ----
   // 上で算出した compat を再利用。null (未 bind / 失敗) 時は section を出さない。
+  // 未適用マイグレーション (Refs #173) は compat 上の backend repo について算出
+  // (GitHub 依存なので fail-soft)。
+  const migrationsByRepo = compat
+    ? await computePendingMigrationsForRepos(
+        env,
+        compat.backends.map((b) => b.backend_repo),
+      )
+    : new Map<string, RepoPendingMigrations>();
   const compatHtml = compat
-    ? renderCompatibilitySection(compat, w.wave_id)
+    ? renderCompatibilitySection(compat, w.wave_id, migrationsByRepo)
     : "";
 
   const rollbackSafetyHtml = w.rollback.safe
@@ -954,6 +978,7 @@ function renderGlobalCompatibilitySection(
   active?: ActiveWaveInfo,
   trafficByRepo?: Map<string, TrafficRecord>,
   pendingFlipCount = 0,
+  migrationsByRepo?: Map<string, RepoPendingMigrations>,
 ): string {
   if (!compat || compat.backends.length === 0) {
     return `
@@ -972,7 +997,7 @@ function renderGlobalCompatibilitySection(
     : compat.verified
     ? `<span class="ok"><strong>all consumers tested</strong></span>`
     : `<span class="err"><strong>some consumers untested</strong></span>`;
-  const svg = renderCompatibilitySvg(compat, active, trafficByRepo);
+  const svg = renderCompatibilitySvg(compat, active, trafficByRepo, migrationsByRepo);
   const body = svg
     ? svg
     : `<p class="meta">backend record はあるが、まだどの frontend も test 履歴を
@@ -1120,9 +1145,50 @@ function renderActiveWaveOverlay(
  * wave 内 backend の現 image に対する既 deploy frontend の突合 matrix を描画する。
  * 緑 (tested) / 赤 (untested) を highlight する。read-only / 非 block。
  */
+/**
+ * backend ノードの「現 image SHA の release 状態」バッジ (Refs #172)。
+ *   tagged   — その SHA に `v*` release tag が付いている (promote 済)
+ *   untagged — staging dev SHA のみ (まだ `v*` tag 無し)
+ * tag→状態の track 自体は #197 (`backend::*.current_tag`) で済んでおり、ここでは
+ * その有無を明示バッジ化して「もう本番 tag が打たれたか」を一目で分かるようにする。
+ */
+function releaseStateBadge(tag: string | null | undefined): {
+  text: string;
+  cls: string;
+} {
+  return tag
+    ? { text: "tagged", cls: "ok" }
+    : { text: "untagged", cls: "meta" };
+}
+
+/**
+ * backend repo の「未適用マイグレーション」サマリ (Refs #173)。
+ * status="unknown" (baseline tag 無し / 算出不能) は表示対象外 (null)。
+ */
+function migrationSummary(
+  pm: RepoPendingMigrations | undefined,
+): { text: string; cls: string; title: string } | null {
+  if (!pm || pm.status === "unknown") return null;
+  if (pm.status === "pending") {
+    return {
+      text: `pending migrations: ${pm.count} ⚠`,
+      cls: "err",
+      title:
+        `${pm.base_tag} → ${pm.head} で追加されるマイグレーション (${pm.count} 件):\n` +
+        pm.files.map((f) => `  - ${f}`).join("\n"),
+    };
+  }
+  return {
+    text: "pending migrations: 0 ✅ migrate は no-op",
+    cls: "ok",
+    title: `${pm.base_tag} 以降 migrations/ への追加無し (migrate は no-op = 安全)`,
+  };
+}
+
 function renderCompatibilitySection(
   compat: WaveCompatibility,
   wave_id: string,
+  migrationsByRepo?: Map<string, RepoPendingMigrations>,
 ): string {
   if (compat.backends.length === 0) {
     return `
@@ -1189,10 +1255,17 @@ function renderCompatibilitySection(
                 </tr>`;
               })
               .join("");
+      const relBadge = releaseStateBadge(b.current_tag);
+      const mig = migrationSummary(migrationsByRepo?.get(b.backend_repo));
+      const migLine = mig
+        ? `<div class="${mig.cls}" style="margin:2px 0 6px" title="${escapeHtml(mig.title)}">${escapeHtml(mig.text)}</div>`
+        : "";
       return `
       <h3>${escapeHtml(b.backend_repo)}
         <span class="meta">${b.current_tag ? `${escapeHtml(b.current_tag)} · ` : ""}@ ${escapeHtml(b.current_image ?? "—")}</span>
+        <span class="${relBadge.cls}">(${relBadge.text})</span>
       </h3>
+      ${migLine}
       <table>
         <thead>
           <tr>
@@ -1217,7 +1290,7 @@ function renderCompatibilitySection(
         matrix が自動更新される。edge / node に hover すると過去 test 履歴が出る。
         Refs <a href="https://github.com/ippoan/ci-dashboard/issues/157">#157</a>.`,
       )}</h2>
-      ${renderCompatibilitySvg(compat)}
+      ${renderCompatibilitySvg(compat, undefined, undefined, migrationsByRepo)}
       ${retestAllBlock}
       ${blocks}
     </div>`;
@@ -1269,6 +1342,7 @@ function renderCompatibilitySvg(
   compat: WaveCompatibility,
   active?: ActiveWaveInfo,
   trafficByRepo?: Map<string, TrafficRecord>,
+  migrationsByRepo?: Map<string, RepoPendingMigrations>,
 ): string {
   type Edge = {
     backend: string;
@@ -1413,15 +1487,31 @@ function renderCompatibilitySvg(
     .map((repo) => {
       const img = backendImage.get(repo) ?? "—";
       const tag = backendTag.get(repo) ?? null;
-      // line2: git tag があれば "<tag> · @ <sha>"、無ければ従来の "@ <sha>"。Refs #197。
-      const line2 = tag ? `${tag} · @ ${shortSha(img)}` : `@ ${shortSha(img)}`;
+      // line2: tag があれば "<tag> · @<sha>"、無ければ "@<sha> · untagged"。
+      // release 状態 (tagged/untagged) を明示する (Refs #172、track 自体は #197)。
+      const line2 = tag
+        ? `${tag} · @${shortSha(img)}`
+        : `@${shortSha(img)} · untagged`;
+      // line3: 未適用マイグレーション (Refs #173)。算出不能 (unknown) なら出さない。
+      const pm = migrationsByRepo?.get(repo);
+      const mig = migrationSummary(pm);
+      const line3 =
+        pm && pm.status === "pending"
+          ? `migrations: ${pm.count} ⚠`
+          : pm && pm.status === "none"
+          ? "migrations: 0 (no-op)"
+          : undefined;
+      const relState = tag ? `\nrelease: tagged (${tag})` : `\nrelease: untagged`;
+      const migTitle = mig ? `\n${mig.title}` : "";
       return node(
         leftX,
         bY(repo),
         repo,
         line2,
         BLUE,
-        `${repo}\ncurrent image: ${img ?? "—"}${tag ? `\ncurrent tag: ${tag}` : ""}`,
+        `${repo}\ncurrent image: ${img ?? "—"}${relState}${migTitle}`,
+        undefined,
+        line3,
       );
     })
     .join("");

--- a/src/release-wave/pending-migrations.ts
+++ b/src/release-wave/pending-migrations.ts
@@ -1,0 +1,168 @@
+/**
+ * Pending migrations preview (Refs ippoan/ci-dashboard#173).
+ *
+ * release 前に「次の `v*` release で本番 DB に適用される未適用マイグレーション」が
+ * 何件あるかを **git ベース**で算出する。定義 = 対象 backend repo の **最新 stable
+ * `v*` tag 以降に `migrations/` 配下へ追加された `.sql` ファイル** (= 次 release の
+ * migrate job が適用する集合)。DB 接続不要 (GitHub compare API のみ、案 1)。
+ *
+ *   base = 最新 stable `v*` tag (無ければ status="unknown": baseline 無しで算出不能)
+ *   head = repo の default branch (main)
+ *   集合 = compare base...head の files[] から status==="added" かつ
+ *          `migrations/<name>.sql` に一致するもの
+ *
+ * GitHub call は cachedTags / cachedRepoMeta (release-cache) + 専用の短命 cached
+ * compare を使い、quota / latency を抑える。算出失敗 (token 無し / API error 等) は
+ * **fail-soft** で skip し、release-wave ページの描画は止めない。
+ *
+ * squash merge で commit SHA は変わるが migrations は file 単位なので
+ * compare の files[] (path 単位) で正確に拾える (issue #173 の注記)。
+ */
+
+import { githubApi, parseRepo, tokenForOrg } from "../github-api";
+import { cachedRepoMeta, cachedTags } from "../release-cache";
+import { parseStableSemver, sortSemverDesc } from "../release-helpers";
+import type { Env } from "../index";
+
+/** 算出結果の状態。 */
+export type PendingMigrationsStatus =
+  /** 1 件以上の未適用マイグレーションあり (= migrate が DB を変更する)。 */
+  | "pending"
+  /** baseline tag はあるが追加マイグレーション無し (= migrate は no-op で安全)。 */
+  | "none"
+  /** baseline (`v*` tag) が無い / 算出不能 (= 判断材料無し)。 */
+  | "unknown";
+
+/** 1 backend repo についての未適用マイグレーション算出結果。 */
+export interface RepoPendingMigrations {
+  /** "owner/name"。 */
+  repo: string;
+  /** baseline に使った最新 stable `v*` tag。無ければ null (status="unknown")。 */
+  base_tag: string | null;
+  /** 比較 head (default branch、通常 "main")。 */
+  head: string;
+  /** base_tag 以降に追加された migration ファイル名 (basename、昇順)。 */
+  files: string[];
+  count: number;
+  status: PendingMigrationsStatus;
+}
+
+/**
+ * repo ルートの `migrations/<name>.sql` に一致。rust-alc-api 等は repo ルートの
+ * `migrations/*.sql` を sqlx migrate が適用する。`docs/migrations/...` のような
+ * 別ディレクトリ配下を誤検出しないよう、先頭を `^migrations/` に固定する。
+ */
+const MIGRATION_FILE_RE = /^migrations\/[^/]+\.sql$/i;
+
+interface CompareFile {
+  filename: string;
+  status: string;
+}
+interface CompareWithFiles {
+  files?: CompareFile[];
+}
+
+const PM_PREFIX = "pm::";
+/** head (default branch) が動くので短命 cache に留める。 */
+const PM_TTL_SECONDS = 120;
+
+function pmKey(repo: string, base: string): string {
+  return `${PM_PREFIX}${repo}::${base}`;
+}
+
+/** 最新の stable `v*` tag を解決する (prerelease / 非 semver は除外)。無ければ null。 */
+async function latestStableTag(
+  token: string,
+  kv: KVNamespace | undefined,
+  owner: string,
+  name: string,
+): Promise<string | null> {
+  const tags = await cachedTags(token, kv, owner, name, 100);
+  const stable = tags
+    .map((t) => t.name)
+    .filter((n) => parseStableSemver(n) !== null);
+  return sortSemverDesc(stable)[0] ?? null;
+}
+
+/**
+ * 単一 repo の未適用マイグレーションを算出する。GitHub 例外は呼び出し側 (batch)
+ * の try/catch で握る前提でそのまま投げる。
+ */
+export async function computeRepoPendingMigrations(
+  token: string,
+  kv: KVNamespace | undefined,
+  repo: string,
+): Promise<RepoPendingMigrations> {
+  const { owner, repo: name } = parseRepo(repo);
+  const meta = await cachedRepoMeta(token, kv, owner, name);
+  const head = meta.default_branch || "main";
+
+  const base = await latestStableTag(token, kv, owner, name);
+  if (!base) {
+    // baseline 無し (= まだ一度も release tag が無い) → 算出不能。
+    return { repo, base_tag: null, head, files: [], count: 0, status: "unknown" };
+  }
+
+  // compare base...head の files[] を取る。head が動くので短命 cache。
+  const cacheKey = pmKey(repo, base);
+  let cmp = kv ? await kv.get<CompareWithFiles>(cacheKey, "json") : null;
+  if (!cmp) {
+    cmp = await githubApi<CompareWithFiles>(
+      token,
+      "GET",
+      `/repos/${owner}/${name}/compare/${encodeURIComponent(base)}...${encodeURIComponent(head)}`,
+    );
+    if (kv) {
+      await kv.put(cacheKey, JSON.stringify({ files: cmp.files ?? [] }), {
+        expirationTtl: PM_TTL_SECONDS,
+      });
+    }
+  }
+
+  const files = (cmp.files ?? [])
+    .filter((f) => f.status === "added" && MIGRATION_FILE_RE.test(f.filename))
+    .map((f) => f.filename.split("/").pop() as string)
+    .sort();
+
+  return {
+    repo,
+    base_tag: base,
+    head,
+    files,
+    count: files.length,
+    status: files.length > 0 ? "pending" : "none",
+  };
+}
+
+/**
+ * 複数 backend repo の未適用マイグレーションをまとめて算出する。
+ *
+ * token は org-agnostic (auth-worker の単一 user-scope token) なので 1 度だけ
+ * 解決して全 repo に流用する。token 解決失敗 (operator 未認証等) は空 Map を返し
+ * (= migration 行を一切出さない)、repo 個別の算出失敗も fail-soft で skip する。
+ * = release-wave ページが GitHub 依存で落ちないことを最優先にする。
+ */
+export async function computePendingMigrationsForRepos(
+  env: Env,
+  repos: string[],
+): Promise<Map<string, RepoPendingMigrations>> {
+  const out = new Map<string, RepoPendingMigrations>();
+  if (repos.length === 0) return out;
+
+  const kv = env.CI_STATUS;
+  let token: string;
+  try {
+    token = await tokenForOrg(env, parseRepo(repos[0] as string).owner);
+  } catch {
+    return out; // 未認証 / token 解決不能 → 何も出さない (fail-soft)
+  }
+
+  for (const repo of repos) {
+    try {
+      out.set(repo, await computeRepoPendingMigrations(token, kv, repo));
+    } catch {
+      // この repo は省略 (GitHub error / repo 無し等)。ページ描画は続行する。
+    }
+  }
+  return out;
+}

--- a/test/release-wave/page.test.ts
+++ b/test/release-wave/page.test.ts
@@ -1005,6 +1005,50 @@ describe("handleReleaseWaveDetailPage compatibility section", () => {
     expect(html).toContain("No backend deploy records");
   });
 
+  it("shows a 'tagged' release-state badge when backend has current_tag (Refs #172)", async () => {
+    const env = fakeEnv({
+      getReturn: { ok: true, data: makeWave() },
+      compatKv: memKv({
+        "backend::ippoan/rust-alc-api": {
+          schema_version: 2,
+          repo: "ippoan/rust-alc-api",
+          current_image: "3212fa882f95",
+          current_tag: "v1.43.0",
+          deployed_at: "2026-05-27T00:00:00Z",
+          deployed_by: "x",
+          wave_id: null,
+        },
+      }),
+    });
+    const html = await (
+      await handleReleaseWaveDetailPage(env, "w1")
+    ).text();
+    expect(html).toContain("v1.43.0");
+    expect(html).toContain("(tagged)");
+    expect(html).not.toContain("(untagged)");
+  });
+
+  it("shows an 'untagged' badge when backend has no current_tag (Refs #172)", async () => {
+    const env = fakeEnv({
+      getReturn: { ok: true, data: makeWave() },
+      compatKv: memKv({
+        "backend::ippoan/rust-alc-api": {
+          schema_version: 2,
+          repo: "ippoan/rust-alc-api",
+          current_image: "deadbeef0000",
+          current_tag: null,
+          deployed_at: "2026-05-27T00:00:00Z",
+          deployed_by: "x",
+          wave_id: null,
+        },
+      }),
+    });
+    const html = await (
+      await handleReleaseWaveDetailPage(env, "w1")
+    ).text();
+    expect(html).toContain("(untagged)");
+  });
+
   it("renders a red row for an untested frontend", async () => {
     const env = fakeEnv({
       getReturn: { ok: true, data: makeWave() },

--- a/test/release-wave/pending-migrations.test.ts
+++ b/test/release-wave/pending-migrations.test.ts
@@ -1,0 +1,137 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  computeRepoPendingMigrations,
+  type RepoPendingMigrations,
+} from "../../src/release-wave/pending-migrations";
+import { clearReleaseCache } from "../../src/release-cache";
+
+// computeRepoPendingMigrations は GitHub の 3 endpoint を順に叩く:
+//   GET /repos/{o}/{n}            (default branch)
+//   GET /repos/{o}/{n}/tags       (最新 stable v* tag)
+//   GET /repos/{o}/{n}/compare/.. (base...head の files[])
+// fetch を URL で振り分けて mock する (release-cache.test.ts と同じ流儀)。
+
+type FetchRoutes = {
+  meta?: unknown;
+  tags?: Array<{ name: string }>;
+  compareFiles?: Array<{ filename: string; status: string }>;
+};
+
+function mockGitHub(routes: FetchRoutes): { compareCalls: () => number } {
+  let compareCalls = 0;
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.includes("/compare/")) {
+      compareCalls++;
+      return Response.json({ files: routes.compareFiles ?? [] });
+    }
+    if (url.endsWith("/tags") || url.includes("/tags?")) {
+      return Response.json(
+        (routes.tags ?? []).map((t) => ({ name: t.name, commit: { sha: "x" } })),
+      );
+    }
+    // repo meta
+    return Response.json(routes.meta ?? { default_branch: "main" });
+  });
+  return { compareCalls: () => compareCalls };
+}
+
+describe("computeRepoPendingMigrations", () => {
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await clearReleaseCache(env.CI_STATUS);
+  });
+
+  it("status=pending: base_tag 以降に追加された migrations/*.sql を拾う", async () => {
+    mockGitHub({
+      tags: [{ name: "v0.0.74" }, { name: "v0.0.73" }, { name: "dev-12" }],
+      compareFiles: [
+        { filename: "migrations/112_alter_yyy.sql", status: "added" },
+        { filename: "migrations/111_add_xxx.sql", status: "added" },
+        { filename: "src/routes/foo.rs", status: "modified" },
+        { filename: "migrations/010_old.sql", status: "modified" }, // 既存変更は除外
+        { filename: "docs/migrations/notes.sql", status: "added" }, // migrations/ 直下のみ
+      ],
+    });
+
+    const pm = await computeRepoPendingMigrations(
+      "tok",
+      env.CI_STATUS,
+      "ippoan/repo-a",
+    );
+
+    const expected: RepoPendingMigrations = {
+      repo: "ippoan/repo-a",
+      base_tag: "v0.0.74",
+      head: "main",
+      // basename 昇順
+      files: ["111_add_xxx.sql", "112_alter_yyy.sql"],
+      count: 2,
+      status: "pending",
+    };
+    expect(pm).toEqual(expected);
+  });
+
+  it("status=none: 追加マイグレーション無し → migrate は no-op", async () => {
+    mockGitHub({
+      tags: [{ name: "v1.2.3" }],
+      compareFiles: [{ filename: "src/index.ts", status: "modified" }],
+    });
+
+    const pm = await computeRepoPendingMigrations(
+      "tok",
+      env.CI_STATUS,
+      "ippoan/repo-b",
+    );
+    expect(pm.status).toBe("none");
+    expect(pm.count).toBe(0);
+    expect(pm.files).toEqual([]);
+    expect(pm.base_tag).toBe("v1.2.3");
+  });
+
+  it("status=unknown: stable v* tag が無い (= baseline 無し、compare も叩かない)", async () => {
+    const m = mockGitHub({
+      tags: [{ name: "dev-3" }, { name: "v1.0.0-rc.1" }], // どちらも stable でない
+      compareFiles: [{ filename: "migrations/001_x.sql", status: "added" }],
+    });
+
+    const pm = await computeRepoPendingMigrations(
+      "tok",
+      env.CI_STATUS,
+      "ippoan/repo-c",
+    );
+    expect(pm.status).toBe("unknown");
+    expect(pm.base_tag).toBeNull();
+    expect(pm.count).toBe(0);
+    expect(m.compareCalls()).toBe(0); // baseline 無し → compare をそもそも呼ばない
+  });
+
+  it("default branch を repo meta から拾う (main 以外でも head に反映)", async () => {
+    mockGitHub({
+      meta: { default_branch: "trunk" },
+      tags: [{ name: "v2.0.0" }],
+      compareFiles: [{ filename: "migrations/050_z.sql", status: "added" }],
+    });
+
+    const pm = await computeRepoPendingMigrations(
+      "tok",
+      env.CI_STATUS,
+      "ippoan/repo-d",
+    );
+    expect(pm.head).toBe("trunk");
+    expect(pm.status).toBe("pending");
+    expect(pm.files).toEqual(["050_z.sql"]);
+  });
+
+  it("compare 結果は短命 cache される (2 回目は GitHub を叩かない)", async () => {
+    const m = mockGitHub({
+      tags: [{ name: "v0.1.0" }],
+      compareFiles: [{ filename: "migrations/001_a.sql", status: "added" }],
+    });
+
+    await computeRepoPendingMigrations("tok", env.CI_STATUS, "ippoan/repo-e");
+    await computeRepoPendingMigrations("tok", env.CI_STATUS, "ippoan/repo-e");
+    expect(m.compareCalls()).toBe(1);
+  });
+});


### PR DESCRIPTION
## 概要

open issue #249 / #182 / #173 / #172 を順に対応した。調査の結果 **#249 と #182 は既に main で実装済み**だったため、本 PR の実質的な新規実装は **#173** と **#172 の表示拡張**。

### #249 — operator が flip を起動できる MCP tool (Refs #249)

`release_wave_pending_flip` / `release_wave_pending_flip_all` tool と core (`pendingFlipCore` / `pendingFlipAllCore`) は **既に main に実装済み**で、`registers exactly 9 tools` テストも green だった。残っていた stale なヘッダコメント (「7 個」) を **9 個**に修正しただけ。

### #182 — no-traffic release 一覧 + Flip ボタン (Refs #182)

`pending-release.ts` (KV) / `/webhooks/release-wave/pending-release` / Pending releases セクション + Flip ボタン / flip API はすべて **main で実装済み**。本 PR での変更なし。

### #173 — release 前チェックに未適用マイグレーション件数を表示 (Refs #173)

案 1 (git ベース、DB 接続不要) を実装:

- 新規 `src/release-wave/pending-migrations.ts`
  - base = repo の最新 stable `v*` tag (無ければ `unknown` = 非表示)
  - head = default branch
  - GitHub compare `base...head` の `files[]` から `status==="added"` かつ `^migrations/<name>.sql` を抽出
  - 既存 `cachedTags` / `cachedRepoMeta` + 専用短命 compare cache (`pm::<repo>::<tag>`, 120s) を利用
  - **fail-soft**: token 解決不能 / API error 時は migration 行を出さずページ描画を続行
- compat グラフ backend ノード (`migrations: N ⚠` / `migrations: 0 (no-op)`) と matrix h3 (`pending migrations: N`) に併記
- 算出対象は Cloud Run backend (`backend::` あり + `traffic::` 無し = migrate job を持つ側)

### #172 — 突合 SHA が release tag 済みかを表示 (Refs #172)

SHA→tag の track 自体は **#197 (`current_tag` / `deploy_history[].tag`) で実装済み**。本 PR はその有無をバッジ化:

- backend ノード line2: `<tag> · @<sha>` (tagged) / `@<sha> · untagged`
- matrix h3 / hover title: `(tagged)` / `(untagged)` バッジ
- comment にある「協調 tag-release / 二重 release 防止」は別 Phase なので本 PR の scope 外

## テスト

- `test/release-wave/pending-migrations.test.ts` 新規 5 件 (pending / none / unknown / default branch / cache)
- `test/release-wave/page.test.ts` に #172 バッジ 2 件追加
- `npx tsc --noEmit` クリーン / `vitest run` **727 passed**

## 補足

- 本ブランチには本 PR 着手前から **#288–#291 (releases ページの cross-repo refs、別件) の未マージ commit が 4 つ**載っており、PR diff に含まれます (指定ブランチ `claude/funny-brahmagupta-PAMLg` 上で作業したため)。本 PR の新規分は末尾 2 commit です。

Refs #172 #173 #249 #182 #197 #137

---
_Generated by [Claude Code](https://claude.ai/code/session_011eKPesVb1WFEJJ9ux3KVYb)_