### PR TITLE
chore: add ippoan/ui-preview to TAGLESS_REPOS

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -124,7 +124,7 @@
         // cut release tags: dashboard はこれらの PR merge を mini-release 扱いし、
         // merged PR の `Refs #N` を逆引きして /releases synthetic block + banner に
         // 出す (= stable tag 前でも早期 close 可能)。未掲載 repo は tag-driven flow。
-        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs,ippoan/cc-relay,ippoan/mcp-cf-workers,ippoan/claude-skills,ippoan/ci-workflows,ippoan/ref-files-worker,ippoan/claude-hooks,ippoan/cdp-relay,ippoan/release-wave-gcp"
+        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs,ippoan/cc-relay,ippoan/mcp-cf-workers,ippoan/claude-skills,ippoan/ci-workflows,ippoan/ref-files-worker,ippoan/claude-hooks,ippoan/cdp-relay,ippoan/release-wave-gcp,ippoan/ui-preview"
       },
       "kv_namespaces": [
         {


### PR DESCRIPTION
## 概要

`ippoan/ui-preview` を `TAGLESS_REPOS`（`wrangler.jsonc` env.staging.vars）に追加する。

## 背景

ui-preview は **PR-merge を CI 経由で行うが release tag を切らない tagless 運用**に確定した。`/releases` ページは tag の無い repo について、`useSynthetic = allowlist.has(repo) || tagless.has(repo)` が真の時だけ synthetic window（default branch の直近 commit から merged PR の `Refs #N` を逆引き）を作る (`src/releases-page.ts`)。

ui-preview は direct-push allowlist にも `TAGLESS_REPOS` にも未掲載だったため synthetic window が作られず、ダッシュボード上で:

> No referenced issues in the recent release window.

と表示されていた（claude-hooks / mcp-cf-workers / cdp-relay 等は `TAGLESS_REPOS` 掲載済みなので tag 無しでも Refs が出る）。

## 変更

`TAGLESS_REPOS` の末尾に `ippoan/ui-preview` を 1 つ追加。これにより tag を一切打たずとも、merged PR (#12 の `Refs #10` 等) が `/releases` の synthetic block + banner に出て、stable tag 前でも目視 close が可能になる。

- direct-push ではなく PR-merge 運用なので、direct-push allowlist (bucket b) ではなく `TAGLESS_REPOS` var (bucket c) が正しい配置。
- source / test には触れていない（config-only）。`parseTaglessRepos` のテストは合成入力のみ検証で本変更の影響なし。反映には ci-dashboard の deploy（staging=prod）が必要。

https://claude.ai/code/session_01KNWgG6wRxpQDU17iaLG1tD

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNWgG6wRxpQDU17iaLG1tD)_