### PR TITLE
feat(webhook): 受信 event を Cloudflare Queues に積み consumer で処理する

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import {
   type AuthClientWorkerEnv,
 } from "@ippoan/auth-client-worker";
 import { AUTH_WORKER_ORIGIN } from "./github-api";
-import { handleWebhook } from "./webhook";
+import { handleWebhook, consumeWebhookBatch, type WebhookQueueMessage } from "./webhook";
 import { handleDashboard } from "./dashboard";
 import { handleIssuesPage } from "./issues-page";
 import { handleProjectsPage } from "./projects-page";
@@ -88,6 +88,12 @@ export interface Env extends AuthClientWorkerEnv {
    * Refs #157 / #158、shape は docs/release-wave-compatibility-kv.md。
    */
   COMPAT_KV: KVNamespace;
+  /**
+   * GitHub webhook の ingest queue (Refs #318)。受信 handler は enqueue + 即
+   * 200 のみ行い、処理は本 worker の queue consumer が担う。binding 未設定の
+   * 環境 (wrangler dev / test) は waitUntil fallback で inline 処理される。
+   */
+  WEBHOOK_QUEUE?: Queue<WebhookQueueMessage>;
 }
 
 // OAuth flow config — shared between /oauth/login, /oauth/callback, and the
@@ -366,4 +372,10 @@ app.post("/api/release-wave/backend-rollback", (c) =>
   handleReleaseWaveBackendRollback(c.req.raw, c.env),
 );
 
-export default app;
+// Queues consumer を載せるため Hono app を module worker 形に包む。
+// `fetch` は従来どおり app に委譲 (tests の worker.fetch も互換)。
+export default {
+  fetch: app.fetch,
+  queue: (batch: MessageBatch<WebhookQueueMessage>, env: Env) =>
+    consumeWebhookBatch(batch, env),
+};

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -21,6 +21,14 @@ import {
 } from "./release-cache";
 import { applyPullRequestEvent } from "./pr-map-cache";
 
+// Queue 経由で consumer に渡す raw event (Refs #318)。body は署名検証済みの
+// raw JSON 文字列をそのまま積む (consumer 側で event 別に parse する)。
+export interface WebhookQueueMessage {
+  event: string | null;
+  body: string;
+  delivery: string;
+}
+
 interface ReleaseWebhookPayload {
   action: string;
   release: {
@@ -182,11 +190,31 @@ export async function handleWebhook(
     delivery: request.headers.get("X-GitHub-Delivery") ?? "",
   }));
 
-  // Ack-then-process (Refs #318)。GitHub の webhook delivery timeout は 10s で、
-  // timeout した delivery は自動再送されない。Hub DO / KV / cache invalidation を
-  // 応答前に await すると CI burst 時に 10s を超えて event が喪失する実害が出た
-  // (2026-06-11 実測: wallTime 17.5s/18.0s + GitHub 側 "timed out" delivery)。
-  // 署名検証済みのこの時点で即 200 を返し、処理本体は waitUntil に流す
+  // Queue 経路 (Refs #318)。GitHub の webhook delivery timeout は 10s で、
+  // timeout した delivery は自動再送されない。受信側は署名検証 + enqueue
+  // だけ行って即 200 を返し、処理は queue consumer (本 worker の queue handler)
+  // が行う。処理失敗は Queues の retry (max_retries) が面倒を見るため、
+  // waitUntil 方式 (#319) の「応答後 30s + 喪失 silent」問題も解消する。
+  const delivery = request.headers.get("X-GitHub-Delivery") ?? "";
+  if (env.WEBHOOK_QUEUE) {
+    try {
+      await env.WEBHOOK_QUEUE.send({ event, body, delivery });
+      return new Response("OK", { status: 200 });
+    } catch (err) {
+      // send 失敗 (メッセージ 128KB 超 / 一時障害) は下の inline 経路に
+      // fallback して取りこぼしを防ぐ。
+      console.log(JSON.stringify({
+        msg: "webhook-enqueue-failed",
+        event,
+        repo: logRepo,
+        delivery,
+        error: err instanceof Error ? err.message : String(err),
+      }));
+    }
+  }
+
+  // Fallback: queue binding が無い環境 (wrangler dev / test) と enqueue 失敗時。
+  // ack-then-process (#319) — 即 200 を返し、処理本体は waitUntil に流す
   // (応答後 30s まで実行が保証される)。処理失敗は log のみ — GitHub への 500 は
   // 再送を引き起こさないため、応答コードで伝える意味がない。
   const work = processWebhookEvent(event, body, env, hub).catch((err) => {
@@ -204,6 +232,33 @@ export async function handleWebhook(
     await work;
   }
   return new Response("OK", { status: 200 });
+}
+
+// Queue consumer (Refs #318)。wrangler の queues.consumers 設定で本 worker の
+// `queue()` handler に配送される。max_concurrency: 1 + batch 逐次処理で
+// event の相対順序を概ね保つ (GitHub の配信自体に厳密順序は無い)。失敗 message
+// は retry() で Queues の再配送に任せる (max_retries 超過で drop + log 済み)。
+export async function consumeWebhookBatch(
+  batch: MessageBatch<WebhookQueueMessage>,
+  env: Env,
+): Promise<void> {
+  const hub = env.CI_HUB.get(env.CI_HUB.idFromName("singleton"));
+  for (const message of batch.messages) {
+    const { event, body, delivery } = message.body;
+    try {
+      await processWebhookEvent(event, body, env, hub);
+      message.ack();
+    } catch (err) {
+      console.log(JSON.stringify({
+        msg: "webhook-process-failed",
+        event,
+        delivery,
+        attempts: message.attempts,
+        error: err instanceof Error ? err.message : String(err),
+      }));
+      message.retry();
+    }
+  }
 }
 
 // Event 処理本体。handleWebhook から waitUntil 経由で呼ばれる (Refs #318)。

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -2,7 +2,8 @@ import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:
 import { describe, it, expect, beforeEach } from "vitest";
 import worker from "../src/index";
 import type { Env } from "../src/index";
-import type { CIStatus, JobStatus } from "../src/webhook";
+import type { CIStatus, JobStatus, WebhookQueueMessage } from "../src/webhook";
+import { consumeWebhookBatch } from "../src/webhook";
 
 const WEBHOOK_SECRET = "test-secret";
 
@@ -951,5 +952,125 @@ describe("POST /webhook pull_request — pr-map patch (Refs #304)", () => {
     };
     // closed-unmerged → 除去 (key ごと消える)
     expect(entry.data["ippoan/secrets-inventory-gcp#3"]).toBeUndefined();
+  });
+});
+
+// ───── Queue ingest (Refs #318) ─────
+//
+// WEBHOOK_QUEUE binding がある env では受信 handler は enqueue + 即 200 のみ
+// 行い、処理は consumeWebhookBatch (queue consumer) が担う。binding 無し /
+// enqueue 失敗時は waitUntil fallback で従来どおり inline 処理される。
+describe("webhook queue ingest (Refs #318)", () => {
+  const issueBody = JSON.stringify({
+    action: "opened",
+    issue: {
+      number: 77, title: "queued issue", state: "open", user: { login: "y" },
+      labels: [], assignees: [], comments: 0,
+      created_at: "2026-06-11T00:00:00Z",
+      updated_at: "2026-06-11T00:00:00Z",
+      html_url: "https://github.com/ippoan/foo/issues/77",
+    },
+    repository: { full_name: "ippoan/foo" },
+  });
+
+  beforeEach(async () => {
+    resetHubCalls();
+    await env.CI_STATUS.delete("issue:ippoan/foo#77");
+  });
+
+  it("WEBHOOK_QUEUE があれば enqueue + 200 で、inline 処理はしない", async () => {
+    const sent: WebhookQueueMessage[] = [];
+    const queueEnv = {
+      ...testEnv(),
+      WEBHOOK_QUEUE: { send: async (m: WebhookQueueMessage) => { sent.push(m); } },
+    } as unknown as Env;
+
+    const sig = await sign(issueBody, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST", body: issueBody,
+        headers: {
+          "X-Hub-Signature-256": sig,
+          "X-GitHub-Event": "issues",
+          "X-GitHub-Delivery": "deliv-1",
+        },
+      }),
+      queueEnv,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toEqual({ event: "issues", body: issueBody, delivery: "deliv-1" });
+    // 処理は consumer 側の責務 — 受信時点では KV に入らない
+    expect(await env.CI_STATUS.get("issue:ippoan/foo#77")).toBeNull();
+  });
+
+  it("enqueue 失敗時は inline 処理に fallback する", async () => {
+    const queueEnv = {
+      ...testEnv(),
+      WEBHOOK_QUEUE: { send: async () => { throw new Error("message too large"); } },
+    } as unknown as Env;
+
+    const sig = await sign(issueBody, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST", body: issueBody,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "issues" },
+      }),
+      queueEnv,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    // fallback で従来どおり KV upsert される
+    const stored = await env.CI_STATUS.get("issue:ippoan/foo#77", "json") as { number: number } | null;
+    expect(stored?.number).toBe(77);
+  });
+
+  it("consumeWebhookBatch: 正常 message は処理して ack", async () => {
+    const acked: string[] = [];
+    const retried: string[] = [];
+    const batch = {
+      messages: [{
+        body: { event: "issues", body: issueBody, delivery: "deliv-2" },
+        attempts: 1,
+        ack: () => acked.push("deliv-2"),
+        retry: () => retried.push("deliv-2"),
+      }],
+    } as unknown as MessageBatch<WebhookQueueMessage>;
+
+    await consumeWebhookBatch(batch, testEnv());
+
+    expect(acked).toEqual(["deliv-2"]);
+    expect(retried).toEqual([]);
+    const stored = await env.CI_STATUS.get("issue:ippoan/foo#77", "json") as { number: number } | null;
+    expect(stored?.number).toBe(77);
+  });
+
+  it("consumeWebhookBatch: 処理失敗 message は retry (後続 message は処理継続)", async () => {
+    const acked: string[] = [];
+    const retried: string[] = [];
+    const make = (delivery: string, event: string, body: string) => ({
+      body: { event, body, delivery },
+      attempts: 1,
+      ack: () => acked.push(delivery),
+      retry: () => retried.push(delivery),
+    });
+    const batch = {
+      messages: [
+        make("bad", "issues", "{not json"),
+        make("good", "issues", issueBody),
+      ],
+    } as unknown as MessageBatch<WebhookQueueMessage>;
+
+    await consumeWebhookBatch(batch, testEnv());
+
+    expect(retried).toEqual(["bad"]);
+    expect(acked).toEqual(["good"]);
   });
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -158,6 +158,31 @@
           "new_sqlite_classes": ["ReleaseWaveHub"]
         }
       ],
+      // GitHub webhook ingest queue (Refs #318)。受信 handler は enqueue + 即
+      // 200、処理は本 worker の queue consumer。**初回 deploy 前に
+      // `npx wrangler queues create ci-dashboard-webhooks` で queue を作成する
+      // こと** (未作成だと deploy が fail する = loud)。consumer は 1 queue
+      // 1 worker 制約のため staging (実運用 env) のみに付ける。
+      "queues": {
+        "producers": [
+          {
+            "binding": "WEBHOOK_QUEUE",
+            "queue": "ci-dashboard-webhooks"
+          }
+        ],
+        "consumers": [
+          {
+            "queue": "ci-dashboard-webhooks",
+            // 順序を概ね保ちつつ burst を平滑化する設定: 直列 1 consumer、
+            // 小 batch、最大 5 回 retry (超過は drop — webhook-process-failed
+            // log に attempts 付きで残る)。
+            "max_batch_size": 10,
+            "max_batch_timeout": 1,
+            "max_retries": 5,
+            "max_concurrency": 1
+          }
+        ]
+      },
       "secrets_store_secrets": [
         {
           "binding": "RELEASE_WAVE_WEBHOOK_SECRET",


### PR DESCRIPTION
## 概要 (Refs #318)

「webhook は受信して queue に積むのが筋」の指摘どおり、ingest を Cloudflare Queues に切り替える。waitUntil 方式 (#319) は応急処置としては機能するが、応答後 **30s の実行上限**と**失敗時の silent 喪失**が残るため、queue + retry で構造的に解消する。

## アーキテクチャ

```
GitHub → POST /webhooks
  → 署名検証 + webhook-received log
  → WEBHOOK_QUEUE.send({event, body, delivery}) → 即 200
       ↓ (ci-dashboard-webhooks queue)
  queue() handler (consumeWebhookBatch)
  → processWebhookEvent (Hub DO / KV / cache invalidation)
  → 成功: ack() / 失敗: retry() (max_retries: 5、超過 drop は attempts 付き log)
```

- consumer は `max_concurrency: 1` + batch 逐次処理で event の相対順序を概ね維持 (GitHub の配信自体に厳密順序は無い)
- **fallback 維持**: binding 無し環境 (wrangler dev / test) と enqueue 失敗時 (message 128KB 超等) は #319 の waitUntil 経路で inline 処理 — 取りこぼしゼロ
- queue 設定は staging (実運用 env) のみ — Queues は 1 queue 1 consumer 制約のため、予約 production には付けない

## ⚠️ Merge 前に必要な operator 操作 (1 回だけ)

queue が未作成だと `deploy-staging` job が fail します (= loud、auto-merge は deploy gate でブロックされる):

```sh
npx wrangler queues create ci-dashboard-webhooks
```

(または Cloudflare dashboard → Queues → Create queue。Queues は Workers Paid plan の機能です — 本 account は DO 利用中なので問題ない想定)

## 検証

```
$ npm run typecheck   # green
$ npm test            # 781 tests passed (queue ingest 4 テスト追加)
```

- enqueue + 200 (inline 処理しない) / enqueue 失敗 fallback / consumer ack / 失敗 retry + 後続継続

Refs #318

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhkgxKWTehmnLWqffude3z)_