### PR TITLE
feat(issues): flag CI fixture issues with a 🔒 保全 badge

### DIFF
--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -374,6 +374,32 @@ function renderHtml(
       transition: opacity 0.15s, background 0.15s;
     }
     .cc-launch:hover { opacity: 1; background: #1f6feb33; }
+    /* CI fixture rows: amber "do-not-touch" affordance. The 🔒 badge + dimmed
+       row + static lock in the launch cell signal that closing/deleting the
+       issue breaks worktree-naming-guard tests (see isFixtureIssue). */
+    .fixture-badge {
+      display: inline-block;
+      font-size: 11px;
+      padding: 1px 8px;
+      border-radius: 10px;
+      background: #d2992222;
+      color: #e3b341;
+      border: 1px solid #d2992288;
+      margin-right: 6px;
+      white-space: nowrap;
+      vertical-align: middle;
+    }
+    tr.fixture { background: #1b1813; }
+    tr.fixture:hover { background: #221d14; }
+    tr.fixture td.title a { color: #8b949e; }
+    .cc-launch-disabled {
+      display: inline-block;
+      font-size: 14px;
+      line-height: 1;
+      padding: 4px 6px;
+      opacity: 0.5;
+      cursor: default;
+    }
     .labels { margin-top: 4px; }
     .label {
       display: inline-block;
@@ -491,10 +517,11 @@ function renderProjectRow(
     ? `<div class="labels">${i.labels.map((l) =>
         `<span class="label">${escapeHtml(l)}</span>`).join("")}</div>`
     : "";
-  return `<tr>
+  const trClass = isFixtureIssue(i) ? ' class="fixture"' : "";
+  return `<tr${trClass}>
     <td class="num"><a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">#${i.number}</a></td>
     <td class="repo"><a href="https://github.com/${escapeHtml(i.repo)}/issues" target="_blank" rel="noopener">${escapeHtml(i.repo)}</a></td>
-    <td class="title"><a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">${escapeHtml(i.title)}</a><div class="labels">${chips}</div>${labelChips}${renderPrChips(i, prMap)}</td>
+    <td class="title">${renderFixtureBadge(i)}<a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">${escapeHtml(i.title)}</a><div class="labels">${chips}</div>${labelChips}${renderPrChips(i, prMap)}</td>
     <td class="author">@${escapeHtml(i.author)}</td>
     <td class="updated">${escapeHtml(i.updated_at.slice(0, 10))}</td>
     ${renderLaunchCell(i)}
@@ -525,9 +552,10 @@ function renderRow(
     ? `<div class="labels">${i.labels.map((l) =>
         `<span class="label">${escapeHtml(l)}</span>`).join("")}</div>`
     : "";
-  return `<tr>
+  const trClass = isFixtureIssue(i) ? ' class="fixture"' : "";
+  return `<tr${trClass}>
     <td class="num"><a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">#${i.number}</a></td>
-    <td class="title"><a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">${escapeHtml(i.title)}</a>${labelChips}${renderPrChips(i, prMap)}</td>
+    <td class="title">${renderFixtureBadge(i)}<a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">${escapeHtml(i.title)}</a>${labelChips}${renderPrChips(i, prMap)}</td>
     <td class="author">@${escapeHtml(i.author)}</td>
     <td class="updated">${escapeHtml(i.updated_at.slice(0, 10))}</td>
     ${renderLaunchCell(i)}
@@ -558,7 +586,30 @@ function renderPrChips(
   return `<div class="pr-chips">${chips}</div>`;
 }
 
+// CI fixture issues (e.g. ippoan/claude-hooks#1, #2) exist only to satisfy
+// worktree-naming-guard test assertions — their body literally says "Do not
+// close. Do not delete." and the test breaks if they're closed/deleted/reopened.
+// They are NOT work items, so the dashboard must make that obvious: flag the
+// row with a 🔒 badge and suppress the 🚀 launch button (launching a Claude
+// session on a fixture risks acting on — i.e. closing — it). Detection is by
+// the `[CI fixture]` title prefix, which both fixtures already carry, so no
+// GitHub-side label change is required. `OrgIssue` doesn't cache the body, so
+// the title prefix is the only marker available at render time anyway.
+export function isFixtureIssue(i: { title: string }): boolean {
+  return /^\s*\[CI fixture\]/i.test(i.title);
+}
+
+function renderFixtureBadge(i: OrgIssue): string {
+  if (!isFixtureIssue(i)) return "";
+  return `<span class="fixture-badge" title="CI fixture — close / delete / reopen しないこと (テストの前提)">🔒 保全</span>`;
+}
+
 function renderLaunchCell(i: OrgIssue): string {
+  // Fixtures aren't actionable — replace the launch button with a static lock
+  // so nobody fires a session that might close the issue.
+  if (isFixtureIssue(i)) {
+    return `<td class="launch"><span class="cc-launch-disabled" title="CI fixture — Claude Code 起動の対象外">🔒</span></td>`;
+  }
   const url = buildClaudeCodeLaunchUrl(i.repo, i.number);
   return `<td class="launch"><a class="cc-launch" href="${escapeHtml(url)}" target="_blank" rel="noopener" title="Claude Code で起動 (${escapeHtml(i.repo)}#${i.number})">🚀</a></td>`;
 }

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -2,7 +2,7 @@ import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import worker from "../src/index";
 import type { Env } from "../src/index";
-import { escapeHtml, buildClaudeCodeLaunchUrl, CLAUDE_CODE_LAUNCH_REPOS } from "../src/issues-page";
+import { escapeHtml, buildClaudeCodeLaunchUrl, CLAUDE_CODE_LAUNCH_REPOS, isFixtureIssue } from "../src/issues-page";
 
 function testEnv(): Env {
   return {
@@ -827,6 +827,85 @@ describe("GET /issues — Related-PR chips", () => {
     expect(res.status).toBe(200);
     const html = await res.text();
     expect(html).toContain("Related-PR links unavailable");
+  });
+});
+
+describe("isFixtureIssue()", () => {
+  it("matches the `[CI fixture]` title prefix (case-insensitive, leading space tolerant)", () => {
+    expect(isFixtureIssue({ title: "[CI fixture] Open issue used by tests" })).toBe(true);
+    expect(isFixtureIssue({ title: "  [ci FIXTURE] whatever" })).toBe(true);
+  });
+  it("does not match ordinary issue titles", () => {
+    expect(isFixtureIssue({ title: "Add feature X" })).toBe(false);
+    expect(isFixtureIssue({ title: "fix: [CI fixture] mentioned mid-title" })).toBe(false);
+  });
+});
+
+describe("GET /issues — CI fixture rows", () => {
+  beforeEach(async () => {
+    await env.CI_STATUS.delete("issues-page:project-map");
+    await env.CI_STATUS.delete("issues-page:pr-map:v2");
+    await env.CI_STATUS.delete("issues:watermark");
+    for (const prefix of ["issue:", "project:"]) {
+      let cursor: string | undefined;
+      do {
+        const page = await env.CI_STATUS.list({ prefix, cursor });
+        await Promise.all(page.keys.map((k) => env.CI_STATUS.delete(k.name)));
+        cursor = page.list_complete ? undefined : page.cursor;
+      } while (cursor);
+    }
+  });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("flags a fixture issue with a 🔒 保全 badge and suppresses its launch button", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (req, init) => {
+      const url = typeof req === "string" ? req : (req as Request).url;
+      const body = (init?.body as string | undefined) ?? "";
+      if (url.includes("/graphql")) {
+        if (body.includes("projectsV2(first:")) {
+          return Response.json({
+            data: { repositoryOwner: { projectsV2: { nodes: [] } } },
+          });
+        }
+        return Response.json({ data: { repositoryOwner: null } });
+      }
+      const decoded = decodeURIComponent(url);
+      if (decoded.includes("is:pr")) {
+        return Response.json({ total_count: 0, incomplete_results: false, items: [] });
+      }
+      // yhonda repo: filter call returns the fixture issue; main org call is
+      // empty. (The repo string here mirrors the real claude-hooks fixture.)
+      if (decoded.includes("repo:yhonda-ohishi/claude-skills")) {
+        return Response.json({
+          total_count: 1, incomplete_results: false,
+          items: [{
+            number: 2,
+            title: "[CI fixture] Open issue used by tests/test-worktree-naming-guard.sh (T1, T5)",
+            state: "open",
+            user: { login: "yhonda-ohishi" },
+            labels: [], assignees: [], comments: 0,
+            created_at: "2026-05-30T00:00:00Z", updated_at: "2026-05-30T00:00:00Z",
+            html_url: "https://github.com/yhonda-ohishi/claude-hooks/issues/2",
+            repository_url: "https://api.github.com/repos/yhonda-ohishi/claude-hooks",
+          }],
+        });
+      }
+      return Response.json({ total_count: 0, incomplete_results: false, items: [] });
+    });
+    const req = new Request("http://localhost/issues");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // Badge present, row dimmed, and the launch cell is a static lock — not a
+    // clickable cc-launch anchor.
+    expect(html).toContain("🔒 保全");
+    expect(html).toContain('class="fixture-badge"');
+    expect(html).toContain('<tr class="fixture">');
+    expect(html).toContain('class="cc-launch-disabled"');
+    expect(html).not.toContain('<a class="cc-launch"');
   });
 });
 


### PR DESCRIPTION
## 目的

`/issues` ページに並ぶ **CI fixture issue**（ippoan/claude-hooks の `[CI fixture] ... Do not close. Do not delete.`、例: claude-hooks#2 は open）を、通常の作業 issue と区別して「触るな」と一目で分かるように表示する。これらは worktree-naming-guard のテスト前提を満たすためだけに存在し、close / delete / reopen するとテストが落ちる。

## 変更

- title セルに 🔒「保全」バッジ + tooltip（`close / delete / reopen しないこと`）
- 該当行を淡くトーンダウン（amber 系）
- 🚀 Claude Code 起動ボタンを抑止し 🔒 に置換（fixture へのセッション起動 = 誤 close risk のため）

判定は `OrgIssue` が body を cache しないため **title の `[CI fixture]` prefix** で行う（#1・#2 とも保持済み → GitHub 側の label 追加は不要）。`isFixtureIssue()` を export して unit test 化。

## テスト

- `isFixtureIssue()` の prefix 判定（大小文字・先頭空白・mid-title 誤検出回避）
- `/issues` 描画で 🔒 保全バッジ + `tr.fixture` + `cc-launch-disabled` が出て、fixture 行には `cc-launch` anchor が出ないこと

`npx tsc --noEmit` / `npx vitest run test/issues-page.test.ts`（23 passed）green。

Refs #293

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ji6yowAcwZbhTyC2cyNeSr)_