### PR TITLE
feat(ui): release 運用 badge (tagless / 要 tag) 表示 + reconcile evict の search-index-lag ガード

### DIFF
--- a/src/issue-cache.ts
+++ b/src/issue-cache.ts
@@ -40,6 +40,16 @@ const SAFETY_WINDOW_MS = 5 * 1000;
 const RECONCILE_LOCK_KEY = "issues:reconciling";
 const RECONCILE_LOCK_TTL_SECONDS = 60;
 
+// Evict の search-index-lag ガード (Refs #311)。reconcile の full snapshot は
+// GitHub Search ベースで、作成・更新直後の issue は index 未反映のことがある
+// (`incomplete_results` は timeout 指標で index lag では立たない)。webhook が
+// KV に upsert した直後の entry を「snapshot に居ない」だけで evict すると、
+// open issue が /issues から一時的に消える (2026-06-11 nuxt-trouble#138 で実害)。
+// 直近 EVICT_GRACE_MS 以内に更新された entry は evict 対象から除外する。
+// closed への遷移は webhook の delete が即時反映するので、この猶予で stale が
+// 残るのは「close webhook も配信ミスした」場合の最大 10 分のみ。
+export const EVICT_GRACE_MS = 10 * 60 * 1000;
+
 export function issueKey(repo: string, number: number): string {
   return `${KEY_PREFIX}${repo}#${number}`;
 }
@@ -173,6 +183,13 @@ export async function reconcileIssues(
     const existing = await listCachedOpenIssues(kv);
     for (const e of existing) {
       if (!freshKeys.has(issueKey(e.repo, e.number))) {
+        // Search index lag ガード (Refs #311): 直近に作成/更新された entry は
+        // index がまだ追い付いていないだけの可能性があるので残す。updated_at
+        // が parse 不能 (NaN) な entry は従来どおり evict する。
+        const updatedMs = Date.parse(e.updated_at);
+        if (Number.isFinite(updatedMs) && now - updatedMs < EVICT_GRACE_MS) {
+          continue;
+        }
         await kv.delete(issueKey(e.repo, e.number));
         removed++;
       }

--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -17,6 +17,7 @@ import {
   getOrFetchProjectIssueMap,
   type ProjectIssueMapResult,
 } from "./project-cache";
+import { parseTaglessRepos } from "./tagless-repos";
 
 // Orgs fetched in full. Same allowlist as github-api.ts (not imported because
 // ALLOWED_ORGS isn't exported; keep the two in sync if either grows).
@@ -123,7 +124,7 @@ interface Freshness {
 }
 
 export async function handleIssuesPage(
-  env: AuthClientWorkerEnv,
+  env: AuthClientWorkerEnv & { TAGLESS_REPOS?: string },
   ctx?: ExecutionContext,
 ): Promise<Response> {
   // SWR (Refs #304): KV を先に読み、warm なら GitHub を一切待たずに render
@@ -272,8 +273,14 @@ export async function handleIssuesPage(
       [...items].sort((a, b) => b.updated_at.localeCompare(a.updated_at)),
     ] as const);
 
+  // Repo の release 運用 badge 用 (Refs #312)。判定は TAGLESS_REPOS wrangler
+  // var のみ (I/O 追加なし)。direct-push allowlist は GitHub fetch が要るので
+  // 本 page では見ない — allowlist のみの repo は「要 tag」表示になるが、
+  // 当該 repo はほぼ issue を持たないため許容 (/releases 側は allowlist も加味)。
+  const taglessSet = parseTaglessRepos(env.TAGLESS_REPOS);
+
   return new Response(
-    renderHtml(merged.total_count, merged.incomplete, projectTagged, repos, project, prs, freshness),
+    renderHtml(merged.total_count, merged.incomplete, projectTagged, repos, project, prs, freshness, taglessSet),
     { headers: { "Content-Type": "text/html; charset=utf-8" } },
   );
 }
@@ -286,13 +293,14 @@ function renderHtml(
   project: ProjectIssueMapResult,
   prs: PrMapResult,
   freshness: Freshness,
+  taglessSet: ReadonlySet<string>,
 ): string {
   const repoSections = repos
-    .map(([repo, items]) => renderRepoSection(repo, items, prs.map))
+    .map(([repo, items]) => renderRepoSection(repo, items, prs.map, taglessSet))
     .join("\n");
 
   const projectSection = projectTagged.length > 0
-    ? renderProjectSection(projectTagged, prs.map)
+    ? renderProjectSection(projectTagged, prs.map, taglessSet)
     : "";
 
   const incompleteBanner = incomplete
@@ -530,6 +538,32 @@ function renderHtml(
       color: #8b949e;
       font-size: 14px;
     }
+    /* Release 運用 badge (Refs #312): tagless = merge がそのまま release で
+       /releases から即 close 可、要 tag = release tag を打つまで close 候補に
+       出ない。issue を片付ける時にどちらの手順かを一目で判別する。 */
+    .release-mode {
+      display: inline-block;
+      font-size: 11px;
+      font-weight: 400;
+      padding: 1px 8px;
+      border-radius: 10px;
+      margin-left: 8px;
+      vertical-align: middle;
+      white-space: nowrap;
+      text-decoration: none;
+    }
+    .mode-tagless {
+      background: #2ea04322;
+      color: #7ee787;
+      border: 1px solid #2ea04388;
+    }
+    .mode-tagless:hover { background: #2ea04344; }
+    .mode-needs-tag {
+      background: #d2992222;
+      color: #e3b341;
+      border: 1px solid #d2992288;
+    }
+    .mode-needs-tag:hover { background: #d2992244; }
   </style>
 </head>
 <body>
@@ -561,9 +595,10 @@ function renderHtml(
 function renderProjectSection(
   items: ReadonlyArray<{ issue: OrgIssue; projects: ProjectRef[] }>,
   prMap: ReadonlyMap<string, IssuePrRef[]>,
+  taglessSet: ReadonlySet<string>,
 ): string {
   const rows = items.map(({ issue, projects }) =>
-    renderProjectRow(issue, projects, prMap)).join("\n");
+    renderProjectRow(issue, projects, prMap, taglessSet)).join("\n");
   return `<section class="projects">
   <h2>📋 Project 付き<span class="count">(${items.length})</span></h2>
   <table>
@@ -577,6 +612,7 @@ function renderProjectRow(
   i: OrgIssue,
   projects: ReadonlyArray<ProjectRef>,
   prMap: ReadonlyMap<string, IssuePrRef[]>,
+  taglessSet: ReadonlySet<string>,
 ): string {
   const chips = projects.map((p) =>
     `<a class="project-chip" href="${escapeHtml(p.url)}" target="_blank" rel="noopener">${escapeHtml(p.title)}</a>`,
@@ -588,7 +624,7 @@ function renderProjectRow(
   const trClass = isFixtureIssue(i) ? ' class="fixture"' : "";
   return `<tr${trClass}>
     <td class="num"><a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">#${i.number}</a></td>
-    <td class="repo"><a href="https://github.com/${escapeHtml(i.repo)}/issues" target="_blank" rel="noopener">${escapeHtml(i.repo)}</a></td>
+    <td class="repo"><a href="https://github.com/${escapeHtml(i.repo)}/issues" target="_blank" rel="noopener">${escapeHtml(i.repo)}</a>${renderReleaseModeBadge(i.repo, taglessSet)}</td>
     <td class="title">${renderFixtureBadge(i)}<a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">${escapeHtml(i.title)}</a><div class="labels">${chips}</div>${labelChips}${renderPrChips(i, prMap)}</td>
     <td class="author">@${escapeHtml(i.author)}</td>
     <td class="updated">${escapeHtml(i.updated_at.slice(0, 10))}</td>
@@ -600,11 +636,12 @@ function renderRepoSection(
   repo: string,
   items: OrgIssue[],
   prMap: ReadonlyMap<string, IssuePrRef[]>,
+  taglessSet: ReadonlySet<string>,
 ): string {
   const rows = items.map((i) => renderRow(i, prMap)).join("\n");
   const repoUrl = `https://github.com/${repo}/issues`;
   return `<section class="repo">
-  <h2><a href="${escapeHtml(repoUrl)}" target="_blank" rel="noopener">${escapeHtml(repo)}</a><span class="count">(${items.length})</span></h2>
+  <h2><a href="${escapeHtml(repoUrl)}" target="_blank" rel="noopener">${escapeHtml(repo)}</a><span class="count">(${items.length})</span>${renderReleaseModeBadge(repo, taglessSet)}</h2>
   <table>
     <thead><tr><th>#</th><th>Title</th><th>Author</th><th>Updated</th><th></th></tr></thead>
     <tbody>${rows}</tbody>
@@ -652,6 +689,20 @@ function renderPrChips(
     return `<a class="pr-chip${cls}" href="${escapeHtml(p.url)}" target="_blank" rel="noopener" title="${escapeHtml(title)}">${icon} #${p.number}${suffix}</a>`;
   }).join("");
   return `<div class="pr-chips">${chips}</div>`;
+}
+
+// Repo の release 運用 badge (Refs #312)。issue を release-close フローで
+// close するのに tag を打つ必要があるか (要 tag) / merge がそのまま release か
+// (tagless) を /issues 上で即読みできるようにする。判定は TAGLESS_REPOS
+// wrangler var のみ (direct-push allowlist は GitHub fetch が要るため見ない)。
+// export しているのは test から直接検証するため。
+export function renderReleaseModeBadge(
+  repo: string,
+  taglessSet: ReadonlySet<string>,
+): string {
+  return taglessSet.has(repo)
+    ? `<a class="release-mode mode-tagless" href="/releases" title="tagless 運用 — merge がそのまま release。tag を打たずに /releases から close できる">tagless</a>`
+    : `<a class="release-mode mode-needs-tag" href="/releases" title="tag-release 運用 — close 候補を出すには release tag を打つ (/tag-release)">🏷️ 要 tag</a>`;
 }
 
 // CI fixture issues (e.g. ippoan/claude-hooks#1, #2) exist only to satisfy

--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -115,6 +115,10 @@ interface RepoView {
   repo: string;
   tagBlocks: TagBlock[];
   olderTags: string[];   // tags beyond the displayed top N
+  // tagless 運用 (TAGLESS_REPOS / direct-push allowlist) なら true。
+  // close するのに release tag が要るか (= 要 tag) を card 見出しの badge で
+  // 表示する (Refs #312)。
+  tagless: boolean;
 }
 
 interface TagBlock {
@@ -251,9 +255,10 @@ async function loadRepoView(
         repo: `${owner}/${name}`,
         tagBlocks: block ? [block] : [],
         olderTags: [],
+        tagless: true,
       };
     }
-    return { repo: `${owner}/${name}`, tagBlocks: [], olderTags: [] };
+    return { repo: `${owner}/${name}`, tagBlocks: [], olderTags: [], tagless: false };
   }
 
   // 2. For each inline tag, compare to its immediate predecessor (next in
@@ -347,6 +352,7 @@ async function loadRepoView(
     repo: `${owner}/${name}`,
     tagBlocks,
     olderTags: sorted.slice(TOP_TAGS_INLINE),
+    tagless: useSynthetic,
   };
 }
 
@@ -915,6 +921,16 @@ ${PWA_REGISTER_SCRIPT}
 </body></html>`;
 }
 
+// repo の release 運用 badge (Refs #312)。close するのに tag を打つ必要が
+// あるか (要 tag) / merge がそのまま release か (tagless) を card 見出しで
+// 即読みできるようにする — 「release から close するのに tag が要るか」を
+// 画面から判断できないのが不便、という operator の指摘への対応。
+function renderModeBadge(tagless: boolean): string {
+  return tagless
+    ? `<span class="mode-badge mode-tagless" title="tagless 運用 — merge がそのまま release。tag を打たずにここから close できる">tagless</span>`
+    : `<span class="mode-badge mode-needs-tag" title="tag-release 運用 — close 候補を出すには release tag を打つ (/tag-release)">🏷️ 要 tag</span>`;
+}
+
 function renderIndexRepo(view: RepoView): string {
   // Only tag blocks with at least one OPEN (actionable) issue get the full
   // table+form treatment. Closed-only blocks are pure noise on the landing
@@ -938,6 +954,7 @@ function renderIndexRepo(view: RepoView): string {
       : `<span class="no-refs">No referenced issues in the recent release window.</span>`;
     return `<section class="repo-card repo-card-compact">
       <a class="repo-link" href="https://github.com/${escapeHtml(view.repo)}/releases" target="_blank" rel="noopener">${escapeHtml(view.repo)}</a>
+      ${renderModeBadge(view.tagless)}
       ${summary}
     </section>`;
   }
@@ -965,7 +982,7 @@ function renderIndexRepo(view: RepoView): string {
   // close them in one shot; the POST handler groups by tag for comment
   // attribution.
   return `<section class="repo-card">
-    <h2><a href="https://github.com/${escapeHtml(view.repo)}/releases" target="_blank" rel="noopener">${escapeHtml(view.repo)}</a></h2>
+    <h2><a href="https://github.com/${escapeHtml(view.repo)}/releases" target="_blank" rel="noopener">${escapeHtml(view.repo)}</a>${renderModeBadge(view.tagless)}</h2>
     <form method="POST" action="/api/release-close-batch" class="batch-close-form">
       <input type="hidden" name="repo" value="${escapeHtml(view.repo)}">
       ${tagSections}
@@ -1171,6 +1188,17 @@ const STYLES = `
   }
   .repo-card-compact .repo-link:hover { color: #58a6ff; }
   .repo-card-compact .closed-summary { font-size: 12px; color: #8b949e; }
+  .mode-badge {
+    display: inline-block; font-size: 11px; font-weight: 400;
+    padding: 1px 8px; border-radius: 10px; margin-left: 8px;
+    vertical-align: middle; white-space: nowrap;
+  }
+  .mode-tagless {
+    background: #2ea04322; color: #7ee787; border: 1px solid #2ea04388;
+  }
+  .mode-needs-tag {
+    background: #d2992222; color: #e3b341; border: 1px solid #d2992288;
+  }
   .tag-block { margin-bottom: 14px; }
   .tag-block-header {
     display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap;

--- a/test/issue-cache.test.ts
+++ b/test/issue-cache.test.ts
@@ -170,6 +170,38 @@ describe("issue-cache", () => {
       expect(kept).toBeTruthy();
     });
 
+    it("直近更新の entry は snapshot に居なくても evict しない (search index lag、Refs #311)", async () => {
+      // webhook で入った直後の issue は search index 未反映で snapshot から
+      // 漏れることがある。grace window 内なら evict せず残す。
+      const justCreated = new Date(Date.now() - 60 * 1000).toISOString();
+      await upsertIssue(env.CI_STATUS, makeIssue({
+        number: 138,
+        repo: "ippoan/nuxt-trouble",
+        created_at: justCreated,
+        updated_at: justCreated,
+        url: "https://github.com/ippoan/nuxt-trouble/issues/138",
+      }));
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+        const url = typeof input === "string" ? input : (input as Request).url;
+        if (url.includes("auth-worker") || url.includes("/mcp/token")) {
+          return Response.json({ access_token: "tok" });
+        }
+        if (url.includes("/search/issues")) {
+          // snapshot は index lag で #138 を含まない (complete 扱い)
+          return mockSearchResponse([makeIssue({ number: 10 })]);
+        }
+        return new Response("ignored", { status: 404 });
+      });
+
+      const result = await reconcileIssues(env, { mainOrgs: ["ippoan"], yhondaRepos: [] });
+      expect(result.fetched).toBe(true);
+      expect(result.removed).toBe(0);
+
+      // grace window 内の #138 は残る
+      const kept = await env.CI_STATUS.get(issueKey("ippoan/nuxt-trouble", 138), "json");
+      expect(kept).toBeTruthy();
+    });
+
     it("incomplete snapshot (search truncated) の時は削除を skip する", async () => {
       await upsertIssue(env.CI_STATUS, makeIssue({ number: 99 }));
       vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -296,6 +296,29 @@ describe("GET /issues", () => {
     expect(html).toContain('href="/"');
   });
 
+  it("repo section に release 運用 badge を表示 (TAGLESS_REPOS 判定、Refs #312)", async () => {
+    stubSearchIssues();
+    const req = new Request("http://localhost/issues");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      req,
+      { ...testEnv(), TAGLESS_REPOS: "ohishi-exp/daiun-salary" },
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    const html = await res.text();
+    // tagless 指定 repo の section は tagless badge、それ以外は 要 tag badge
+    expect(html).toContain("mode-tagless");
+    expect(html).toContain("mode-needs-tag");
+    // section 単位の対応を確認: daiun-salary の h2 には tagless、
+    // rust-alc-api の h2 には 要 tag が付く。
+    const daiunH2 = html.split("\n").find((l) => l.includes("ohishi-exp/daiun-salary</a><span"));
+    expect(daiunH2).toContain("mode-tagless");
+    const alcH2 = html.split("\n").find((l) => l.includes("ippoan/rust-alc-api</a><span"));
+    expect(alcH2).toContain("mode-needs-tag");
+  });
+
   it("escapes HTML in issue titles (XSS guard)", async () => {
     stubSearchIssues();
     const req = new Request("http://localhost/issues");

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -366,6 +366,8 @@ describe("GET /releases", () => {
     // …but wrapped in a <details> with the right summary copy.
     expect(html).toContain('<details class="closed-details">');
     expect(html).toContain("<summary>1 closed issue</summary>");
+    // Tag-release 運用 badge (要 tag) が card 見出しに付く (Refs #312)。
+    expect(html).toContain('<span class="mode-badge mode-needs-tag"');
     // Open issue stays in the main candidate table outside the <details>;
     // closed issue's checkbox row is below the <details> boundary.
     const [beforeDetails, afterDetails] = html.split('<details class="closed-details">');
@@ -596,6 +598,10 @@ describe("GET /releases", () => {
     // The candidate row + form pair encoding works the same as the tag path.
     expect(html).toContain(`name="pair" value="master@deadbee:2"`);
     expect(html).toContain("worktree-naming-guard hook");
+    // Tagless 運用 badge が card 見出しに付く (Refs #312)。CSS 定義は常に
+    // 含まれるので、badge の実 HTML (span) でアサートする。
+    expect(html).toContain('<span class="mode-badge mode-tagless"');
+    expect(html).not.toContain('<span class="mode-badge mode-needs-tag"');
   });
 
   it("renders an empty card (no synthetic block) when the recent commit window has no Refs", async () => {


### PR DESCRIPTION
## 概要

2 件の独立した変更 (同一 session branch のため 1 PR、commit は分離):

### 1. /issues・/releases に release 運用 badge を表示 (Refs #312)

issue を release-close フローで close するのに tag を打つ必要があるか / merge がそのまま release かが画面から判断できず、close の段取りが分かりにくかった (operator 指摘) への対応。

- **/issues**: 各 repo section の見出しと Project 付き section の repo cell に badge (`tagless` = 緑 / `🏷️ 要 tag` = 黄、`/releases` へのリンク付き)。判定は `TAGLESS_REPOS` wrangler var のみ (I/O 追加なし。direct-push allowlist のみの repo は要 tag 表示になるが当該 repo はほぼ issue を持たないため許容)
- **/releases**: 各 repo card 見出し (full / compact 両方) に同 badge。判定は index page が既に計算している synthetic path 判定 (TAGLESS_REPOS + direct-push allowlist) を `RepoView.tagless` に乗せる

### 2. reconcile evict の search-index-lag ガード (Refs #311)

reconcile の full snapshot は GitHub Search ベースで、作成・更新直後の issue は index 未反映のことがある (`incomplete_results` は timeout 指標で index lag では立たない)。webhook で KV に入った直後の entry が「snapshot に居ない」だけで evict され、open issue が /issues から一時的に消えていた (2026-06-11 nuxt-trouble#138 で実害)。

`updated_at` が直近 10 分以内の entry は evict 対象から除外する。closed への遷移は webhook の delete が即時反映するため、この猶予で stale が残るのは close webhook も配信ミスした場合の最大 10 分のみ。

## 検証

```
$ npm run typecheck   # green
$ npm test            # 776 tests passed (47 files)
```

- 追加テスト: evict grace period (issue-cache) / badge の section 単位対応 (/issues) / synthetic・tag 両 path の badge (/releases)

Refs #311 / Refs #312

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhkgxKWTehmnLWqffude3z)_