### PR TITLE
feat: add ippoan/nuxt-notify to TAGLESS_REPOS

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -124,7 +124,7 @@
         // cut release tags: dashboard はこれらの PR merge を mini-release 扱いし、
         // merged PR の `Refs #N` を逆引きして /releases synthetic block + banner に
         // 出す (= stable tag 前でも早期 close 可能)。未掲載 repo は tag-driven flow。
-        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs,ippoan/cc-relay,ippoan/mcp-cf-workers,ippoan/claude-skills,ippoan/ci-workflows,ippoan/ref-files-worker,ippoan/claude-hooks,ippoan/cdp-relay,ippoan/release-wave-gcp,ippoan/ui-preview"
+        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs,ippoan/cc-relay,ippoan/mcp-cf-workers,ippoan/claude-skills,ippoan/ci-workflows,ippoan/ref-files-worker,ippoan/claude-hooks,ippoan/cdp-relay,ippoan/release-wave-gcp,ippoan/ui-preview,ippoan/nuxt-notify"
       },
       "kv_namespaces": [
         {


### PR DESCRIPTION
## 概要

`ippoan/nuxt-notify` を `/releases` ページに表示させる。

nuxt-notify は tag を打たず main push で CI deploy する **tagless 運用** (`wrangler.jsonc` に明記)。`/releases` は `TAGLESS_REPOS` wrangler var に載っている repo を synthetic-block で表示するので、ここに追加するだけで:

- `/releases` の synthetic block + dashboard banner に出る
- merged PR の `Refs #N` を逆引きして stable tag 前でも早期 close 可能

になる。

## 変更

`wrangler.jsonc` の `env.staging.vars.TAGLESS_REPOS` 末尾に `ippoan/nuxt-notify` を追加 (1 行)。

## 補足

- Release Wave 参加自体は `ci-workflows/config/release-wave-targets.yaml` に既に登録済み (monorepo 3 unit: nuxt-notify / notify-email-receiver / notify-realtime-bus)。本 PR は `/releases` 一覧表示の opt-in のみ。
- `TAGLESS_REPOS` は `env.staging.vars` の単一 SoT。反映には ci-dashboard の再 deploy が必要。

Refs #137

---
_Generated by [Claude Code](https://claude.ai/code/session_01SrPsBf6jKpb553PuQvQ1ce)_