### PR TITLE
fix(webhook): ack-then-process — 即 200 を返し event 処理は waitUntil へ

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -155,8 +155,8 @@ app.get("/ws", (c) => getHub(c.env).fetch(c.req.raw));
 // `/webhooks` で始まるパスを edge auth から除外) に合わせたエイリアス。
 // 単数 `/webhook` は CF Access 配下のため GitHub 配信が 302 で到達できない。
 // handleWebhook は X-Hub-Signature-256 を自前検証するので edge auth 不要。
-app.post("/webhook", (c) => handleWebhook(c.req.raw, c.env, getHub(c.env)));
-app.post("/webhooks", (c) => handleWebhook(c.req.raw, c.env, getHub(c.env)));
+app.post("/webhook", (c) => handleWebhook(c.req.raw, c.env, getHub(c.env), c.executionCtx));
+app.post("/webhooks", (c) => handleWebhook(c.req.raw, c.env, getHub(c.env), c.executionCtx));
 
 // Status
 app.get("/status", async (c) => {

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -141,7 +141,8 @@ async function verifySignature(
 export async function handleWebhook(
   request: Request,
   env: Env,
-  hub: DurableObjectStub
+  hub: DurableObjectStub,
+  ctx?: ExecutionContext,
 ): Promise<Response> {
   const signature = request.headers.get("X-Hub-Signature-256");
   if (!signature) {
@@ -181,6 +182,37 @@ export async function handleWebhook(
     delivery: request.headers.get("X-GitHub-Delivery") ?? "",
   }));
 
+  // Ack-then-process (Refs #318)。GitHub の webhook delivery timeout は 10s で、
+  // timeout した delivery は自動再送されない。Hub DO / KV / cache invalidation を
+  // 応答前に await すると CI burst 時に 10s を超えて event が喪失する実害が出た
+  // (2026-06-11 実測: wallTime 17.5s/18.0s + GitHub 側 "timed out" delivery)。
+  // 署名検証済みのこの時点で即 200 を返し、処理本体は waitUntil に流す
+  // (応答後 30s まで実行が保証される)。処理失敗は log のみ — GitHub への 500 は
+  // 再送を引き起こさないため、応答コードで伝える意味がない。
+  const work = processWebhookEvent(event, body, env, hub).catch((err) => {
+    console.log(JSON.stringify({
+      msg: "webhook-process-failed",
+      event,
+      repo: logRepo,
+      error: err instanceof Error ? err.message : String(err),
+    }));
+  });
+  if (ctx) {
+    ctx.waitUntil(work);
+  } else {
+    // test / ctx 非提供の呼び出し元では従来どおり同期処理 (挙動互換)。
+    await work;
+  }
+  return new Response("OK", { status: 200 });
+}
+
+// Event 処理本体。handleWebhook から waitUntil 経由で呼ばれる (Refs #318)。
+async function processWebhookEvent(
+  event: string | null,
+  body: string,
+  env: Env,
+  hub: DurableObjectStub,
+): Promise<void> {
   if (event === "workflow_run") {
     const payload: WorkflowRunPayload = JSON.parse(body);
     // Route through Hub DO for serialized KV access
@@ -215,7 +247,7 @@ export async function handleWebhook(
       }));
     }
 
-    return new Response("OK", { status: 200 });
+    return;
   }
 
   if (event === "workflow_job") {
@@ -224,7 +256,7 @@ export async function handleWebhook(
       method: "POST",
       body: JSON.stringify({ job: payload.workflow_job }),
     }));
-    return new Response("OK", { status: 200 });
+    return;
   }
 
   // Tagless-repo close-detection trigger. For repos that never cut a release
@@ -269,7 +301,7 @@ export async function handleWebhook(
         }));
       }
     }
-    return new Response("OK", { status: 200 });
+    return;
   }
 
   // /issues SSR page の KV cache (issue-cache.ts) 更新経路。Webhook で来た
@@ -287,7 +319,7 @@ export async function handleWebhook(
     if (owner && name) {
       await invalidateReleaseCacheIssue(env.CI_STATUS, owner, name, payload.issue.number);
     }
-    return new Response("OK", { status: 200 });
+    return;
   }
 
   // /issues SSR の comment 数表示用。`created` / `deleted` だけ反映、
@@ -296,7 +328,7 @@ export async function handleWebhook(
   if (event === "issue_comment") {
     const payload: IssueCommentWebhookPayload = JSON.parse(body);
     await applyIssueCommentEvent(env.CI_STATUS, payload);
-    return new Response("OK", { status: 200 });
+    return;
   }
 
   // /projects SSR の KV cache (project-cache.ts) invalidation 経路。
@@ -305,7 +337,7 @@ export async function handleWebhook(
   if (event === "projects_v2") {
     const payload: ProjectsV2WebhookPayload = JSON.parse(body);
     await applyProjectsV2Event(env.CI_STATUS, payload);
-    return new Response("OK", { status: 200 });
+    return;
   }
 
   // `projects_v2_item` event = 個別 card の add/edit/delete/archive/reorder。
@@ -313,7 +345,7 @@ export async function handleWebhook(
   if (event === "projects_v2_item") {
     const payload: ProjectsV2ItemWebhookPayload = JSON.parse(body);
     await applyProjectsV2ItemEvent(env.CI_STATUS, payload);
-    return new Response("OK", { status: 200 });
+    return;
   }
 
   // /releases SSR の release-cache.ts (TTL 300s tags) を webhook で flush。
@@ -325,7 +357,7 @@ export async function handleWebhook(
     if (owner && name) {
       await invalidateRepoTags(env.CI_STATUS, owner, name);
     }
-    return new Response("OK", { status: 200 });
+    return;
   }
 
   // `push` event は tag push (refs/tags/*) なら tags cache、default branch
@@ -351,10 +383,10 @@ export async function handleWebhook(
         }
       }
     }
-    return new Response("OK", { status: 200 });
+    return;
   }
 
-  return new Response("Ignored event: " + event, { status: 200 });
+  // 未知 event は noop (応答は handleWebhook が常に 200 を返す)。
 }
 
 export { verifySignature };

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -204,7 +204,8 @@ describe("POST /webhook", () => {
     const res = await worker.fetch(req, testEnv(), ctx);
     await waitOnExecutionContext(ctx);
     expect(res.status).toBe(200);
-    expect(await res.text()).toBe("Ignored event: watch");
+    // Ack-then-process (Refs #318): 応答は event 処理結果を反映せず常に "OK"。
+    expect(await res.text()).toBe("OK");
   });
 
   it("stores workflow_run status in KV", async () => {


### PR DESCRIPTION
## 背景 (Refs #318)

GitHub の webhook delivery timeout は **10s** で、timeout した delivery は**自動再送されない**。handler が Hub DO fetch / KV write / cache invalidation を**応答前に await** していたため、CI burst 時に応答が 10s を超えて event が喪失していた。

実測 (2026-06-11):
- GitHub 側 delivery log: `We couldn't deliver this payload: timed out` (workflow_job.completed)
- Workers observability: `POST /webhooks` の wallTime **17.5s / 18.0s / 11.8s** の invocation

issues event も同じ handler を通るため、burst に巻き込まれた配信の遅延・喪失が「/issues の open issue 反映が遅い」の一因になっていた。

## 変更

- 署名検証 + `webhook-received` log まで同期で実施し、**即 200 "OK" を返す**
- event 処理本体を `processWebhookEvent()` に切り出し `ctx.waitUntil` へ (応答後 **30s** まで実行保証 — 観測された最大 18s は収まる)
- 処理失敗は `webhook-process-failed` log のみ (GitHub への 500 は再送を引き起こさないため fail-open)
- ctx 非提供の呼び出し (test 等) は従来どおり同期 await (挙動互換)
- 応答 body は常に `OK` に統一 (`Ignored event:` 分岐は noop 化、該当テスト更新)

## DO 側の対応について

「DO をちゃんと使えば直せるのでは」の指摘どおり、Hub DO 内の重い処理 (release-alert-detect の GitHub API 呼び出し) を storage queue + alarm で deferred 化する完全耐久案もあるが、worker 側 ack で delivery 喪失は構造的に消えるため、まずこちらを入れて `webhook-received` log で観測する。waitUntil の 30s を超える burst が観測されたら DO queue 化を follow-up する (#318 に記載)。

## 検証

```
$ npm run typecheck   # green
$ npm test            # 777 tests passed
```

Refs #318

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhkgxKWTehmnLWqffude3z)_