### PR TITLE
fix(releases): close 後の flash param を history.replaceState で address bar から除去

### DIFF
--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -845,6 +845,24 @@ function renderRow(r: IssueRow): string {
   </tr>`;
 }
 
+// Flash param (closed= / failed= / failed_reasons=) を address bar から除去する
+// (Refs #314)。server 側の PRG + 1 回目の banner 表示は従来どおりで、render 後に
+// history.replaceState で URL を clean にする。これでリロードしても flash banner
+// が再表示されず、確認のための再読込が「また close された」ように見えない。
+// `repo` は tag 同伴 (detail page) の時だけ残す — tag 無しの repo= は index に
+// fall through する flash 添付用 param なので一緒に消す。
+const FLASH_CLEANUP_SCRIPT = `<script>
+(() => {
+  try {
+    const u = new URL(location.href);
+    for (const k of ["closed", "failed", "failed_reasons"]) u.searchParams.delete(k);
+    if (!u.searchParams.get("tag")) u.searchParams.delete("repo");
+    const qs = u.searchParams.toString();
+    history.replaceState(null, "", u.pathname + (qs ? "?" + qs : ""));
+  } catch { /* URL/History API 非対応環境では従来挙動のまま */ }
+})();
+</script>`;
+
 function renderFlash(
   closed: number[],
   failed: number[],
@@ -879,7 +897,7 @@ function renderFlash(
       failedList = `<div class="flash err">❌ Failed to close: ${failed.map(issueLink).join(" ")} (try again)</div>`;
     }
   }
-  return closedList + failedList;
+  return closedList + failedList + FLASH_CLEANUP_SCRIPT;
 }
 
 function renderIndex(

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -395,6 +395,20 @@ describe("GET /releases", () => {
     // Issue numbers link to the GitHub repo that came along on the redirect.
     expect(html).toContain("https://github.com/ippoan/nuxt-pwa-carins/issues/23");
     expect(html).toContain("https://github.com/ippoan/nuxt-pwa-carins/issues/24");
+    // Flash param を address bar から除去する script が同伴する (Refs #314)。
+    // リロードしても banner が再表示されない。
+    expect(html).toContain("history.replaceState");
+  });
+
+  it("flash 無しの page には replaceState script を出さない (Refs #314)", async () => {
+    const req = new Request("http://localhost/releases");
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).not.toContain("history.replaceState");
   });
 
   it("renders release candidates with merged ref sources", async () => {


### PR DESCRIPTION
## 概要

`POST /api/release-close{,-batch}` の redirect 先 (`/releases?repo=ippoan%2Fauth-worker&closed=268` のような URL) は flash param が address bar に残り続けるため、close 結果を確認しようとリロードすると banner が再表示され「今また close された」ように見えていた (operator 指摘)。

## 変更

- `renderFlash` が banner と一緒に 1 行 script を注入し、render 直後に `closed` / `failed` / `failed_reasons` (+ tag 無しの `repo` — index への flash 添付専用 param) を `history.replaceState` で URL から除去する
- server 側の PRG と redirect 直後 1 回の banner 表示は従来どおり。以降のリロード/共有/ブックマークは clean URL (`/releases` or `/releases?repo=X&tag=Y`) に当たる
- flash 無しの page には script を出さない
- cookie / KV での flash 永続化はオーバーキルのため不採用 (issue #314 参照)

## 検証

```
$ npm run typecheck   # green
$ npm test            # 777 tests passed
```

- 追加テスト: flash 付き page に `history.replaceState` script が同伴する / flash 無し page には出ない

Refs #314

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhkgxKWTehmnLWqffude3z)_