### PR TITLE
fix(issues): track ippoan/claude-hooks instead of migrated yhonda-ohishi/claude-hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,5 +42,5 @@ PR テンプレートは `.github/pull_request_template.md` で `Refs` を強制
 ## 関連
 
 - 規約: yhonda-ohishi/claude-skills の対応 issue (本 PR 後に作成)
-- 実装: yhonda-ohishi/claude-hooks の PreToolUse hook (本 PR 後に作成)
+- 実装: ippoan/claude-hooks の PreToolUse hook (本 PR 後に作成)
 - 詳細: [`docs/branch-issue-linking.md`](docs/branch-issue-linking.md)

--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -17,7 +17,9 @@ const ORGS = ["ippoan", "ohishi-exp"];
 // yhonda-ohishi org has many old personal repos (2023-2024 lineworks_bot /
 // nginx / authjs-nuxt-test etc.) that would create noise. Only surface the
 // active claude-tooling repos by filtering on `repo:` qualifiers.
-const YHONDA_REPOS = ["yhonda-ohishi/claude-skills", "yhonda-ohishi/claude-hooks"];
+// NB: claude-hooks has migrated to ippoan/claude-hooks, which is already
+// covered by the full ORGS scan, so it is no longer listed here.
+const YHONDA_REPOS = ["yhonda-ohishi/claude-skills"];
 
 // Orgs scanned for Projects v2 (used by `fetchProjectIssueMap`). yhonda-ohishi
 // is included so the user's claude-tooling repos can still be pinned to a
@@ -40,7 +42,7 @@ export const CLAUDE_CODE_LAUNCH_REPOS = [
   "ippoan/secrets-inventory",
   "ippoan/secrets-inventory-gcp",
   "yhonda-ohishi/claude-skills",
-  "yhonda-ohishi/claude-hooks",
+  "ippoan/claude-hooks",
 ];
 
 // Build a claude.ai/code launch URL pre-attached with the standard repo set

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -23,7 +23,6 @@ const ALL_REPOS = [
   "ippoan/release-wave-gcp",
   "ippoan/nuxt-notify",
   "ippoan/rust-alc-api",
-  "yhonda-ohishi/claude-hooks",
   "ippoan/claude-md",
   "ippoan/auth-worker",
   "ippoan/ci-dashboard",

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -340,18 +340,19 @@ describe("GET /issues", () => {
     expect(main!).toContain("org:ohishi-exp");
     expect(main!).not.toContain("repo:yhonda-ohishi/claude-");
 
-    // yhonda-ohishi call: repo: qualifiers (OR) for the two active claude
-    // tooling repos only — and CRUCIALLY no `org:yhonda-ohishi`. GitHub Search
-    // silently drops `repo:` when combined with `org:` (it widens the result
-    // to the entire org), so fetchOrgIssues must omit `org:` whenever the
-    // caller-supplied query contains a `repo:` qualifier. Regression guard
+    // yhonda-ohishi call: repo: qualifiers (OR) for the active claude tooling
+    // repo only (claude-hooks has migrated to ippoan/claude-hooks and is now
+    // covered by the org:ippoan scan) — and CRUCIALLY no `org:yhonda-ohishi`.
+    // GitHub Search silently drops `repo:` when combined with `org:` (it widens
+    // the result to the entire org), so fetchOrgIssues must omit `org:` whenever
+    // the caller-supplied query contains a `repo:` qualifier. Regression guard
     // for issue #53.
     const yhonda = issueDecoded.find((d) => d.includes("repo:yhonda-ohishi/claude-skills"));
     expect(yhonda).toBeDefined();
     expect(yhonda!).toContain("is:issue");
     expect(yhonda!).toContain("state:open");
     expect(yhonda!).toContain("repo:yhonda-ohishi/claude-skills");
-    expect(yhonda!).toContain("repo:yhonda-ohishi/claude-hooks");
+    expect(yhonda!).not.toContain("repo:yhonda-ohishi/claude-hooks");
     expect(yhonda!).not.toContain("org:yhonda-ohishi");
 
     // Every call must exclude archived repos so old projects (e.g.
@@ -873,9 +874,10 @@ describe("GET /issues — CI fixture rows", () => {
       if (decoded.includes("is:pr")) {
         return Response.json({ total_count: 0, incomplete_results: false, items: [] });
       }
-      // yhonda repo: filter call returns the fixture issue; main org call is
-      // empty. (The repo string here mirrors the real claude-hooks fixture.)
-      if (decoded.includes("repo:yhonda-ohishi/claude-skills")) {
+      // main org:ippoan call returns the fixture issue; the yhonda repo: call is
+      // empty. The CI fixture now lives in ippoan/claude-hooks (migrated from
+      // yhonda-ohishi/claude-hooks), so it surfaces via the org:ippoan scan.
+      if (decoded.includes("org:ippoan")) {
         return Response.json({
           total_count: 1, incomplete_results: false,
           items: [{
@@ -885,8 +887,8 @@ describe("GET /issues — CI fixture rows", () => {
             user: { login: "yhonda-ohishi" },
             labels: [], assignees: [], comments: 0,
             created_at: "2026-05-30T00:00:00Z", updated_at: "2026-05-30T00:00:00Z",
-            html_url: "https://github.com/yhonda-ohishi/claude-hooks/issues/2",
-            repository_url: "https://api.github.com/repos/yhonda-ohishi/claude-hooks",
+            html_url: "https://github.com/ippoan/claude-hooks/issues/2",
+            repository_url: "https://api.github.com/repos/ippoan/claude-hooks",
           }],
         });
       }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -124,7 +124,7 @@
         // cut release tags: dashboard はこれらの PR merge を mini-release 扱いし、
         // merged PR の `Refs #N` を逆引きして /releases synthetic block + banner に
         // 出す (= stable tag 前でも早期 close 可能)。未掲載 repo は tag-driven flow。
-        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs,ippoan/cc-relay,ippoan/mcp-cf-workers,yhonda-ohishi/claude-hooks,ippoan/claude-skills,ippoan/ci-workflows,ippoan/ref-files-worker,ippoan/claude-hooks,ippoan/cdp-relay"
+        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs,ippoan/cc-relay,ippoan/mcp-cf-workers,ippoan/claude-skills,ippoan/ci-workflows,ippoan/ref-files-worker,ippoan/claude-hooks,ippoan/cdp-relay"
       },
       "kv_namespaces": [
         {


### PR DESCRIPTION
## 概要

`/issues` に **`yhonda-ohishi/claude-hooks(1)`** が表示されていた。claude-hooks は `ippoan/claude-hooks` に移行済なので、ci-dashboard の追跡対象を ippoan 側に統一する。

`ippoan` は `ORGS` の全 repo フルスキャン対象なので、`YHONDA_REPOS`（yhonda-ohishi org のノイズ回避で特定 repo だけ拾うリスト）から `yhonda-ohishi/claude-hooks` を**除去するだけ**で `ippoan/claude-hooks` が自動で被覆される。

## 変更

- `src/issues-page.ts`
  - `YHONDA_REPOS` から `yhonda-ohishi/claude-hooks` を除去（→ org:ippoan スキャンで被覆）
  - `CLAUDE_CODE_LAUNCH_REPOS` の `yhonda-ohishi/claude-hooks` → `ippoan/claude-hooks`
- `src/launch.ts` `ALL_REPOS` の `yhonda-ohishi/claude-hooks` を除去（`ippoan/claude-hooks` は既存で重複していた）
- `wrangler.jsonc` `TAGLESS_REPOS` の `yhonda-ohishi/claude-hooks` を除去（同上、重複排除）
- `test/issues-page.test.ts` の fixture mock / query 期待値を実態に更新（CI fixture は `ippoan/claude-hooks#2`、org:ippoan 取得経路に移動）
- `CLAUDE.md` の「関連」prose の repo 参照も ippoan に更新

## 検証

- `npx tsc --noEmit` OK
- `npx vitest run` → **730 passed**（@ippoan/* は GitHub Packages 401 のため local copy に `file:` フォールバックして install、package.json/lock は commit に含めず復元）

## scope

`yhonda-ohishi/claude-skills` も同様に移行済（`ippoan/claude-skills`）だが、本 PR の scope は claude-hooks のみ。claude-skills は別途。

Refs #295

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjqGj6WpzoLd572WcTX3CM)_