### PR TITLE
feat(issues): SWR 化 + pull_request webhook の pr-map patch + rate-limit backoff

### DIFF
--- a/src/github-backoff.ts
+++ b/src/github-backoff.ts
@@ -1,0 +1,56 @@
+import { GitHubApiError } from "./github-api";
+
+// 共有 rate-limit backoff marker (Refs #304)。
+//
+// /issues の SWR 化で reconcile / PR map refresh が background 実行になるが、
+// user-scope token の quota が枯渇している間に再検証を繰り返すと
+// 「枯渇 → さらに叩く → 枯渇が伸びる」のハンマリングになる。403/429 を
+// 観測したら KV に marker を置き、TTL が切れるまで GitHub fetch 系を no-op
+// させる。marker は watermark / storedAt を一切動かさないので、解除後の
+// 最初のリクエストで即 refresh が走る (= staleness が複利しない)。
+const BACKOFF_KEY = "github:rl-backoff";
+const BACKOFF_TTL_SECONDS = 300;
+
+export interface RateLimitBackoff {
+  setAt: number;
+  /** バナーの「HH:MM 頃に再開」表示用。KV get は残 TTL を返さないので
+   *  value 側に持つ。 */
+  until: number;
+  status: number;
+  message: string;
+}
+
+/** GitHub の rate limit 由来とみなすエラーか。primary (403) / secondary
+ *  (429) の両方を拾う。github-api.ts は response body を message に含める
+ *  ので文言 match も併用する。 */
+export function isRateLimitError(err: unknown): boolean {
+  if (err instanceof GitHubApiError && (err.status === 403 || err.status === 429)) {
+    return true;
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  return /rate limit/i.test(msg);
+}
+
+export async function setRateLimitBackoff(kv: KVNamespace, err: unknown): Promise<void> {
+  const now = Date.now();
+  const msg = err instanceof Error ? err.message : String(err);
+  const entry: RateLimitBackoff = {
+    setAt: now,
+    until: now + BACKOFF_TTL_SECONDS * 1000,
+    status: err instanceof GitHubApiError ? err.status : 0,
+    message: msg.slice(0, 200),
+  };
+  await kv.put(BACKOFF_KEY, JSON.stringify(entry), {
+    expirationTtl: BACKOFF_TTL_SECONDS,
+  });
+}
+
+export async function getRateLimitBackoff(kv: KVNamespace): Promise<RateLimitBackoff | null> {
+  return await kv.get(BACKOFF_KEY, "json") as RateLimitBackoff | null;
+}
+
+// Test 用に内部定数を公開。production code からは呼ばない。
+export const __testing = {
+  BACKOFF_KEY,
+  BACKOFF_TTL_SECONDS,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,8 +119,9 @@ function getReleaseWaveHub(env: Env): DurableObjectStub {
 // Dashboard
 app.get("/", () => handleDashboard());
 
-// Open issues (SSR, cross-org)
-app.get("/issues", (c) => handleIssuesPage(c.env));
+// Open issues (SSR, cross-org)。executionCtx は SWR の background
+// reconcile / PR map refresh 用 (Refs #304)。
+app.get("/issues", (c) => handleIssuesPage(c.env, c.executionCtx));
 
 // Projects v2 read-only listing (SSR, cross-org). Refs #72.
 app.get("/projects", (c) => handleProjectsPage(c.env));

--- a/src/issue-cache.ts
+++ b/src/issue-cache.ts
@@ -1,6 +1,11 @@
 import type { OrgIssue, FetchOrgIssuesParams } from "./mcp/tools/issues";
 import { fetchOrgIssues } from "./mcp/tools/issues";
 import type { AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
+import {
+  getRateLimitBackoff,
+  isRateLimitError,
+  setRateLimitBackoff,
+} from "./github-backoff";
 
 // KV schema:
 //   issue:<owner>/<name>#<number>  -> OrgIssue JSON   (open issues only;
@@ -20,16 +25,28 @@ const KEY_PREFIX = "issue:";
 
 // SSR 連続リロード時の thundering herd を吸収しつつ「stale すぎる」と
 // 感じさせない値。書き込みは webhook が数秒以内に届くので 60s 内の更新
-// ラグは webhook 側でほぼ埋まる。
-const FRESH_THRESHOLD_MS = 60 * 1000;
+// ラグは webhook 側でほぼ埋まる。issues-page のバナー (「裏で更新中」判定)
+// からも参照するため export (Refs #304)。
+export const FRESH_THRESHOLD_MS = 60 * 1000;
 
 // Watermark は `now - SAFETY_WINDOW_MS` でセット。full snapshot 方式では
 // delta query が無いので overlap の意味は無く、次 reconcile の fresh 判定を
 // 5s ぶん早く解除する保険として残す (= 連続アクセス時の取りこぼし余地を縮める)。
 const SAFETY_WINDOW_MS = 5 * 1000;
 
+// SWR 化 (Refs #304) で background reconcile が並走し得るため、fetch+write
+// 区間を soft lock で重複排除する。KV expirationTtl の最小値 60s に合わせる。
+// best-effort: cross-colo の重複は許容 (= 従来挙動の無駄撃ちに退化するだけ)。
+const RECONCILE_LOCK_KEY = "issues:reconciling";
+const RECONCILE_LOCK_TTL_SECONDS = 60;
+
 export function issueKey(repo: string, number: number): string {
   return `${KEY_PREFIX}${repo}#${number}`;
+}
+
+/** /issues バナー表示用: 最後に full snapshot が成功した時刻 (ISO 文字列)。 */
+export async function getIssuesWatermark(kv: KVNamespace): Promise<string | null> {
+  return kv.get(KEY_WATERMARK);
 }
 
 /** Webhook 経路から呼ぶ単一 issue 反映。open → put / closed → delete。
@@ -98,6 +115,23 @@ export async function reconcileIssues(
     return { patched: 0, fetched: false, removed: 0 };
   }
 
+  // Rate-limit backoff 中は GitHub を叩かない (Refs #304)。watermark を
+  // 書かないので、marker (TTL 300s) が切れた後の最初のリクエストで即
+  // refresh が走る = staleness は複利しない。
+  if (await getRateLimitBackoff(kv)) {
+    return { patched: 0, fetched: false, removed: 0 };
+  }
+
+  // Background reconcile の重複排除 (best-effort soft lock)。watermark は
+  // 成功時にしか進まないため、SWR で並んだ N リクエストが全部 fetch する
+  // のを防ぐ。
+  if (await kv.get(RECONCILE_LOCK_KEY)) {
+    return { patched: 0, fetched: false, removed: 0 };
+  }
+  await kv.put(RECONCILE_LOCK_KEY, "1", {
+    expirationTtl: RECONCILE_LOCK_TTL_SECONDS,
+  });
+
   // 2-query pattern: GitHub search は org: と repo: を混ぜると repo: 側を黙って
   // drop するので、yhonda-ohishi の特定 repo だけ別 query に分離する
   // (mcp/tools/issues.ts 参照)。両方とも state:open の full snapshot。
@@ -113,10 +147,17 @@ export async function reconcileIssues(
     query: params.yhondaRepos.map((r) => `repo:${r}`).join(" "),
   };
 
-  const [main, yhonda] = await Promise.all([
-    fetchOrgIssues(env, mainParams),
-    fetchOrgIssues(env, yhondaParams),
-  ]);
+  let main: Awaited<ReturnType<typeof fetchOrgIssues>>;
+  let yhonda: Awaited<ReturnType<typeof fetchOrgIssues>>;
+  try {
+    [main, yhonda] = await Promise.all([
+      fetchOrgIssues(env, mainParams),
+      fetchOrgIssues(env, yhondaParams),
+    ]);
+  } catch (err) {
+    if (isRateLimitError(err)) await setRateLimitBackoff(kv, err);
+    throw err;
+  }
 
   const fresh = [...main.items, ...yhonda.items];
   const freshKeys = new Set(fresh.map((i) => issueKey(i.repo, i.number)));
@@ -212,4 +253,5 @@ export const __testing = {
   KEY_PREFIX,
   FRESH_THRESHOLD_MS,
   SAFETY_WINDOW_MS,
+  RECONCILE_LOCK_KEY,
 };

--- a/src/issue-prs.ts
+++ b/src/issue-prs.ts
@@ -174,10 +174,14 @@ export async function fetchAllOpenPrsByIssue(
   // Sort each list: open first (work still in flight), then merged; within
   // each group by recency so the most-recently-updated PR renders first.
   for (const prs of merged.values()) {
-    prs.sort((a, b) => {
-      if (a.state !== b.state) return a.state === "open" ? -1 : 1;
-      return b.updated_at.localeCompare(a.updated_at);
-    });
+    prs.sort(sortPrRefs);
   }
   return merged;
+}
+
+/** open 優先 → 各 state 内は updated_at 降順。fetchAllOpenPrsByIssue と
+ *  pr-map-cache の webhook patch (Refs #304) が同じ順序規約を共有する。 */
+export function sortPrRefs(a: IssuePrRef, b: IssuePrRef): number {
+  if (a.state !== b.state) return a.state === "open" ? -1 : 1;
+  return b.updated_at.localeCompare(a.updated_at);
 }

--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -1,10 +1,18 @@
 import { type OrgIssue } from "./mcp/tools/issues";
 import { type ProjectRef } from "./mcp/tools/projects";
-import { fetchAllOpenPrsByIssue, type IssuePrRef } from "./issue-prs";
+import { type IssuePrRef } from "./issue-prs";
 import type { AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
 import { renderTabs, TAB_STYLES } from "./nav-tabs";
 import { PWA_HEAD_TAGS, PWA_REGISTER_SCRIPT } from "./pwa";
-import { listCachedOpenIssues, reconcileIssues, type ReconcileResult } from "./issue-cache";
+import {
+  listCachedOpenIssues,
+  reconcileIssues,
+  getIssuesWatermark,
+  FRESH_THRESHOLD_MS,
+  type ReconcileResult,
+} from "./issue-cache";
+import { loadPrMap, type PrMapResult } from "./pr-map-cache";
+import { getRateLimitBackoff } from "./github-backoff";
 import {
   getOrFetchProjectIssueMap,
   type ProjectIssueMapResult,
@@ -69,54 +77,9 @@ export function buildClaudeCodeLaunchUrl(repo: string, issueNumber: number): str
 // あれば warm cache を共有して即返、`projects_v2_item` webhook が来ると
 // project-cache.applyProjectsV2ItemEvent が KV を flush する。
 
-// PR map cache mirrors the project-map cache pattern. The freshness window is
-// shorter (2 min) because PR state churns faster than Project board edits — a
-// new PR opened minutes ago should appear without forcing a manual reload —
-// but the 24 h store window keeps a stale copy as fallback when GitHub search
-// rate-limits the worker.
-// v2 suffix invalidates the open-only payload from before merged PRs were
-// included (the shape changed — `IssuePrRef.state` is now required).
-const PR_MAP_CACHE_KEY = "issues-page:pr-map:v2";
-const PR_MAP_FRESH_SECONDS = 120;
-const PR_MAP_STORE_SECONDS = 86400;
-
-interface PrMapCacheEntry {
-  storedAt: number;
-  data: Record<string, IssuePrRef[]>;
-}
-
-interface PrMapResult {
-  map: Map<string, IssuePrRef[]>;
-  stale: boolean;
-  error: string | null;
-}
-
-async function loadPrMap(
-  env: AuthClientWorkerEnv,
-  mainOrgs: string[],
-  yhondaRepos: string[],
-): Promise<PrMapResult> {
-  const kv = env.CI_STATUS;
-  const cached = await kv.get(PR_MAP_CACHE_KEY, "json") as PrMapCacheEntry | null;
-  const now = Date.now();
-  if (cached && now - cached.storedAt < PR_MAP_FRESH_SECONDS * 1000) {
-    return { map: new Map(Object.entries(cached.data)), stale: false, error: null };
-  }
-  try {
-    const fresh = await fetchAllOpenPrsByIssue(env, mainOrgs, yhondaRepos);
-    const entry: PrMapCacheEntry = { storedAt: now, data: Object.fromEntries(fresh) };
-    await kv.put(PR_MAP_CACHE_KEY, JSON.stringify(entry), {
-      expirationTtl: PR_MAP_STORE_SECONDS,
-    });
-    return { map: fresh, stale: false, error: null };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (cached) {
-      return { map: new Map(Object.entries(cached.data)), stale: true, error: message };
-    }
-    return { map: new Map(), stale: false, error: message };
-  }
-}
+// PR map cache は src/pr-map-cache.ts に移設 (Refs #304)。webhook.ts の
+// pull_request patch と本 page の SSR read が両方 import するため、page
+// module から独立させて循環 import を避けている。
 
 // `@ippoan/auth-client-worker` SDK が auth-worker delegation 中に投げる error
 // は `Error.message` に常に診断文字列を入れる (introspect.ts / tokens.ts /
@@ -133,26 +96,87 @@ function isAuthError(err: unknown): boolean {
   );
 }
 
-export async function handleIssuesPage(env: AuthClientWorkerEnv): Promise<Response> {
-  // KV cache-first 読み出し (Refs #129)。reconcile は watermark が古い時
-  // だけ走り、それ以外は KV read で完結する (= GitHub API 0 call)。
-  // reconcile 失敗時も cache が空でなければ stale banner 付きで render する。
+// KV には過去設定の repo が残っている可能性があるので allowlist で filter。
+// mainOrgs 配下は全 repo 許可、yhonda-ohishi は YHONDA_REPOS のみ。
+function filterAllowed(cached: OrgIssue[]): OrgIssue[] {
+  const mainOrgSet = new Set(ORGS);
+  const yhondaRepoSet = new Set(YHONDA_REPOS);
+  return cached.filter((i) => {
+    const owner = i.repo.split("/")[0] ?? "";
+    if (mainOrgSet.has(owner)) return true;
+    return yhondaRepoSet.has(i.repo);
+  });
+}
+
+/** バナー描画に使う鮮度情報 (Refs #304)。 */
+interface Freshness {
+  /** 最後に full snapshot が成功してからの秒数。watermark 無しは null。 */
+  reconcileAgeSec: number | null;
+  /** warm path で background reconcile を waitUntil に投げた。 */
+  issuesRefreshing: boolean;
+  /** PR map が stale を即返しして background refresh 中。 */
+  prRefreshing: boolean;
+  /** rate-limit backoff 中。値は再開予定時刻 (epoch ms)。 */
+  backoffUntil: number | null;
+  /** cold start で同期 reconcile が失敗した時のみ生エラーを表示する。 */
+  coldError: string | null;
+}
+
+export async function handleIssuesPage(
+  env: AuthClientWorkerEnv,
+  ctx?: ExecutionContext,
+): Promise<Response> {
+  // SWR (Refs #304): KV を先に読み、warm なら GitHub を一切待たずに render
+  // して reconcile は ctx.waitUntil で裏実行する。rate limit / 一時障害が
+  // ページ表示を壊す経路は cold start (cache 空) だけに限定される。
+  // 鮮度は webhook (issues / issue_comment / pull_request) の即時 patch が
+  // 担保し、reconcile は安全網。
+  const kv = env.CI_STATUS;
   let reconcileError: string | null = null;
   let reconcileResult: ReconcileResult | null = null;
-  try {
-    reconcileResult = await reconcileIssues(env, { mainOrgs: ORGS, yhondaRepos: YHONDA_REPOS });
-  } catch (err) {
-    if (isAuthError(err)) {
-      // 認証失効: GitHub 同意画面 → /oauth/callback → return_to で /issues に戻る
-      return new Response(null, {
-        status: 302,
-        headers: { Location: "/oauth/login?return_to=/issues" },
-      });
-    }
-    reconcileError = err instanceof Error ? err.message : String(err);
-  }
+  let issuesRefreshing = false;
 
-  const cached = await listCachedOpenIssues(env.CI_STATUS);
+  let cached = await listCachedOpenIssues(kv);
+  let filtered = filterAllowed(cached);
+
+  if (filtered.length > 0) {
+    // Warm path: 背景 reconcile (reconcileIssues 自身が fresh window /
+    // backoff / lock で no-op 判定する)。auth error は background では
+    // 302 できないので log のみ — cache が温かい限り表示は継続し、cold
+    // start 時に従来どおり /oauth/login へ誘導される。
+    // 未 catch の reject は waitUntil 経由で例外になる (テストでは
+    // waitOnExecutionContext が fail する) ため必ず pre-catch する。
+    issuesRefreshing = true;
+    const p = reconcileIssues(env, { mainOrgs: ORGS, yhondaRepos: YHONDA_REPOS })
+      .then((r) => {
+        console.log(JSON.stringify({ msg: "issues-page-bg-reconcile", reconcile: r }));
+      })
+      .catch((err) => {
+        console.log(JSON.stringify({
+          msg: "issues-page-bg-reconcile-failed",
+          isAuth: isAuthError(err),
+          error: err instanceof Error ? err.message : String(err),
+        }));
+      });
+    if (ctx) ctx.waitUntil(p);
+    else void p;
+  } else {
+    // Cold path: 従来どおり同期 reconcile。302 / 502 の挙動を保全する。
+    try {
+      reconcileResult = await reconcileIssues(env, { mainOrgs: ORGS, yhondaRepos: YHONDA_REPOS });
+    } catch (err) {
+      if (isAuthError(err)) {
+        // 認証失効: GitHub 同意画面 → /oauth/callback → return_to で /issues に戻る
+        return new Response(null, {
+          status: 302,
+          headers: { Location: "/oauth/login?return_to=/issues" },
+        });
+      }
+      reconcileError = err instanceof Error ? err.message : String(err);
+    }
+    cached = await listCachedOpenIssues(kv);
+    filtered = filterAllowed(cached);
+  }
 
   // observability: reconcile が GitHub を引いたか (fetched) / 何件 upsert・
   // evict したか (patched/removed) と KV cache 件数。/issues の表示が古い時に
@@ -161,17 +185,9 @@ export async function handleIssuesPage(env: AuthClientWorkerEnv): Promise<Respon
     msg: "issues-page",
     reconcile: reconcileResult,
     reconcileError,
+    issuesRefreshing,
     cachedCount: cached.length,
   }));
-  // KV には過去設定の repo が残っている可能性があるので allowlist で
-  // filter。mainOrgs 配下は全 repo 許可、yhonda-ohishi は YHONDA_REPOS のみ。
-  const mainOrgSet = new Set(ORGS);
-  const yhondaRepoSet = new Set(YHONDA_REPOS);
-  const filtered = cached.filter((i) => {
-    const owner = i.repo.split("/")[0] ?? "";
-    if (mainOrgSet.has(owner)) return true;
-    return yhondaRepoSet.has(i.repo);
-  });
 
   // Cache が空かつ reconcile も fail → 完全に表示不能なので 502。
   if (filtered.length === 0 && reconcileError) {
@@ -181,16 +197,51 @@ export async function handleIssuesPage(env: AuthClientWorkerEnv): Promise<Respon
     });
   }
 
+  // Cold start で backoff により fetch できず cache も空 → 「issue ゼロ 🎉」
+  // と誤表示せず cooldown を明示する (Refs #304)。
+  if (filtered.length === 0 && reconcileResult && !reconcileResult.fetched) {
+    const coldBackoff = await getRateLimitBackoff(kv);
+    if (coldBackoff) {
+      const resume = new Date(coldBackoff.until).toISOString().slice(11, 16);
+      return new Response(
+        renderError(`GitHub rate-limit cooldown — auto-refresh resumes by ${resume} UTC`),
+        {
+          status: 503,
+          headers: {
+            "Content-Type": "text/html; charset=utf-8",
+            "Retry-After": String(Math.max(1, Math.ceil((coldBackoff.until - Date.now()) / 1000))),
+          },
+        },
+      );
+    }
+  }
+
   const merged = {
     total_count: filtered.length,
     incomplete: false,
     items: filtered,
   };
 
-  const [project, prs] = await Promise.all([
+  const [project, prs, watermark, backoff] = await Promise.all([
     getOrFetchProjectIssueMap(env, PROJECT_ORGS),
-    loadPrMap(env, ORGS, YHONDA_REPOS),
+    loadPrMap(env, ORGS, YHONDA_REPOS, ctx),
+    getIssuesWatermark(kv),
+    getRateLimitBackoff(kv),
   ]);
+
+  const reconcileAgeSec = watermark
+    ? Math.max(0, Math.round((Date.now() - Date.parse(watermark)) / 1000))
+    : null;
+  const freshness: Freshness = {
+    reconcileAgeSec,
+    // 「裏で更新中」表示は実際に stale だった時だけ (fresh window 内の
+    // no-op reconcile でバナーを出すとノイズになる)。
+    issuesRefreshing: issuesRefreshing &&
+      (reconcileAgeSec === null || reconcileAgeSec * 1000 >= FRESH_THRESHOLD_MS),
+    prRefreshing: prs.refreshing,
+    backoffUntil: backoff?.until ?? null,
+    coldError: reconcileError,
+  };
   const projectMap = project.map;
   const prMap = prs.map;
 
@@ -222,7 +273,7 @@ export async function handleIssuesPage(env: AuthClientWorkerEnv): Promise<Respon
     ] as const);
 
   return new Response(
-    renderHtml(merged.total_count, merged.incomplete, projectTagged, repos, project, prs, reconcileError),
+    renderHtml(merged.total_count, merged.incomplete, projectTagged, repos, project, prs, freshness),
     { headers: { "Content-Type": "text/html; charset=utf-8" } },
   );
 }
@@ -234,7 +285,7 @@ function renderHtml(
   repos: ReadonlyArray<readonly [string, OrgIssue[]]>,
   project: ProjectIssueMapResult,
   prs: PrMapResult,
-  issueStaleError: string | null,
+  freshness: Freshness,
 ): string {
   const repoSections = repos
     .map(([repo, items]) => renderRepoSection(repo, items, prs.map))
@@ -247,10 +298,23 @@ function renderHtml(
   const incompleteBanner = incomplete
     ? `<div class="banner">⚠️ Result was truncated by GitHub search. Showing ${total} issues but more may exist.</div>`
     : "";
-  // KV cache の reconcile が fail した時の stale 注意。cache がある以上
-  // ページは出せるが、最新の close / open は反映されていない可能性がある。
-  const issueStaleBanner = issueStaleError
-    ? `<div class="banner banner-info">📋 Issue list shown is from KV cache — fresh reconcile failed (${escapeHtml(issueStaleError)})</div>`
+  // Rate-limit cooldown 中: 生の GitHub エラーは出さず、cache 表示 + 再開
+  // 予定だけを穏当に伝える (Refs #304)。
+  const backoffBanner = freshness.backoffUntil
+    ? `<div class="banner banner-info">⏳ GitHub rate-limit cooldown — serving cached data; auto-refresh resumes by ${new Date(freshness.backoffUntil).toISOString().slice(11, 16)} UTC</div>`
+    : "";
+  // Cold start で同期 reconcile が fail したが cache はあった時のみ生エラー。
+  const issueStaleBanner = freshness.coldError
+    ? `<div class="banner banner-info">📋 Issue list shown is from KV cache — fresh reconcile failed (${escapeHtml(freshness.coldError)})</div>`
+    : "";
+  // Warm path の SWR 表示。backoff バナーが出ている時は冗長なので省略。
+  const refreshingBanner = !freshness.backoffUntil && !freshness.coldError &&
+    (freshness.issuesRefreshing || freshness.prRefreshing)
+    ? `<div class="banner banner-info">🔄 Refreshing in background${
+        freshness.reconcileAgeSec !== null
+          ? ` (issues last reconciled ${freshness.reconcileAgeSec}s ago)`
+          : ""
+      }</div>`
     : "";
   const projectBanner = project.stale
     ? `<div class="banner banner-info">📋 Project tags shown are from the last successful sync — fresh fetch failed (${escapeHtml(project.error ?? "")})</div>`
@@ -480,6 +544,8 @@ function renderHtml(
     </div>
   </header>
   ${incompleteBanner}
+  ${backoffBanner}
+  ${refreshingBanner}
   ${issueStaleBanner}
   ${projectBanner}
   ${prBanner}

--- a/src/pr-map-cache.ts
+++ b/src/pr-map-cache.ts
@@ -1,0 +1,232 @@
+import {
+  fetchAllOpenPrsByIssue,
+  extractIssueRefs,
+  sortPrRefs,
+  type IssuePrRef,
+} from "./issue-prs";
+import type { AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
+import {
+  getRateLimitBackoff,
+  isRateLimitError,
+  setRateLimitBackoff,
+} from "./github-backoff";
+
+// /issues の関連 PR chip 用 KV cache (issues-page.ts から移設、Refs #304)。
+// webhook.ts (pull_request patch) と issues-page.ts (SSR read) の両方が
+// import するため、page module から独立させて循環 import を避ける。
+//
+// KV schema:
+//   issues-page:pr-map:v2 -> { storedAt, patchedAt?, data: Record<issueKey, IssuePrRef[]> }
+//
+// `storedAt` は「最後に full 4-call Search fetch が成功した時刻」。webhook
+// patch では **触らない** (issue-cache の watermark 規約と同じ — 配信ミスは
+// 次の full refresh が必ず救う)。`patchedAt` は observability 用の optional
+// field で、旧 entry (無し) もそのまま有効 = key の version bump 不要。
+export const PR_MAP_CACHE_KEY = "issues-page:pr-map:v2";
+
+// Webhook patch (applyPullRequestEvent) が PR の open/merge を秒で反映する
+// ようになったので、full refresh は安全網に格下げして 120s → 600s に拡大
+// (= Search ×4 の頻度を 1/5 に。Refs #304 の rate limit 対策本体)。
+const PR_MAP_FRESH_SECONDS = 600;
+const PR_MAP_STORE_SECONDS = 86400;
+
+// SWR の background refresh が同一 fresh window 内で重複しないための
+// soft lock。KV の expirationTtl 最小値が 60s なのでそれに合わせる。
+// best-effort (cross-colo の重複は許容 = 従来挙動と同じ無駄撃ちに退化)。
+const REFRESH_LOCK_KEY = "issues-page:pr-map:refreshing";
+const REFRESH_LOCK_TTL_SECONDS = 60;
+
+interface PrMapCacheEntry {
+  storedAt: number;
+  patchedAt?: number;
+  data: Record<string, IssuePrRef[]>;
+}
+
+export interface PrMapResult {
+  map: Map<string, IssuePrRef[]>;
+  /** cold start fetch が失敗して何も出せない/古いものしか無い (hard banner)。 */
+  stale: boolean;
+  /** cache を即返しして refresh を waitUntil に投げた (mild banner)。 */
+  refreshing: boolean;
+  error: string | null;
+}
+
+/** SWR 読み出し: cache があれば常に即返し。stale なら background refresh を
+ *  ctx.waitUntil に投げる (reject は必ず pre-catch — 未 catch の reject は
+ *  テストの waitOnExecutionContext を fail させる)。cache が全く無い cold
+ *  start のみ同期 fetch (従来挙動 = hard banner 維持)。 */
+export async function loadPrMap(
+  env: AuthClientWorkerEnv,
+  mainOrgs: string[],
+  yhondaRepos: string[],
+  ctx?: ExecutionContext,
+): Promise<PrMapResult> {
+  const kv = env.CI_STATUS;
+  const cached = await kv.get(PR_MAP_CACHE_KEY, "json") as PrMapCacheEntry | null;
+  const now = Date.now();
+  if (cached) {
+    const fresh = now - cached.storedAt < PR_MAP_FRESH_SECONDS * 1000;
+    if (!fresh) {
+      const p = refreshPrMap(env, mainOrgs, yhondaRepos).catch((err) => {
+        console.log(JSON.stringify({
+          msg: "pr-map-bg-refresh-failed",
+          error: err instanceof Error ? err.message : String(err),
+        }));
+      });
+      if (ctx) ctx.waitUntil(p);
+      else void p;
+    }
+    return {
+      map: new Map(Object.entries(cached.data)),
+      stale: false,
+      refreshing: !fresh,
+      error: null,
+    };
+  }
+  // Cold start: 同期 fetch。失敗は従来どおり error として返し hard banner。
+  try {
+    const fresh = await fetchAllOpenPrsByIssue(env, mainOrgs, yhondaRepos);
+    const entry: PrMapCacheEntry = { storedAt: now, data: Object.fromEntries(fresh) };
+    await kv.put(PR_MAP_CACHE_KEY, JSON.stringify(entry), {
+      expirationTtl: PR_MAP_STORE_SECONDS,
+    });
+    return { map: fresh, stale: false, refreshing: false, error: null };
+  } catch (err) {
+    if (isRateLimitError(err)) await setRateLimitBackoff(kv, err);
+    const message = err instanceof Error ? err.message : String(err);
+    return { map: new Map(), stale: false, refreshing: false, error: message };
+  }
+}
+
+/** full 4-call Search fetch で cache を取り直す (background 実行前提)。
+ *  backoff 中 / lock 中 / 既に fresh なら no-op。storedAt は成功時のみ更新
+ *  するので、backoff no-op が staleness を複利させることはない。 */
+export async function refreshPrMap(
+  env: AuthClientWorkerEnv,
+  mainOrgs: string[],
+  yhondaRepos: string[],
+): Promise<void> {
+  const kv = env.CI_STATUS;
+  if (await getRateLimitBackoff(kv)) return;
+  if (await kv.get(REFRESH_LOCK_KEY)) return;
+  await kv.put(REFRESH_LOCK_KEY, "1", { expirationTtl: REFRESH_LOCK_TTL_SECONDS });
+  // lock 取得後に再読: 並走した refresh が先に完走していたら bail。
+  const recheck = await kv.get(PR_MAP_CACHE_KEY, "json") as PrMapCacheEntry | null;
+  if (recheck && Date.now() - recheck.storedAt < PR_MAP_FRESH_SECONDS * 1000) return;
+  try {
+    const fresh = await fetchAllOpenPrsByIssue(env, mainOrgs, yhondaRepos);
+    const entry: PrMapCacheEntry = {
+      storedAt: Date.now(),
+      data: Object.fromEntries(fresh),
+    };
+    await kv.put(PR_MAP_CACHE_KEY, JSON.stringify(entry), {
+      expirationTtl: PR_MAP_STORE_SECONDS,
+    });
+  } catch (err) {
+    if (isRateLimitError(err)) await setRateLimitBackoff(kv, err);
+    throw err;
+  }
+}
+
+// ───── pull_request webhook → pr-map patch ─────
+
+/** webhook.ts の PullRequestPayload と構造互換 (import すると循環するので
+ *  ここで最小定義)。title 以下は GitHub の実配信には常に載るが、optional に
+ *  して最小 payload (テスト fixture / 将来の field 削減) でも落ちないように
+ *  する。 */
+export interface PrMapWebhookPayload {
+  action: string;
+  pull_request: {
+    number: number;
+    merged: boolean;
+    title?: string;
+    body?: string | null;
+    draft?: boolean;
+    html_url?: string;
+    updated_at?: string;
+  };
+  repository: { full_name: string };
+}
+
+// title/body/draft/state が変わる action だけ反映する。`synchronize` (push)
+// や label / review 系は PR chip の表示内容を変えないので skip。
+const PATCH_ACTIONS = new Set([
+  "opened",
+  "edited",
+  "closed",
+  "reopened",
+  "converted_to_draft",
+  "ready_for_review",
+]);
+
+/** pull_request event を pr-map cache に反映する。
+ *
+ *  - cache 不在は no-op (applyIssueCommentEvent と同じ規約 — 空 map に
+ *    patch すると次の full fetch まで他 PR が全部隠れる)
+ *  - closed && merged → state "merged" で残す (release-close 待ちゾーン)
+ *  - closed && !merged → 全 key から除去のみ
+ *  - それ以外 → state "open" で extractIssueRefs(title+body) の各 key に配置
+ *  - storedAt は触らない (= full refresh の安全網周期を維持)
+ */
+export async function applyPullRequestEvent(
+  kv: KVNamespace,
+  payload: PrMapWebhookPayload,
+): Promise<void> {
+  if (!PATCH_ACTIONS.has(payload.action)) return;
+  const cached = await kv.get(PR_MAP_CACHE_KEY, "json") as PrMapCacheEntry | null;
+  if (!cached) return;
+
+  const repo = payload.repository.full_name;
+  const pr = payload.pull_request;
+
+  // まずこの PR を全 key から除去 (ref の付け替え / close に共通の前処理)。
+  const data = cached.data;
+  for (const key of Object.keys(data)) {
+    const filtered = data[key]!.filter(
+      (ref) => !(ref.repo === repo && ref.number === pr.number),
+    );
+    if (filtered.length === 0) delete data[key];
+    else data[key] = filtered;
+  }
+
+  // closed-unmerged は除去のみ。title が無い最小 payload も再配置できない
+  // ので除去のみ (実配信では title は常に載る)。
+  const removeOnly =
+    (payload.action === "closed" && !pr.merged) || pr.title === undefined;
+  if (!removeOnly) {
+    const state: IssuePrRef["state"] =
+      payload.action === "closed" && pr.merged ? "merged" : "open";
+    const ref: IssuePrRef = {
+      repo,
+      number: pr.number,
+      title: pr.title!,
+      url: pr.html_url ?? `https://github.com/${repo}/pull/${pr.number}`,
+      draft: pr.draft ?? false,
+      updated_at: pr.updated_at ?? new Date().toISOString(),
+      state,
+    };
+    const refs = extractIssueRefs(repo, `${pr.title}\n${pr.body ?? ""}`);
+    for (const key of refs) {
+      const list = data[key] ?? [];
+      list.push(ref);
+      list.sort(sortPrRefs);
+      data[key] = list;
+    }
+  }
+
+  const entry: PrMapCacheEntry = {
+    storedAt: cached.storedAt,
+    patchedAt: Date.now(),
+    data,
+  };
+  await kv.put(PR_MAP_CACHE_KEY, JSON.stringify(entry), {
+    expirationTtl: PR_MAP_STORE_SECONDS,
+  });
+}
+
+// Test 用に内部定数を公開。production code からは呼ばない。
+export const __testing = {
+  PR_MAP_FRESH_SECONDS,
+  PR_MAP_STORE_SECONDS,
+  REFRESH_LOCK_KEY,
+};

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -19,6 +19,7 @@ import {
   invalidateRepoCommits,
   invalidateRepoCompare,
 } from "./release-cache";
+import { applyPullRequestEvent } from "./pr-map-cache";
 
 interface ReleaseWebhookPayload {
   action: string;
@@ -79,6 +80,14 @@ interface PullRequestPayload {
     merged: boolean;
     merge_commit_sha: string | null;
     base: { ref: string };
+    // pr-map patch (Refs #304) 用。GitHub の実配信には常に載るが、optional
+    // にして最小 payload (テスト fixture) でも落ちないようにする。title が
+    // 無い場合 applyPullRequestEvent は除去のみ行う。
+    title?: string;
+    body?: string | null;
+    draft?: boolean;
+    html_url?: string;
+    updated_at?: string;
   };
   repository: {
     full_name: string;
@@ -204,6 +213,13 @@ export async function handleWebhook(
   if (event === "pull_request") {
     const payload: PullRequestPayload = JSON.parse(body);
     const repo = payload.repository.full_name;
+
+    // /issues の関連 PR chip (pr-map cache) を即時 patch する (Refs #304)。
+    // merge 判定とは独立に全 action で呼ぶ — opened / edited / reopened /
+    // draft flip も chip の表示内容を変えるため。対象外 action や cache
+    // 不在は applyPullRequestEvent 側が no-op にする。
+    await applyPullRequestEvent(env.CI_STATUS, payload);
+
     const isMergeToDefault =
       payload.action === "closed" &&
       payload.pull_request.merged === true &&

--- a/test/github-backoff.test.ts
+++ b/test/github-backoff.test.ts
@@ -1,0 +1,46 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect, beforeEach } from "vitest";
+import { GitHubApiError } from "../src/github-api";
+import {
+  isRateLimitError,
+  setRateLimitBackoff,
+  getRateLimitBackoff,
+  __testing,
+} from "../src/github-backoff";
+
+describe("github-backoff", () => {
+  beforeEach(async () => {
+    await env.CI_STATUS.delete(__testing.BACKOFF_KEY);
+  });
+
+  it("isRateLimitError: GitHubApiError 403/429 と 'rate limit' 文言を拾う", () => {
+    expect(isRateLimitError(new GitHubApiError(403, "GitHub API 403: forbidden"))).toBe(true);
+    expect(isRateLimitError(new GitHubApiError(429, "GitHub API 429: slow down"))).toBe(true);
+    expect(isRateLimitError(new GitHubApiError(500, "GitHub API 500: boom"))).toBe(false);
+    expect(isRateLimitError(new Error("API rate limit already exceeded for user ID 1"))).toBe(true);
+    expect(isRateLimitError(new Error("network down"))).toBe(false);
+    expect(isRateLimitError("string error mentioning rate limit")).toBe(true);
+  });
+
+  it("set → get roundtrip: until ≈ now + TTL、message は 200 字 trim", async () => {
+    const before = Date.now();
+    await setRateLimitBackoff(env.CI_STATUS, new GitHubApiError(403, "x".repeat(500)));
+    const entry = await getRateLimitBackoff(env.CI_STATUS);
+    expect(entry).not.toBeNull();
+    expect(entry!.status).toBe(403);
+    expect(entry!.message).toHaveLength(200);
+    expect(entry!.until).toBeGreaterThanOrEqual(before + __testing.BACKOFF_TTL_SECONDS * 1000);
+    expect(entry!.until).toBeLessThanOrEqual(Date.now() + __testing.BACKOFF_TTL_SECONDS * 1000);
+  });
+
+  it("marker 無しは null", async () => {
+    expect(await getRateLimitBackoff(env.CI_STATUS)).toBeNull();
+  });
+
+  it("非 GitHubApiError は status 0 で記録される", async () => {
+    await setRateLimitBackoff(env.CI_STATUS, new Error("secondary rate limit hit"));
+    const entry = await getRateLimitBackoff(env.CI_STATUS);
+    expect(entry!.status).toBe(0);
+    expect(entry!.message).toContain("secondary rate limit");
+  });
+});

--- a/test/issue-cache.test.ts
+++ b/test/issue-cache.test.ts
@@ -29,6 +29,8 @@ function makeIssue(over: Partial<OrgIssue> = {}): OrgIssue {
 }
 
 async function clearCache(): Promise<void> {
+  // backoff marker (Refs #304) も leak すると後続 reconcile が silent no-op になる。
+  await env.CI_STATUS.delete("github:rl-backoff");
   // KV.list でテスト間 leak しないよう全 prefix を flush。
   for (const prefix of [__testing.KEY_PREFIX, "issues:"]) {
     let cursor: string | undefined;
@@ -198,6 +200,44 @@ describe("issue-cache", () => {
       // incomplete なので #99 は誤 evict しない
       const still = await env.CI_STATUS.get(issueKey("ippoan/ci-dashboard", 99));
       expect(still).not.toBeNull();
+    });
+
+    it("rate-limit backoff 中は fetch せず watermark も書かない (Refs #304)", async () => {
+      const { setRateLimitBackoff } = await import("../src/github-backoff");
+      const { GitHubApiError } = await import("../src/github-api");
+      await setRateLimitBackoff(env.CI_STATUS, new GitHubApiError(403, "rate limit"));
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+      const result = await reconcileIssues(env, { mainOrgs: ["ippoan"], yhondaRepos: [] });
+      expect(result.fetched).toBe(false);
+      expect(fetchSpy).not.toHaveBeenCalled();
+      // watermark 未更新 → backoff 解除後の初リクエストで即 refresh できる
+      expect(await env.CI_STATUS.get(__testing.KEY_WATERMARK)).toBeNull();
+    });
+
+    it("fetch が 403 (rate limit) なら backoff marker を立てて throw (Refs #304)", async () => {
+      const { getRateLimitBackoff } = await import("../src/github-backoff");
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+        const url = typeof input === "string" ? input : (input as Request).url;
+        if (url.includes("auth-worker") || url.includes("/mcp/token")) {
+          return Response.json({ access_token: "tok" });
+        }
+        return new Response("API rate limit exceeded", { status: 403 });
+      });
+
+      await expect(
+        reconcileIssues(env, { mainOrgs: ["ippoan"], yhondaRepos: [] }),
+      ).rejects.toThrow();
+      expect(await getRateLimitBackoff(env.CI_STATUS)).not.toBeNull();
+    });
+
+    it("reconcile lock 中は fetch しない (SWR の重複排除、Refs #304)", async () => {
+      await env.CI_STATUS.put(__testing.RECONCILE_LOCK_KEY, "1", { expirationTtl: 60 });
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+      const result = await reconcileIssues(env, { mainOrgs: ["ippoan"], yhondaRepos: [] });
+      expect(result.fetched).toBe(false);
+      expect(fetchSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -244,6 +244,11 @@ describe("GET /issues", () => {
     // reconcile が fresh window 判定で skip し、cold-start の fetch が
     // 走らないため stub が当たらず空 cache を返す。
     await env.CI_STATUS.delete("issues:watermark");
+    // Refs #304: backoff / soft-lock marker が漏れると後続テストの reconcile
+    // が silent no-op になり cold-start fixture が当たらない。
+    await env.CI_STATUS.delete("github:rl-backoff");
+    await env.CI_STATUS.delete("issues:reconciling");
+    await env.CI_STATUS.delete("issues-page:pr-map:refreshing");
     // Refs #135: /issues も project-cache の KV (`project:*`) を共有するため
     // テスト間で flush しないと前テストの fixture が漏れる。
     for (const prefix of ["issue:", "project:"]) {
@@ -440,6 +445,11 @@ describe("GET /issues — Project section", () => {
     // reconcile が fresh window 判定で skip し、cold-start の fetch が
     // 走らないため stub が当たらず空 cache を返す。
     await env.CI_STATUS.delete("issues:watermark");
+    // Refs #304: backoff / soft-lock marker が漏れると後続テストの reconcile
+    // が silent no-op になり cold-start fixture が当たらない。
+    await env.CI_STATUS.delete("github:rl-backoff");
+    await env.CI_STATUS.delete("issues:reconciling");
+    await env.CI_STATUS.delete("issues-page:pr-map:refreshing");
     // Refs #135: /issues も project-cache の KV (`project:*`) を共有するため
     // テスト間で flush しないと前テストの fixture が漏れる。
     for (const prefix of ["issue:", "project:"]) {
@@ -616,6 +626,11 @@ describe("GET /issues — Claude Code launch button", () => {
     // reconcile が fresh window 判定で skip し、cold-start の fetch が
     // 走らないため stub が当たらず空 cache を返す。
     await env.CI_STATUS.delete("issues:watermark");
+    // Refs #304: backoff / soft-lock marker が漏れると後続テストの reconcile
+    // が silent no-op になり cold-start fixture が当たらない。
+    await env.CI_STATUS.delete("github:rl-backoff");
+    await env.CI_STATUS.delete("issues:reconciling");
+    await env.CI_STATUS.delete("issues-page:pr-map:refreshing");
     // Refs #135: /issues も project-cache の KV (`project:*`) を共有するため
     // テスト間で flush しないと前テストの fixture が漏れる。
     for (const prefix of ["issue:", "project:"]) {
@@ -677,6 +692,11 @@ describe("GET /issues — Related-PR chips", () => {
     // reconcile が fresh window 判定で skip し、cold-start の fetch が
     // 走らないため stub が当たらず空 cache を返す。
     await env.CI_STATUS.delete("issues:watermark");
+    // Refs #304: backoff / soft-lock marker が漏れると後続テストの reconcile
+    // が silent no-op になり cold-start fixture が当たらない。
+    await env.CI_STATUS.delete("github:rl-backoff");
+    await env.CI_STATUS.delete("issues:reconciling");
+    await env.CI_STATUS.delete("issues-page:pr-map:refreshing");
     // Refs #135: /issues も project-cache の KV (`project:*`) を共有するため
     // テスト間で flush しないと前テストの fixture が漏れる。
     for (const prefix of ["issue:", "project:"]) {
@@ -847,6 +867,11 @@ describe("GET /issues — CI fixture rows", () => {
     await env.CI_STATUS.delete("issues-page:project-map");
     await env.CI_STATUS.delete("issues-page:pr-map:v2");
     await env.CI_STATUS.delete("issues:watermark");
+    // Refs #304: backoff / soft-lock marker が漏れると後続テストの reconcile
+    // が silent no-op になり cold-start fixture が当たらない。
+    await env.CI_STATUS.delete("github:rl-backoff");
+    await env.CI_STATUS.delete("issues:reconciling");
+    await env.CI_STATUS.delete("issues-page:pr-map:refreshing");
     for (const prefix of ["issue:", "project:"]) {
       let cursor: string | undefined;
       do {
@@ -920,5 +945,167 @@ describe("escapeHtml()", () => {
 
   it("is a no-op for plain text", () => {
     expect(escapeHtml("plain text 123")).toBe("plain text 123");
+  });
+});
+
+// ───── SWR (Refs #304) ─────
+//
+// Warm cache (issue:* が KV に居る) 時は GitHub を一切待たずに render し、
+// reconcile / PR map refresh は ctx.waitUntil で裏実行される。
+describe("GET /issues — SWR (Refs #304)", () => {
+  beforeEach(async () => {
+    await env.CI_STATUS.delete("issues-page:project-map");
+    await env.CI_STATUS.delete("issues-page:pr-map:v2");
+    await env.CI_STATUS.delete("issues:watermark");
+    await env.CI_STATUS.delete("github:rl-backoff");
+    await env.CI_STATUS.delete("issues:reconciling");
+    await env.CI_STATUS.delete("issues-page:pr-map:refreshing");
+    for (const prefix of ["issue:", "project:"]) {
+      let cursor: string | undefined;
+      do {
+        const page = await env.CI_STATUS.list({ prefix, cursor });
+        await Promise.all(page.keys.map((k) => env.CI_STATUS.delete(k.name)));
+        cursor = page.list_complete ? undefined : page.cursor;
+      } while (cursor);
+    }
+  });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  async function seedIssue(repo: string, number: number, title: string): Promise<void> {
+    await env.CI_STATUS.put(`issue:${repo}#${number}`, JSON.stringify({
+      repo, number, title, state: "open", author: "y", labels: [], assignees: [],
+      comments: 0, created_at: "2026-06-01T00:00:00Z", updated_at: "2026-06-01T00:00:00Z",
+      url: `https://github.com/${repo}/issues/${number}`,
+    }));
+  }
+
+  async function seedPrMap(storedAt: number): Promise<void> {
+    await env.CI_STATUS.put("issues-page:pr-map:v2", JSON.stringify({ storedAt, data: {} }));
+  }
+
+  function searchCalls(spy: ReturnType<typeof vi.spyOn>): number {
+    return spy.mock.calls.filter((c) => {
+      const u = typeof c[0] === "string" ? c[0] : (c[0] as Request).url;
+      return u.includes("/search/issues");
+    }).length;
+  }
+
+  it("warm + fresh: GitHub Search を 1 回も呼ばない", async () => {
+    const fetchSpy = stubSearchIssues();
+    await seedIssue("ippoan/rust-alc-api", 7, "cached issue");
+    await env.CI_STATUS.put("issues:watermark", new Date(Date.now() - 5_000).toISOString());
+    await seedPrMap(Date.now());
+
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request("http://localhost/issues"), testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("cached issue");
+    expect(html).not.toContain("Refreshing in background");
+    expect(searchCalls(fetchSpy as never)).toBe(0);
+  });
+
+  it("warm + stale: 旧データを即返しして background で 6 call refresh", async () => {
+    const fetchSpy = stubSearchIssues();
+    await seedIssue("ippoan/rust-alc-api", 7, "old cached title");
+    const oldWm = new Date(Date.now() - 120_000).toISOString();
+    await env.CI_STATUS.put("issues:watermark", oldWm);
+    await seedPrMap(Date.now() - 700_000);
+
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request("http://localhost/issues"), testEnv(), ctx);
+
+    // 即返し: 旧 cache の中身 + 🔄 バナー、生エラー無し
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("old cached title");
+    expect(html).toContain("Refreshing in background");
+
+    // background 完了後: issues ×2 + PR ×4 = 6 call、watermark が進む
+    await waitOnExecutionContext(ctx);
+    expect(searchCalls(fetchSpy as never)).toBe(6);
+    const wm = await env.CI_STATUS.get("issues:watermark");
+    expect(Date.parse(wm!)).toBeGreaterThan(Date.parse(oldWm));
+    // stub の fresh data が KV に反映されている (#7 の本物 title)
+    const updated = await env.CI_STATUS.get("issue:ippoan/rust-alc-api#7", "json") as { title: string };
+    expect(updated.title).toContain("alert('xss')");
+  });
+
+  it("warm + GitHub 403: 200 で cache 表示、backoff marker が立ち 2 回目は 0 call + cooldown バナー", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
+      const url = typeof req === "string" ? req : (req as Request).url;
+      if (url.includes("/graphql")) {
+        return Response.json({ data: { repositoryOwner: { projectsV2: { nodes: [] } } } });
+      }
+      return new Response("API rate limit exceeded", { status: 403 });
+    });
+    await seedIssue("ippoan/rust-alc-api", 7, "survives rate limit");
+    await env.CI_STATUS.put("issues:watermark", new Date(Date.now() - 120_000).toISOString());
+    await seedPrMap(Date.now() - 700_000);
+
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request("http://localhost/issues"), testEnv(), ctx);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("survives rate limit");
+    expect(html).not.toContain("Failed to fetch issues");
+
+    // background の 403 で backoff marker が立つ (waitUntil は pre-catch 済み)
+    await waitOnExecutionContext(ctx);
+    expect(await env.CI_STATUS.get("github:rl-backoff")).not.toBeNull();
+
+    // 2 回目: backoff 中 → search 0 call + cooldown バナー
+    // NB: 既に spy 済みの fetch への vi.spyOn は同一 spy を返し 1 回目の履歴が
+    // 累積するため、mockClear してから delta を測る。
+    const fetchSpy2 = vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
+      const url = typeof req === "string" ? req : (req as Request).url;
+      if (url.includes("/graphql")) {
+        return Response.json({ data: { repositoryOwner: { projectsV2: { nodes: [] } } } });
+      }
+      return new Response("should not be called", { status: 500 });
+    });
+    fetchSpy2.mockClear();
+    const ctx2 = createExecutionContext();
+    const res2 = await worker.fetch(new Request("http://localhost/issues"), testEnv(), ctx2);
+    await waitOnExecutionContext(ctx2);
+    expect(res2.status).toBe(200);
+    const html2 = await res2.text();
+    expect(html2).toContain("rate-limit cooldown");
+    expect(searchCalls(fetchSpy2 as never)).toBe(0);
+  });
+
+  it("warm + auth error: 302 せず 200 で cache を返す (background では redirect 不可)", async () => {
+    stubSearchIssues();
+    await seedIssue("ippoan/rust-alc-api", 7, "warm survives auth expiry");
+    await env.CI_STATUS.put("issues:watermark", new Date(Date.now() - 120_000).toISOString());
+    await seedPrMap(Date.now());
+    // token cache を落とす → background reconcile が auth error で fail する
+    await env.CI_STATUS.delete("auth-client-worker:gh-token");
+
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request("http://localhost/issues"), testEnv(), ctx);
+    // waitUntil の reject が pre-catch されていれば resolve する
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    expect((await res.text())).toContain("warm survives auth expiry");
+  });
+
+  it("cold + backoff: 「issue ゼロ」と誤表示せず 503 cooldown を返す", async () => {
+    const { setRateLimitBackoff } = await import("../src/github-backoff");
+    const { GitHubApiError } = await import("../src/github-api");
+    await setRateLimitBackoff(env.CI_STATUS, new GitHubApiError(403, "rate limit"));
+    const fetchSpy = stubSearchIssues();
+
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request("http://localhost/issues"), testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBeTruthy();
+    expect(await res.text()).toContain("rate-limit cooldown");
+    expect(searchCalls(fetchSpy as never)).toBe(0);
   });
 });

--- a/test/pr-map-cache.test.ts
+++ b/test/pr-map-cache.test.ts
@@ -1,0 +1,264 @@
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import type { AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
+import { appTestEnv } from "./_helpers/app-env";
+import {
+  loadPrMap,
+  refreshPrMap,
+  applyPullRequestEvent,
+  PR_MAP_CACHE_KEY,
+  __testing,
+  type PrMapWebhookPayload,
+} from "../src/pr-map-cache";
+import {
+  setRateLimitBackoff,
+  getRateLimitBackoff,
+  __testing as backoffTesting,
+} from "../src/github-backoff";
+import { GitHubApiError } from "../src/github-api";
+import type { IssuePrRef } from "../src/issue-prs";
+
+const ORGS = ["ippoan", "ohishi-exp"];
+const YHONDA = ["yhonda-ohishi/claude-skills"];
+
+function testEnv(): AuthClientWorkerEnv {
+  return appTestEnv() as unknown as AuthClientWorkerEnv;
+}
+
+/** /search/issues (is:pr) を空 result で stub。失敗させたい時は status を渡す。 */
+function stubPrSearch(opts: { status?: number; bodyText?: string } = {}) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (req) => {
+    const url = typeof req === "string" ? req : (req as Request).url;
+    if (!url.includes("/search/issues")) {
+      return new Response("not stubbed: " + url, { status: 500 });
+    }
+    if (opts.status) {
+      return new Response(opts.bodyText ?? "rate limited", { status: opts.status });
+    }
+    return Response.json({ total_count: 0, incomplete_results: false, items: [] });
+  });
+}
+
+function prRef(over: Partial<IssuePrRef> = {}): IssuePrRef {
+  return {
+    repo: "ippoan/x",
+    number: 42,
+    title: "feat: y",
+    url: "https://github.com/ippoan/x/pull/42",
+    draft: false,
+    updated_at: "2026-06-01T00:00:00Z",
+    state: "open",
+    ...over,
+  };
+}
+
+interface StoredEntry {
+  storedAt: number;
+  patchedAt?: number;
+  data: Record<string, IssuePrRef[]>;
+}
+
+async function seedMap(data: Record<string, IssuePrRef[]>, storedAt = Date.now()): Promise<void> {
+  await env.CI_STATUS.put(PR_MAP_CACHE_KEY, JSON.stringify({ storedAt, data }));
+}
+
+async function readMap(): Promise<StoredEntry | null> {
+  return await env.CI_STATUS.get(PR_MAP_CACHE_KEY, "json") as StoredEntry | null;
+}
+
+function prPayload(over: {
+  action?: string;
+  number?: number;
+  merged?: boolean;
+  title?: string;
+  body?: string | null;
+  draft?: boolean;
+  repo?: string;
+} = {}): PrMapWebhookPayload {
+  const { action = "opened", number = 42, merged = false, title, body, draft, repo = "ippoan/x" } = over;
+  return {
+    action,
+    pull_request: {
+      number,
+      merged,
+      ...(title !== undefined ? { title } : {}),
+      ...(body !== undefined ? { body } : {}),
+      ...(draft !== undefined ? { draft } : {}),
+      html_url: `https://github.com/${repo}/pull/${number}`,
+      updated_at: "2026-06-10T00:00:00Z",
+    },
+    repository: { full_name: repo },
+  };
+}
+
+beforeEach(async () => {
+  await env.CI_STATUS.delete(PR_MAP_CACHE_KEY);
+  await env.CI_STATUS.delete(__testing.REFRESH_LOCK_KEY);
+  await env.CI_STATUS.delete(backoffTesting.BACKOFF_KEY);
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("loadPrMap (SWR)", () => {
+  it("fresh cache: fetch せず即返し (refreshing=false)", async () => {
+    const fetchSpy = stubPrSearch();
+    await seedMap({ "ippoan/x#7": [prRef()] });
+    const ctx = createExecutionContext();
+    const res = await loadPrMap(testEnv(), ORGS, YHONDA, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(res.refreshing).toBe(false);
+    expect(res.stale).toBe(false);
+    expect(res.map.get("ippoan/x#7")).toHaveLength(1);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("stale cache: 旧データ即返し + refreshing=true、background で fetch + storedAt 更新", async () => {
+    const fetchSpy = stubPrSearch();
+    const oldStoredAt = Date.now() - (__testing.PR_MAP_FRESH_SECONDS + 10) * 1000;
+    await seedMap({ "ippoan/x#7": [prRef()] }, oldStoredAt);
+    const ctx = createExecutionContext();
+    const res = await loadPrMap(testEnv(), ORGS, YHONDA, ctx);
+    // 即返し: 旧データのまま
+    expect(res.refreshing).toBe(true);
+    expect(res.map.get("ippoan/x#7")).toHaveLength(1);
+    // background refresh の完了後に storedAt が進み、4 call fetch 済み
+    await waitOnExecutionContext(ctx);
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
+    const entry = await readMap();
+    expect(entry!.storedAt).toBeGreaterThan(oldStoredAt);
+  });
+
+  it("stale + background 403: 即返しは成功、backoff marker が立つ (waitUntil reject しない)", async () => {
+    stubPrSearch({ status: 403, bodyText: "API rate limit exceeded" });
+    const oldStoredAt = Date.now() - (__testing.PR_MAP_FRESH_SECONDS + 10) * 1000;
+    await seedMap({ "ippoan/x#7": [prRef()] }, oldStoredAt);
+    const ctx = createExecutionContext();
+    const res = await loadPrMap(testEnv(), ORGS, YHONDA, ctx);
+    expect(res.map.size).toBe(1);
+    // pre-catch されているので waitOnExecutionContext は throw しない
+    await waitOnExecutionContext(ctx);
+    expect(await getRateLimitBackoff(env.CI_STATUS)).not.toBeNull();
+    // storedAt は失敗時に進まない
+    const entry = await readMap();
+    expect(entry!.storedAt).toBe(oldStoredAt);
+  });
+
+  it("cold start (cache 無し): 同期 fetch、失敗は error として返す (従来挙動)", async () => {
+    stubPrSearch({ status: 403, bodyText: "API rate limit exceeded" });
+    const ctx = createExecutionContext();
+    const res = await loadPrMap(testEnv(), ORGS, YHONDA, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(res.map.size).toBe(0);
+    expect(res.error).toContain("403");
+    // cold start の rate limit も backoff を立てる
+    expect(await getRateLimitBackoff(env.CI_STATUS)).not.toBeNull();
+  });
+});
+
+describe("refreshPrMap (short-circuits)", () => {
+  it("backoff 中は fetch しない", async () => {
+    const fetchSpy = stubPrSearch();
+    await setRateLimitBackoff(env.CI_STATUS, new GitHubApiError(403, "rate limit"));
+    await refreshPrMap(testEnv(), ORGS, YHONDA);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("soft lock 中は fetch しない", async () => {
+    const fetchSpy = stubPrSearch();
+    await env.CI_STATUS.put(__testing.REFRESH_LOCK_KEY, "1", { expirationTtl: 60 });
+    await refreshPrMap(testEnv(), ORGS, YHONDA);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("lock 取得後に fresh entry を見つけたら bail", async () => {
+    const fetchSpy = stubPrSearch();
+    await seedMap({}, Date.now()); // fresh
+    await refreshPrMap(testEnv(), ORGS, YHONDA);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("applyPullRequestEvent (pull_request webhook patch)", () => {
+  it("cache 不在は no-op (entry を作らない)", async () => {
+    await applyPullRequestEvent(env.CI_STATUS, prPayload({ title: "t", body: "Refs #7" }));
+    expect(await readMap()).toBeNull();
+  });
+
+  it("opened + Refs #7: 該当 issue key に追加、storedAt 不変 + patchedAt 付与", async () => {
+    const storedAt = Date.now() - 1000;
+    await seedMap({}, storedAt);
+    await applyPullRequestEvent(
+      env.CI_STATUS,
+      prPayload({ action: "opened", title: "feat: y", body: "Refs #7" }),
+    );
+    const entry = await readMap();
+    expect(entry!.storedAt).toBe(storedAt);
+    expect(entry!.patchedAt).toBeGreaterThan(0);
+    expect(entry!.data["ippoan/x#7"]).toHaveLength(1);
+    expect(entry!.data["ippoan/x#7"]![0]!.state).toBe("open");
+  });
+
+  it("closed + merged: state が merged に変わる", async () => {
+    await seedMap({ "ippoan/x#7": [prRef()] });
+    await applyPullRequestEvent(
+      env.CI_STATUS,
+      prPayload({ action: "closed", merged: true, title: "feat: y", body: "Refs #7" }),
+    );
+    const entry = await readMap();
+    expect(entry!.data["ippoan/x#7"]).toHaveLength(1);
+    expect(entry!.data["ippoan/x#7"]![0]!.state).toBe("merged");
+  });
+
+  it("closed + unmerged: 全 key から除去 (空 key は削除)", async () => {
+    await seedMap({ "ippoan/x#7": [prRef()] });
+    await applyPullRequestEvent(
+      env.CI_STATUS,
+      prPayload({ action: "closed", merged: false, title: "feat: y", body: "Refs #7" }),
+    );
+    const entry = await readMap();
+    expect(entry!.data["ippoan/x#7"]).toBeUndefined();
+  });
+
+  it("edited で ref を #7→#8 に移動: 旧 key から消えて新 key に現れる", async () => {
+    await seedMap({ "ippoan/x#7": [prRef()] });
+    await applyPullRequestEvent(
+      env.CI_STATUS,
+      prPayload({ action: "edited", title: "feat: y", body: "Refs #8" }),
+    );
+    const entry = await readMap();
+    expect(entry!.data["ippoan/x#7"]).toBeUndefined();
+    expect(entry!.data["ippoan/x#8"]).toHaveLength(1);
+  });
+
+  it("title 無し最小 payload は除去のみ (既存 fixture 互換)", async () => {
+    await seedMap({ "ippoan/x#7": [prRef()] });
+    await applyPullRequestEvent(env.CI_STATUS, prPayload({ action: "closed", merged: true }));
+    const entry = await readMap();
+    expect(entry!.data["ippoan/x#7"]).toBeUndefined();
+  });
+
+  it("対象外 action (synchronize) は no-op (patchedAt 付かない)", async () => {
+    await seedMap({ "ippoan/x#7": [prRef()] });
+    await applyPullRequestEvent(
+      env.CI_STATUS,
+      prPayload({ action: "synchronize", title: "feat: y", body: "Refs #99" }),
+    );
+    const entry = await readMap();
+    expect(entry!.patchedAt).toBeUndefined();
+    expect(entry!.data["ippoan/x#7"]).toHaveLength(1);
+  });
+
+  it("他 repo の同番号 PR は除去しない", async () => {
+    await seedMap({
+      "ippoan/x#7": [prRef(), prRef({ repo: "ippoan/other", url: "https://github.com/ippoan/other/pull/42" })],
+    });
+    await applyPullRequestEvent(
+      env.CI_STATUS,
+      prPayload({ action: "closed", merged: false, title: "t", body: "Refs #7" }),
+    );
+    const entry = await readMap();
+    expect(entry!.data["ippoan/x#7"]).toHaveLength(1);
+    expect(entry!.data["ippoan/x#7"]![0]!.repo).toBe("ippoan/other");
+  });
+});

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -836,3 +836,119 @@ describe("POST /webhook", () => {
     expect(await env.CI_STATUS.get("rcache:v1:issue:ippoan/foo:42")).toBeNull();
   });
 });
+
+// ───── pull_request → pr-map cache patch (Refs #304) ─────
+//
+// /issues の関連 PR chip 用 KV cache (pr-map-cache.ts) を webhook が即時
+// patch する配線のテスト。patch ロジック自体の matrix は
+// test/pr-map-cache.test.ts でカバーする — ここでは「webhook handler から
+// applyPullRequestEvent が呼ばれ、KV に反映される」ことだけを確認する。
+describe("POST /webhook pull_request — pr-map patch (Refs #304)", () => {
+  const PR_MAP_KEY = "issues-page:pr-map:v2";
+
+  beforeEach(async () => {
+    resetHubCalls();
+    await env.CI_STATUS.delete(PR_MAP_KEY);
+  });
+
+  it("opened + Refs #N で pr-map に chip が追加される (storedAt 不変)", async () => {
+    const storedAt = Date.now() - 1000;
+    await env.CI_STATUS.put(PR_MAP_KEY, JSON.stringify({ storedAt, data: {} }));
+
+    const body = JSON.stringify({
+      action: "opened",
+      pull_request: {
+        number: 12,
+        merged: false,
+        merge_commit_sha: null,
+        base: { ref: "main" },
+        title: "feat: do the thing",
+        body: "Refs #7",
+        draft: false,
+        html_url: "https://github.com/ippoan/rust-alc-api/pull/12",
+        updated_at: "2026-06-10T00:00:00Z",
+      },
+      repository: { full_name: "ippoan/rust-alc-api", default_branch: "main" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST", body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "pull_request" },
+      }),
+      testEnv(), ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(200);
+
+    const entry = await env.CI_STATUS.get(PR_MAP_KEY, "json") as {
+      storedAt: number;
+      patchedAt?: number;
+      data: Record<string, Array<{ number: number; state: string }>>;
+    };
+    expect(entry.storedAt).toBe(storedAt);
+    expect(entry.patchedAt).toBeGreaterThan(0);
+    expect(entry.data["ippoan/rust-alc-api#7"]).toHaveLength(1);
+    expect(entry.data["ippoan/rust-alc-api#7"]![0]!.number).toBe(12);
+    expect(entry.data["ippoan/rust-alc-api#7"]![0]!.state).toBe("open");
+  });
+
+  it("cache 不在の pull_request event は pr-map を作らない (no-op)", async () => {
+    const body = JSON.stringify({
+      action: "opened",
+      pull_request: {
+        number: 12, merged: false, merge_commit_sha: null, base: { ref: "main" },
+        title: "feat: x", body: "Refs #7",
+        html_url: "https://github.com/ippoan/rust-alc-api/pull/12",
+        updated_at: "2026-06-10T00:00:00Z",
+      },
+      repository: { full_name: "ippoan/rust-alc-api", default_branch: "main" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST", body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "pull_request" },
+      }),
+      testEnv(), ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(await env.CI_STATUS.get(PR_MAP_KEY)).toBeNull();
+  });
+
+  it("title 無しの最小 payload (既存 fixture 形) でも 200 (除去のみ動作)", async () => {
+    await env.CI_STATUS.put(PR_MAP_KEY, JSON.stringify({
+      storedAt: Date.now(),
+      data: {
+        "ippoan/secrets-inventory-gcp#3": [{
+          repo: "ippoan/secrets-inventory-gcp", number: 8, title: "old",
+          url: "https://github.com/ippoan/secrets-inventory-gcp/pull/8",
+          draft: false, updated_at: "2026-06-01T00:00:00Z", state: "open",
+        }],
+      },
+    }));
+    const body = JSON.stringify({
+      action: "closed",
+      pull_request: { number: 8, merged: false, merge_commit_sha: null, base: { ref: "main" } },
+      repository: { full_name: "ippoan/secrets-inventory-gcp", default_branch: "main" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST", body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "pull_request" },
+      }),
+      testEnv(), ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(200);
+    const entry = await env.CI_STATUS.get(PR_MAP_KEY, "json") as {
+      data: Record<string, unknown[]>;
+    };
+    // closed-unmerged → 除去 (key ごと消える)
+    expect(entry.data["ippoan/secrets-inventory-gcp#3"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Refs #304

## 問題

/issues が GitHub rate limit で頻繁に "rate over" (502 / 生エラーバナー)。SSR が KV stale 時に Search API を同期で待ち (issue reconcile ×2 + 関連 PR map ×4)、token が MCP / Actions PAT と共有のため quota が枯れやすい (Search は token あたり 30 req/分の専用枠)。

## 変更内容

### 1. SWR 化 (`src/issues-page.ts` / `src/index.ts`)

- issue cache が warm なら **GitHub を一切待たずに即 render**、reconcile は `ctx.waitUntil` で裏実行 (エラーは log のみ、ページに生エラーを出さない)
- cold start (cache 空) は従来どおり同期 — `/oauth/login` redirect / 502 の挙動とテストは不変
- cold start + backoff 中は「issue ゼロ 🎉」と誤表示せず **503 + Retry-After** で cooldown を明示

### 2. pr-map cache の移設 + webhook patch (`src/pr-map-cache.ts` / `src/webhook.ts`)

- pr-map cache を issues-page.ts から `src/pr-map-cache.ts` に移設 (webhook ↔ page の循環 import 回避)。KV key / shape は互換 (`patchedAt?` 追加のみ、v2 のまま)
- `pull_request` webhook (opened/edited/closed/reopened/draft flip) が cache を直接 patch。`storedAt` は触らない = full refresh が安全網 (issue-cache の watermark 規約と同じ)
- これにより fresh window を **120s → 600s** に拡大 (Search ×4 が 1/5 に)。PR の open/merge は webhook で秒反映 = 鮮度はむしろ向上

### 3. rate-limit backoff (`src/github-backoff.ts`)

- 403/429 検出で KV marker (TTL 300s)。reconcile / pr-map refresh は marker 中 no-op
- watermark / storedAt は no-op 時に動かさない → 解除後の初リクエストで即 refresh (staleness が複利しない)
- ページには ⏳ cooldown info バナー (再開予定時刻付き)、🔄 background refresh バナーを表示

### 4. soft lock

`issues:reconciling` / `issues-page:pr-map:refreshing` (TTL 60s) で並走する background refresh を重複排除。

## 不採用案 (issue #304 に記録)

- **delta query (`updated:>=`)**: Search quota はリクエスト単位消費で節約ゼロ + #129 で実害が出て full snapshot に戻した経緯あり
- **ETag conditional**: /search は ETag が安定せず hit 率 ~0
- **cron 化**: 即時性要件 (releases との突き合わせ) で却下

## テスト

761 passed (新規 30: github-backoff 4 / pr-map-cache 14 / issue-cache 3 / issues-page SWR 5 / webhook patch 3 + 既存更新)。既存テストは cold path 前提のため挙動不変、beforeEach に新 marker の cleanup を追加。

## 効果見込み

- SSR の同期 GitHub 呼び出しゼロ (cold start 除く) = rate over がユーザーに見える経路の消滅
- Search 呼び出し ≈ 65% 減、backoff 中は 0

https://claude.ai/code/session_019STQEmTfAqCGkrKvv4bGrL

---
_Generated by [Claude Code](https://claude.ai/code/session_019STQEmTfAqCGkrKvv4bGrL)_