### PR TITLE
feat(releases): TAGLESS_REPOS に ohishi-exp/rust-ichibanboshi と daiun-salary を追加

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -124,7 +124,7 @@
         // cut release tags: dashboard はこれらの PR merge を mini-release 扱いし、
         // merged PR の `Refs #N` を逆引きして /releases synthetic block + banner に
         // 出す (= stable tag 前でも早期 close 可能)。未掲載 repo は tag-driven flow。
-        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs,ippoan/cc-relay,ippoan/mcp-cf-workers,ippoan/claude-skills,ippoan/ci-workflows,ippoan/ref-files-worker,ippoan/claude-hooks,ippoan/cdp-relay,ippoan/release-wave-gcp,ippoan/ui-preview,ippoan/nuxt-notify,ippoan/nuxt-egov,ippoan/alc-app,ippoan/rust-flickr,ippoan/cf-billing-monitor"
+        "TAGLESS_REPOS": "ippoan/secrets-inventory,ippoan/secrets-inventory-gcp,ippoan/ci-dashboard,ippoan/HealthConnectReaderWorker,ippoan/claude-md,ippoan/mcp-relay-rs,ippoan/cc-relay,ippoan/mcp-cf-workers,ippoan/claude-skills,ippoan/ci-workflows,ippoan/ref-files-worker,ippoan/claude-hooks,ippoan/cdp-relay,ippoan/release-wave-gcp,ippoan/ui-preview,ippoan/nuxt-notify,ippoan/nuxt-egov,ippoan/alc-app,ippoan/rust-flickr,ippoan/cf-billing-monitor,ohishi-exp/rust-ichibanboshi,ohishi-exp/daiun-salary"
       },
       "kv_namespaces": [
         {


### PR DESCRIPTION
## 概要

release 確認画面 (`/releases`) に tag を打たない運用の ohishi-exp repo 2 つを追加する。

Refs #309

## 変更内容

`wrangler.jsonc` の `env.staging.vars.TAGLESS_REPOS` (運用 vars の SoT) に追加:

- `ohishi-exp/rust-ichibanboshi` — deploy.sh 手動 deploy、tag 無し運用
- `ohishi-exp/daiun-salary` — deploy.yml は v* tag trigger だが現状 tag 未使用

## 確認済みの前提 (コード変更不要)

- `TAGLESS_REPOS` entry は synthetic path (default branch commit から `Refs #N` 抽出) を取るため tag 不要 (`src/releases-page.ts`)
- `github-api.ts` の `ALLOWED_ORGS` に `ohishi-exp` が既に含まれ、token は org-agnostic (operator scope) — cross-org repo でも release 表示 / `close_issue` が動く

https://claude.ai/code/session_017RcaTi26gsPjZ8r2Qdf6z5

---
_Generated by [Claude Code](https://claude.ai/code/session_017RcaTi26gsPjZ8r2Qdf6z5)_