### PR TITLE
feat: add nuxt-egov and alc-app to TAGLESS_REPOS

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -124,7 +124,7 @@
         // cut release tags: dashboard はこれらの PR merge を mini-release 扱いし、
         // merged PR の `Refs #N` を逆引きして /releases synthetic block + banner に
         // 出す (= stable tag 前でも早期 close 可能)。未掲載 repo は tag-driven flow。
-        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs,ippoan/cc-relay,ippoan/mcp-cf-workers,ippoan/claude-skills,ippoan/ci-workflows,ippoan/ref-files-worker,ippoan/claude-hooks,ippoan/cdp-relay,ippoan/release-wave-gcp,ippoan/ui-preview,ippoan/nuxt-notify"
+        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs,ippoan/cc-relay,ippoan/mcp-cf-workers,ippoan/claude-skills,ippoan/ci-workflows,ippoan/ref-files-worker,ippoan/claude-hooks,ippoan/cdp-relay,ippoan/release-wave-gcp,ippoan/ui-preview,ippoan/nuxt-notify,ippoan/nuxt-egov,ippoan/alc-app"
       },
       "kv_namespaces": [
         {


### PR DESCRIPTION
## 概要

`/releases` ページで `ippoan/nuxt-egov` と `ippoan/alc-app` がどちらも
**"No referenced issues in the recent release window."** と表示されていた。
これは両 repo が tag-driven flow 扱いで、latest tag → HEAD の window に
`Refs #N` が見つからないため。

両 repo を `TAGLESS_REPOS` に追加し、default branch への PR merge を
mini-release イベントとして扱う (= merged PR の `Refs #N` を逆引きして
synthetic block / banner に出す) ようにする。stable tag 前でも早期 close
できるようになる。

## 変更

- `wrangler.jsonc` の `env.staging.vars.TAGLESS_REPOS` に
  `ippoan/nuxt-egov,ippoan/alc-app` を追記 (単一 SoT)

## 検証

- `npx vitest run test/tagless-repos.test.ts test/releases-page.test.ts` → 28 passed
- repo 名は codebase の既存表記 (`ippoan/alc-app` 等、release-wave dispatch 参照) に一致

Refs #145


---
_Generated by [Claude Code](https://claude.ai/code/session_012RSaF5uPDMg4cfku7R4sgF)_