### PR TITLE
feat(release-wave): auto fan-out retest to consumers on backend deploy

### DIFF
--- a/src/release-wave/dispatch.ts
+++ b/src/release-wave/dispatch.ts
@@ -18,7 +18,7 @@
 import type { Env } from "../index";
 import { githubApi, parseRepo, tokenForOrg } from "../github-api";
 import type { WaveState } from "./types";
-import type { WaveCompatibility } from "./compat";
+import type { WaveCompatibility, CompatibilityResult } from "./compat";
 
 // ----------------------------------------------------------------------------
 // Types
@@ -147,6 +147,45 @@ export function decideRetestDispatches(
         },
       });
     }
+  }
+  return out;
+}
+
+// ----------------------------------------------------------------------------
+// Pure: decideBackendDeployRetestDispatches (auto-retest on backend deploy)
+// ----------------------------------------------------------------------------
+
+/**
+ * backend deploy 完了 (`backend-deploy-report` webhook) を起点に、新 image を
+ * 未 test の consumer (frontend) へ `release-wave-retest` を自動 fan-out する
+ * dispatch を作る。`/release-wave` の手動 "Re-test" ボタンと等価だが、operator
+ * 操作を待たず deploy 報告で自動化する (Refs #157)。
+ *
+ * `decideRetestDispatches` の wave 非依存版。compatibility matrix の赤
+ * (`tested_against_target === false` = 新 image を未検証の consumer) だけを
+ * 対象にする。これにより同一 image の再報告 (idempotent deploy / 重複 webhook)
+ * では既に緑の consumer に再 dispatch しない (= idempotency)。
+ *
+ * client_payload は `retest-consumer` endpoint と同 shape。consumer 側の
+ * retest 受け (frontend-ci の `compat_backend_image` 経路) は `wave_id` を
+ * 参照しないため、wave 非依存でも動く。
+ */
+export function decideBackendDeployRetestDispatches(
+  compat: CompatibilityResult,
+): Dispatch[] {
+  const out: Dispatch[] = [];
+  for (const m of compat.matrix) {
+    if (m.tested_against_target) continue; // 新 image を test 済みは skip
+    out.push({
+      repo: m.frontend,
+      event_type: "release-wave-retest",
+      client_payload: {
+        // wave 非依存 (= 単独 deploy 起点)。wave_id は載せない。
+        backend_repo: compat.backend_repo,
+        backend_image: compat.backend_target_image,
+        ...(m.prod_version ? { prod_version: m.prod_version } : {}),
+      },
+    });
   }
   return out;
 }

--- a/src/release-wave/webhook.ts
+++ b/src/release-wave/webhook.ts
@@ -20,9 +20,15 @@ import { z } from "zod";
 import type { Env } from "../index";
 import type { ReleaseWaveHub, RpcResult } from "./do";
 import type { WaveState } from "./types";
-import { recordFrontendTest, recordBackendDeploy, getBackendCurrent } from "./compat";
+import {
+  recordFrontendTest,
+  recordBackendDeploy,
+  getBackendCurrent,
+  computeCompatibility,
+} from "./compat";
 import { recordPendingRelease } from "./pending-release";
 import { recordTraffic } from "./traffic";
+import { dispatchAll, decideBackendDeployRetestDispatches } from "./dispatch";
 import {
   recordBackendTraffic,
   type BackendServiceTraffic,
@@ -285,6 +291,23 @@ export async function handleBackendDeployReportWebhook(
     wave_id: v.data.wave_id ?? null,
     now: new Date().toISOString(),
   });
+
+  // 新 image が prod に出たので、その image を未 test の consumer (frontend) に
+  // integration retest を自動 fan-out する (Refs #157)。手動 "Re-test" ボタンと
+  // 等価だが deploy 報告を起点に自動化する。best-effort: dispatch 失敗
+  // (token 取得失敗 / GitHub non-2xx 等) は dispatchAll が per-repo に握り潰し、
+  // report の 200 応答は止めない。COMPAT_KV は validateAndAuth より前段の
+  // recordBackendDeploy が触れている = この時点で bound 確定。
+  const compat = await computeCompatibility(
+    env.COMPAT_KV,
+    v.data.repo,
+    v.data.current_image,
+  );
+  const dispatches = decideBackendDeployRetestDispatches(compat);
+  if (dispatches.length > 0) {
+    await dispatchAll(env, dispatches);
+  }
+
   return jsonResponse(200, { ok: true, record });
 }
 

--- a/test/release-wave/dispatch.test.ts
+++ b/test/release-wave/dispatch.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect } from "vitest";
 import {
   decideDispatches,
   decideRetestDispatches,
+  decideBackendDeployRetestDispatches,
 } from "../../src/release-wave/dispatch";
 import { createWave, transition } from "../../src/release-wave/state";
 import type { WaveState } from "../../src/release-wave/types";
 import type {
   WaveCompatibility,
   CompatMatrixEntry,
+  CompatibilityResult,
 } from "../../src/release-wave/compat";
 
 const T0 = "2026-05-28T00:00:00Z";
@@ -342,5 +344,73 @@ describe("decideRetestDispatches", () => {
       "ippoan/rust-alc-api",
       "ippoan/cc-relay",
     ]);
+  });
+});
+
+// ============================================================================
+// decideBackendDeployRetestDispatches (auto-retest on backend deploy, Refs #157)
+// ============================================================================
+
+function compatResult(over: Partial<CompatibilityResult> = {}): CompatibilityResult {
+  return {
+    backend_repo: "ippoan/rust-alc-api",
+    backend_target_image: "img-new",
+    verified: false,
+    matrix: [],
+    ...over,
+  };
+}
+
+describe("decideBackendDeployRetestDispatches", () => {
+  it("returns empty when the backend has no consumers", () => {
+    expect(decideBackendDeployRetestDispatches(compatResult())).toEqual([]);
+  });
+
+  it("returns empty when every consumer already tested the new image", () => {
+    const c = compatResult({
+      matrix: [
+        entry({ frontend: "ippoan/alc-app", tested_against_target: true }),
+        entry({ frontend: "ippoan/auth-worker", tested_against_target: true }),
+      ],
+    });
+    expect(decideBackendDeployRetestDispatches(c)).toEqual([]);
+  });
+
+  it("fans out wave-independent retest to each consumer not yet on the new image", () => {
+    const c = compatResult({
+      backend_target_image: "img-new",
+      matrix: [
+        entry({ frontend: "ippoan/alc-app", prod_version: "v1.2.10" }),
+        entry({ frontend: "ippoan/auth-worker", tested_against_target: true }),
+        entry({ frontend: "ippoan/nuxt-items", prod_version: "v3" }),
+      ],
+    });
+    const ds = decideBackendDeployRetestDispatches(c);
+    expect(ds.map((d) => d.repo)).toEqual([
+      "ippoan/alc-app",
+      "ippoan/nuxt-items",
+    ]);
+    expect(ds[0]).toEqual({
+      repo: "ippoan/alc-app",
+      event_type: "release-wave-retest",
+      client_payload: {
+        backend_repo: "ippoan/rust-alc-api",
+        backend_image: "img-new",
+        prod_version: "v1.2.10",
+      },
+    });
+    // wave 非依存 = client_payload に wave_id を載せない。
+    for (const d of ds) {
+      expect(d.client_payload).not.toHaveProperty("wave_id");
+    }
+  });
+
+  it("omits prod_version from the payload when the consumer has none", () => {
+    const c = compatResult({
+      matrix: [entry({ frontend: "ippoan/alc-app", prod_version: null })],
+    });
+    const ds = decideBackendDeployRetestDispatches(c);
+    expect(ds).toHaveLength(1);
+    expect(ds[0]!.client_payload).not.toHaveProperty("prod_version");
   });
 });

--- a/test/release-wave/webhook.test.ts
+++ b/test/release-wave/webhook.test.ts
@@ -1,11 +1,13 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   handleContractAppliedWebhook,
   handleFlipReportWebhook,
   handlePendingReleaseWebhook,
   handleTrafficReportWebhook,
   handleBackendTrafficReportWebhook,
+  handleBackendDeployReportWebhook,
 } from "../../src/release-wave/webhook";
+import { recordFrontendTest } from "../../src/release-wave/compat";
 import { getPendingRelease } from "../../src/release-wave/pending-release";
 import { getTraffic } from "../../src/release-wave/traffic";
 import { getBackendTraffic } from "../../src/release-wave/backend-traffic";
@@ -759,5 +761,126 @@ describe("handleBackendTrafficReportWebhook", () => {
       env,
     );
     expect(resp.status).toBe(401);
+  });
+});
+
+// ============================================================================
+// /webhooks/release-wave/backend-deploy-report — auto-retest fan-out
+//   (backend deploy 完了 → 新 image 未 test の consumer に retest 自動 dispatch)
+// ============================================================================
+
+// dispatchAll は GitHub repository_dispatch を打つ IO。workers test pool では
+// 相対モジュールの vi.mock が SUT の import を差し替えられないため、api.test.ts と
+// 同じく global fetch を stub し、CI_STATUS に fresh な gh-token を seed して
+// tokenForOrg を auth-worker 往復なしで通す。`/dispatches` 宛 fetch の有無で
+// fan-out を検証する。
+const FRESH_TOKEN = {
+  token: "ghs_retest_token",
+  expires_at_ms: Date.now() + 3600_000,
+};
+
+/** auto-retest 用 env: webhook secret + COMPAT_KV + token cache を備える。 */
+function deployEnv(compatKv: KVNamespace): Env {
+  return {
+    RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({}) },
+    RELEASE_WAVE_WEBHOOK_SECRET: { get: async () => "expected-secret" },
+    COMPAT_KV: compatKv,
+    CI_STATUS: memKv({ "auth-client-worker:gh-token": FRESH_TOKEN }),
+    INTERNAL_SHARED_SECRET: { get: async () => "secret" },
+  } as unknown as Env;
+}
+
+const BD_URL =
+  "https://ci-dashboard.ippoan.org/webhooks/release-wave/backend-deploy-report";
+
+function deployReq(body: unknown): Request {
+  return jsonRequest({ url: BD_URL, body, secret: "expected-secret" });
+}
+
+/** consumer (frontend) を 1 件 seed した COMPAT_KV を作る。 */
+async function compatKvWithConsumer(testedImage: string): Promise<KVNamespace> {
+  const kv = memKv();
+  await recordFrontendTest(kv, {
+    repo: "ippoan/auth-worker",
+    prod_version: "v0.5.32",
+    tested: { backend_repo: "ippoan/rust-alc-api", backend_image: testedImage },
+    now: "2026-06-10T00:00:00Z",
+  });
+  return kv;
+}
+
+describe("handleBackendDeployReportWebhook auto-retest", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not dispatch when the backend has no consumers", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    const resp = await handleBackendDeployReportWebhook(
+      deployReq({
+        repo: "ippoan/rust-alc-api",
+        current_image: "img-new",
+        deployed_by: "release-wave-gcp",
+      }),
+      deployEnv(memKv()),
+    );
+    expect(resp.status).toBe(200);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("fans out wave-independent retest to consumers not on the new image", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    // consumer は rust-alc-api @ img-old を test 済み → 新 img-new は未 test (赤)。
+    const kv = await compatKvWithConsumer("img-old");
+
+    const resp = await handleBackendDeployReportWebhook(
+      deployReq({
+        repo: "ippoan/rust-alc-api",
+        current_image: "img-new",
+        deployed_by: "release-wave-gcp",
+      }),
+      deployEnv(kv),
+    );
+    expect(resp.status).toBe(200);
+
+    const dispatchCall = fetchSpy.mock.calls.find((c) =>
+      String(c[0]).includes("/repos/ippoan/auth-worker/dispatches"),
+    );
+    expect(dispatchCall).toBeDefined();
+    const body = JSON.parse(dispatchCall![1].body) as {
+      event_type: string;
+      client_payload: Record<string, unknown>;
+    };
+    expect(body.event_type).toBe("release-wave-retest");
+    expect(body.client_payload).toMatchObject({
+      backend_repo: "ippoan/rust-alc-api",
+      backend_image: "img-new",
+      prod_version: "v0.5.32",
+    });
+    // wave 非依存 = wave_id を載せない。
+    expect(body.client_payload).not.toHaveProperty("wave_id");
+  });
+
+  it("skips consumers that already tested the new image (idempotent re-report)", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchSpy);
+    // consumer は既に img-new を test 済み → 緑なので dispatch されない。
+    const kv = await compatKvWithConsumer("img-new");
+
+    const resp = await handleBackendDeployReportWebhook(
+      deployReq({
+        repo: "ippoan/rust-alc-api",
+        current_image: "img-new",
+        deployed_by: "release-wave-gcp",
+      }),
+      deployEnv(kv),
+    );
+    expect(resp.status).toBe(200);
+    const dispatchCall = fetchSpy.mock.calls.find((c) =>
+      String(c[0]).includes("/dispatches"),
+    );
+    expect(dispatchCall).toBeUndefined();
   });
 });


### PR DESCRIPTION
## 目的

`/release-wave` の compatibility グラフにある手動の「Re-test」操作を、**backend deploy 完了を起点に自動化**する。これまでは backend が新 image を deploy しても、operator が手で retest ボタンを押すまで consumer (frontend) の互換性検証が走らなかった。

> トリガーは「PR merge 時」ではなく **backend deploy 完了時** (`backend-deploy-report` webhook = 新 image が prod に出て `backend::<repo>.current_image` が更新される瞬間) を採用。これが「新しい backend に対する互換性を再検証する」という意味で最も正しいタイミング (merge 直後は新 image が未 deploy なので retest が古い image に対して走ってしまう)。

## 変更

- **`decideBackendDeployRetestDispatches`** (`dispatch.ts`) — `decideRetestDispatches` の wave 非依存版。compatibility matrix の赤 (= 新 image を未検証の consumer) だけに `release-wave-retest` を fan-out する pure 関数。同一 image の再報告 (idempotent deploy / 重複 webhook) では既に緑の consumer を skip する (idempotency)。
- **`handleBackendDeployReportWebhook`** (`webhook.ts`) — `recordBackendDeploy` で `backend::<repo>` を更新した後、新 image に対する compatibility を計算して未 test consumer へ自動 dispatch。`dispatchAll` は best-effort なので、token 取得失敗 / GitHub non-2xx でも deploy report の 200 応答は止めない。

「どの repo を backend とみなすか」は専用設定を持たず、**COMPAT_KV に consumer (tested_against を持つ frontend) が存在する repo** を自動で対象にする (新 backend を足しても設定不要)。

client_payload の shape は既存 `retest-consumer` endpoint と同一で、consumer 側 (frontend-ci の `compat_backend_image` 経路) は `wave_id` を参照しないため wave 非依存でも動く。

## テスト

- `dispatch.test.ts` — `decideBackendDeployRetestDispatches` の純粋ロジック (consumer 無し / 全緑 / 赤のみ抽出 / prod_version 省略)。
- `webhook.test.ts` — handler の wiring (consumer 無し→dispatch 無し / 赤 consumer→`/dispatches` 発火 + payload 検証 / 緑 consumer→idempotent skip)。global `fetch` stub + token cache seed で GitHub 往復なしに検証。

`npm run typecheck` / 全 774 テスト green。

Refs #157

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXEYaeDmFs5c1iHf9m8QwF)_