### PR TITLE
feat(tagless): add ippoan/release-wave-gcp to TAGLESS_REPOS

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -124,7 +124,7 @@
         // cut release tags: dashboard はこれらの PR merge を mini-release 扱いし、
         // merged PR の `Refs #N` を逆引きして /releases synthetic block + banner に
         // 出す (= stable tag 前でも早期 close 可能)。未掲載 repo は tag-driven flow。
-        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs,ippoan/cc-relay,ippoan/mcp-cf-workers,ippoan/claude-skills,ippoan/ci-workflows,ippoan/ref-files-worker,ippoan/claude-hooks,ippoan/cdp-relay"
+        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs,ippoan/cc-relay,ippoan/mcp-cf-workers,ippoan/claude-skills,ippoan/ci-workflows,ippoan/ref-files-worker,ippoan/claude-hooks,ippoan/cdp-relay,ippoan/release-wave-gcp"
       },
       "kv_namespaces": [
         {


### PR DESCRIPTION
## 問題

`https://ci-dashboard.ippoan.org/releases` に `ippoan/release-wave-gcp` が出ない、merged PR (#6 / #8) の `Refs #5` / `Refs #7` が dashboard 側で逆引きされない、という症状があった。

原因: `wrangler.jsonc` の `TAGLESS_REPOS` に `ippoan/release-wave-gcp` が未登録だった。

release-wave-gcp は `v*` tag を打たない proxy 運用 (staging = 実運用、`secrets-inventory-gcp` と同じパターン) なので、tag 駆動の release flow では `/releases` に出てこない。`TAGLESS_REPOS` に入れることで PR merge イベントを mini-release として扱い、`Refs #N` を逆引きして synthetic block + banner に出すのが正しい配線。

参考モデルの `secrets-inventory-gcp` は既に登録済みであり、対称的な proxy 兄弟として `release-wave-gcp` も登録する。

## 修正

`wrangler.jsonc` の `TAGLESS_REPOS` 末尾に `ippoan/release-wave-gcp` を 1 entry 追加。

## 期待挙動

- `/releases` に `ippoan/release-wave-gcp` の synthetic block が出る
- merged PR ippoan/release-wave-gcp#6 (`Refs #5`) / #8 (`Refs #7`) から close 候補として #5 / #7 が一覧表示される


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dh3WNrUrApxnoGB4YHY1bN)_