### PR TITLE
feat(release): register rust-flickr / cf-billing-monitor as tagless repos

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -124,7 +124,7 @@
         // cut release tags: dashboard はこれらの PR merge を mini-release 扱いし、
         // merged PR の `Refs #N` を逆引きして /releases synthetic block + banner に
         // 出す (= stable tag 前でも早期 close 可能)。未掲載 repo は tag-driven flow。
-        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs,ippoan/cc-relay,ippoan/mcp-cf-workers,ippoan/claude-skills,ippoan/ci-workflows,ippoan/ref-files-worker,ippoan/claude-hooks,ippoan/cdp-relay,ippoan/release-wave-gcp,ippoan/ui-preview,ippoan/nuxt-notify,ippoan/nuxt-egov,ippoan/alc-app"
+        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs,ippoan/cc-relay,ippoan/mcp-cf-workers,ippoan/claude-skills,ippoan/ci-workflows,ippoan/ref-files-worker,ippoan/claude-hooks,ippoan/cdp-relay,ippoan/release-wave-gcp,ippoan/ui-preview,ippoan/nuxt-notify,ippoan/nuxt-egov,ippoan/alc-app,ippoan/rust-flickr,ippoan/cf-billing-monitor"
       },
       "kv_namespaces": [
         {


### PR DESCRIPTION
`TAGLESS_REPOS` (env.staging.vars) に以下 2 repo を追加。

- `ippoan/rust-flickr`
- `ippoan/cf-billing-monitor`

どちらも release tag を切らない single-env 運用 (PR merge = mini-release)。
未掲載だと `/releases` で synthetic block が作られず、merged PR の `Refs #N`
逆引き / 早期 close UI に出ない。これで dashboard が両 repo の PR merge を
mini-release 扱いする。

Refs #137

---
_Generated by [Claude Code](https://claude.ai/code/session_014djPbVVEmy5grquYnWKRXn)_