### PR TITLE
fix(releases): recover PR-body-only Refs in the latest tag window on the index

### DIFF
--- a/src/release-alert.ts
+++ b/src/release-alert.ts
@@ -65,24 +65,38 @@ export async function collectIssueNumbersForRange(
   tag: string,
   prevTag: string | null,
   kv?: KVNamespace,
+  // Cap the PR follow-up fan-out (newest-first). The detail page leaves this
+  // unbounded (single repo). The releases index passes a cap so the per-repo
+  // PR-body recovery, fanned across N repos, stays within the Worker
+  // subrequest budget. Refs ippoan/ci-dashboard#301.
+  maxPrFollowup?: number,
 ): Promise<{ issueNumbers: Set<number>; commitCount: number }> {
   const commits = prevTag
     ? (await cachedCompare(token, kv, owner, name, prevTag, tag)).commits
     : await cachedCommits(token, kv, owner, name, tag, 50);
 
   const issueNumbers = new Set<number>();
-  const prNumbers = new Set<number>();
   const repoCtx = { owner, name };
   for (const c of commits) {
-    const msg = c.commit.message;
-    for (const n of extractRefIssues(msg, repoCtx)) issueNumbers.add(n);
-    const pr = extractPrNumber(msg);
-    if (pr !== null) prNumbers.add(pr);
+    for (const n of extractRefIssues(c.commit.message, repoCtx)) issueNumbers.add(n);
   }
 
   // PR follow-up pass: head.ref (branch name) and body carry refs that the
-  // squash-merge subject line drops.
-  await Promise.all([...prNumbers].map(async (n) => {
+  // squash-merge subject line drops. Collect PR numbers newest-first so a cap
+  // (index path) keeps the freshest PRs. cachedCompare (prevTag set) returns
+  // oldest-first → reverse; cachedCommits (no prevTag) is already newest-first.
+  const recentFirst = prevTag ? [...commits].reverse() : commits;
+  const prNumbers: number[] = [];
+  const seenPr = new Set<number>();
+  for (const c of recentFirst) {
+    const pr = extractPrNumber(c.commit.message);
+    if (pr !== null && !seenPr.has(pr)) {
+      seenPr.add(pr);
+      prNumbers.push(pr);
+    }
+  }
+  const capped = maxPrFollowup != null ? prNumbers.slice(0, maxPrFollowup) : prNumbers;
+  await Promise.all(capped.map(async (n) => {
     try {
       const pr = await cachedPullRequest(token, kv, owner, name, n);
       const fromBranch = extractBranchIssue(pr.head.ref);

--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -257,13 +257,32 @@ async function loadRepoView(
   }
 
   // 2. For each inline tag, compare to its immediate predecessor (next in
-  //    sorted-desc) and harvest issue refs from commit messages. We skip the
-  //    PR-fetch heuristic the detail page uses, to keep the index sub-request
-  //    budget bounded (fans out across N repos).
+  //    sorted-desc) and harvest issue refs from commit messages.
+  //
+  //    For the MOST RECENT release window (i === 0) we additionally recover
+  //    refs that live only in the PR body / head branch — squash-merge drops
+  //    the `Refs #N` trailer from the commit subject, keeping just `(#PR)`, so
+  //    a commit-message-only scan misses them (e.g. alc-app#30, referenced
+  //    solely in PR #31's body). This reuses the detail page's
+  //    collectIssueNumbersForRange with a MAX_PR_FOLLOWUP cap so the per-repo
+  //    PR fan-out, multiplied across N repos on the index, stays within the
+  //    Worker subrequest budget. Older inline tags (i >= 1) stay on the cheap
+  //    commit-message-only scan — the latest window is the one operators act
+  //    on for close-confirmation. Refs ippoan/ci-dashboard#301.
   const rawBlocks = await Promise.all(topTags.map(async (tag, i) => {
     const prevTag = sorted[i + 1] ?? null;
     if (!prevTag) {
       return { tag, prevTag: null, refs: [] as number[] };
+    }
+    if (i === 0) {
+      try {
+        const { issueNumbers } = await collectIssueNumbersForRange(
+          token, owner, name, tag, prevTag, kv, MAX_PR_FOLLOWUP,
+        );
+        return { tag, prevTag, refs: [...issueNumbers] };
+      } catch {
+        return { tag, prevTag, refs: [] };
+      }
     }
     try {
       const cmp = await cachedCompare(token, kv, owner, name, prevTag, tag);

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -242,6 +242,60 @@ describe("GET /releases", () => {
     expect(html).toContain('<form method="GET" action="/releases"');
   });
 
+  it("recovers a PR-body-only Ref in the latest tag window on the index (squash drops it from the subject)", async () => {
+    // Refs ippoan/ci-dashboard#301: the index's tag-compare path now runs the
+    // detail page's PR follow-up for the MOST RECENT release window, so a
+    // `Refs #N` that lives only in the PR body (squash-merge keeps just the
+    // `(#PR)` subject) still surfaces on the card. Mirrors alc-app#30, which
+    // shipped in v0.0.7 referenced solely by PR #31's body.
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
+      const url = typeof req === "string" ? req : (req as Request).url;
+
+      if (url.includes("/repos/ippoan/alc-app/tags")) {
+        return Response.json([
+          { name: "v0.0.7", commit: { sha: "a" } },
+          { name: "v0.0.6", commit: { sha: "b" } },
+        ]);
+      }
+      // Latest window: squash subject carries only `(#31)` — no `Refs` trailer.
+      if (url.includes("/repos/ippoan/alc-app/compare/v0.0.6...v0.0.7")) {
+        return Response.json({
+          commits: [{ sha: "x", commit: { message: "ci: add release-wave-retest.yml (#31)" } }],
+        });
+      }
+      // The Ref lives only in the PR body.
+      if (url.endsWith("/repos/ippoan/alc-app/pulls/31")) {
+        return Response.json({
+          number: 31,
+          head: { ref: "claude/great-dijkstra-vpnk8o" },
+          body: "wires up the retest receiver.\n\nRefs ippoan/alc-app#30",
+        });
+      }
+      if (url.endsWith("/repos/ippoan/alc-app/issues/30")) {
+        return Response.json({
+          number: 30, title: "release-wave retest missing", state: "open",
+          labels: [], assignees: [],
+          html_url: "https://github.com/ippoan/alc-app/issues/30",
+          updated_at: "2026-06-09T00:00:00Z",
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const e = testEnv({ watched: ["ippoan/alc-app"] });
+    const req = new Request("http://localhost/releases");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, e, ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // #30, recovered from PR #31's body, renders on the alc-app card.
+    expect(html).toContain("ippoan/alc-app");
+    expect(html).toContain("release-wave retest missing");
+    expect(html).toMatch(/name="pair" value="v0\.0\.7:30"/);
+  });
+
   it("falls back to the index page when only `repo` is given (no tag, no flash)", async () => {
     // Pre-#45 this rendered a partial lookup form. Now any incomplete shape
     // lands on the index so the operator never sees an empty form on its own.


### PR DESCRIPTION
## 概要

`/releases` の **tag 付き repo の card** で、最新リリース窓に含まれる PR の `Refs #N` が **PR 本文にしか無い**場合に index で拾えず「No referenced issues in the recent release window.」になる問題を修正する。

実例: `ippoan/alc-app` は v0.0.7 に PR #31 が含まれるが、`Refs ippoan/alc-app#30` は PR 本文だけにあり squash-merge の commit subject は `... (#31)` のみ。そのため alc-app の card に #30 が出ていなかった（detail ページでは出る）。

## 原因

index の tag-compare 経路（`releases-page.ts` の `rawBlocks`）は **commit メッセージからのみ** `Refs #N` を抽出していた（N repo 横断の fan-out を抑えるため意図的に PR fetch を回避）。squash-merge は PR 本文の `Refs #N` trailer を subject から落とすため拾えない。detail ページ・synthetic(tagless) 経路は既に PR follow-up で救済済みだったが、tag 付き repo の index 経路だけ未対応だった。

## 変更

- **`releases-page.ts`**: index の tag-compare 経路で **最新リリース窓 (`i === 0`) のみ** detail ページと同じ `collectIssueNumbersForRange` を再利用し、PR 本文 / head branch から `Refs #N` を救済。older inline tag (`i >= 1`) は従来の cheap な commit-message-only scan のまま（operator が close 確認で触るのは最新窓のため）。
- **`release-alert.ts`**: `collectIssueNumbersForRange` に optional `maxPrFollowup` cap (newest-first) を追加。detail ページは無指定=従来どおり無制限、index は `MAX_PR_FOLLOWUP` 上限で呼び、per-repo の PR fan-out が N repo 横断で Worker subrequest budget を超えないようにする。
- **test 追加**: 最新窓の squash commit `(#PR)` + PR 本文 `Refs #N` が index card に出ることを固定（alc-app#30 シナリオ）。

## 検証

- `npx tsc --noEmit` clean
- `npx vitest run` 全 **731 test green**（新規 +1 含む）

> `Refs #300`（alc-app / nuxt-egov を TAGLESS_REPOS に追加）は「Unreleased zone」を足すが、#30 は released 窓 (v0.0.6..v0.0.7) にあるため本修正で補完される。

Refs ippoan/ci-dashboard#301

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4p3x1R28rpnhYkupp4HsN)_