### PR TITLE
feat(webhook): 受信 event の観測 log (webhook-received) を追加

### DIFF
--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -158,6 +158,29 @@ export async function handleWebhook(
 
   const event = request.headers.get("X-GitHub-Event");
 
+  // 受信 event の観測 log (Refs #316)。request log には X-GitHub-Event が
+  // 乗らないため、「issues event がどの repo から届いているか」を observability
+  // で集計できるようここで 1 行出す。webhook は per-repo 設定なので、Issues
+  // event 未購読の repo (= /issues の反映が reconcile 頼みで遅い repo) の特定に
+  // 使う。payload の parse 失敗時は repo/action 空のまま log だけ出して続行。
+  let logRepo = "";
+  let logAction = "";
+  try {
+    const p = JSON.parse(body) as {
+      action?: string;
+      repository?: { full_name?: string };
+    };
+    logRepo = p.repository?.full_name ?? "";
+    logAction = p.action ?? "";
+  } catch { /* 観測用なので落とさない */ }
+  console.log(JSON.stringify({
+    msg: "webhook-received",
+    event,
+    action: logAction,
+    repo: logRepo,
+    delivery: request.headers.get("X-GitHub-Delivery") ?? "",
+  }));
+
   if (event === "workflow_run") {
     const payload: WorkflowRunPayload = JSON.parse(body);
     // Route through Hub DO for serialized KV access


### PR DESCRIPTION
## 背景

「/issues の open issue 反映が遅い」報告の調査 (Refs #316)。observability の実測で `POST /webhooks` は届いていて全 200 だったが、request log に `X-GitHub-Event` が乗らないため、CI 由来 (workflow_run / workflow_job) の大量配信に混ざって **`issues` event がどの repo から届いているか / 届いていないか** を切り分けられなかった。

webhook は per-repo 設定のため、Issues event 未購読の repo は webhook upsert 経路が効かず、reconcile (fresh window 60s + GitHub Search index lag + rate-limit backoff) 頼みになり反映が遅くなる。

## 変更

`handleWebhook` の署名検証後に structured log を 1 行追加:

```json
{"msg":"webhook-received","event":"issues","action":"opened","repo":"ippoan/nuxt-trouble","delivery":"<guid>"}
```

- payload parse 失敗時は repo/action 空のまま log だけ出して続行 (観測用なので fail-open)
- これで observability から `event=issues` を repo 別に集計でき、webhook 未設定の repo を特定して GitHub 側設定 (Issues / Issue comments event 追加) につなげられる

## 検証

```
$ npm run typecheck   # green
$ npm test            # 777 tests passed
```

Refs #316

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhkgxKWTehmnLWqffude3z)_