### PR TITLE
feat(issues): WebSocket で /issues を live 更新 (issues-updated broadcast + auto reload)

### DIFF
--- a/src/hub.ts
+++ b/src/hub.ts
@@ -16,7 +16,10 @@ import { invalidateIssue } from "./release-cache";
 //   - "release-alerts"  → ReleaseAlert[] (post-tag-release banner)
 type WsEnvelope =
   | { type: "ci-statuses"; data: CIStatus[] }
-  | { type: "release-alerts"; data: ReleaseAlert[] };
+  | { type: "release-alerts"; data: ReleaseAlert[] }
+  // /issues page の live reload trigger (Refs #321)。webhook の issues event
+  // 処理後に webhook.ts が /issues-updated 経由で broadcast する。
+  | { type: "issues-updated"; data: { repo: string; number: number; state: string } };
 
 const ALERT_KEY_PREFIX = "release-alert:";
 const ALERT_TTL_SECONDS = 7 * 86400;
@@ -242,6 +245,15 @@ export class CIDashboardHub extends DurableObject<Env> {
         }
       }
       if (changed) this.broadcastAlerts();
+      return new Response("OK");
+    }
+
+    // /issues page の live reload trigger (Refs #321)。KV upsert 済みの issue
+    // 変更を WS client に通知する。dashboard JS は未知 type を無視するので
+    // 同一 /ws チャネルに相乗りして良い。
+    if (url.pathname === "/issues-updated") {
+      const data = await request.json<{ repo: string; number: number; state: string }>();
+      this.broadcastEnvelope({ type: "issues-updated", data });
       return new Response("OK");
     }
 

--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -588,9 +588,58 @@ function renderHtml(
     ? `<div class="empty">🎉 No open issues. Nice work.</div>`
     : repoSections}
   ${PWA_REGISTER_SCRIPT}
+  ${LIVE_RELOAD_SCRIPT}
 </body>
 </html>`;
 }
+
+// /issues の live 更新 (Refs #321)。Hub DO の /ws に接続し、webhook の issues
+// event 処理後に broadcast される `issues-updated` envelope を受けたら debounce
+// 付きで reload する。SSR + KV read は高速なので DOM patch ではなく reload で
+// 十分。dashboard と同じ ping/pong keepalive + 3s reconnect。タブが非表示の間
+// は reload を保留し、再表示時にまとめて 1 回 reload する (バックグラウンド
+// タブの無駄な再描画防止)。
+const LIVE_RELOAD_SCRIPT = `
+  <script>
+    (() => {
+      let pending = false;
+      let timer = null;
+      const doReload = () => {
+        if (document.visibilityState !== "visible") { pending = true; return; }
+        location.reload();
+      };
+      document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState === "visible" && pending) { pending = false; doReload(); }
+      });
+      const connect = () => {
+        const proto = location.protocol === "https:" ? "wss:" : "ws:";
+        const ws = new WebSocket(proto + "//" + location.host + "/ws");
+        let ping = null;
+        ws.onopen = () => {
+          ping = setInterval(() => {
+            if (ws.readyState === WebSocket.OPEN) ws.send("ping");
+          }, 30000);
+        };
+        ws.onmessage = (e) => {
+          if (e.data === "pong") return;
+          try {
+            const msg = JSON.parse(e.data);
+            if (msg && msg.type === "issues-updated") {
+              // burst (連続 close 等) を 1 回の reload にまとめる
+              if (timer) clearTimeout(timer);
+              timer = setTimeout(doReload, 1500);
+            }
+          } catch { /* ignore */ }
+        };
+        ws.onclose = () => {
+          if (ping) clearInterval(ping);
+          setTimeout(connect, 3000);
+        };
+        ws.onerror = () => { ws.close(); };
+      };
+      connect();
+    })();
+  </script>`;
 
 function renderProjectSection(
   items: ReadonlyArray<{ issue: OrgIssue; projects: ProjectRef[] }>,

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -374,6 +374,20 @@ async function processWebhookEvent(
     if (owner && name) {
       await invalidateReleaseCacheIssue(env.CI_STATUS, owner, name, payload.issue.number);
     }
+    // /issues page の live reload trigger (Refs #321)。KV upsert 完了後に
+    // broadcast するので、reload 時の SSR read は必ず更新後の KV を見る。
+    // 通知失敗は page 側の問題に留まる (次の手動 reload で追い付く) ため
+    // fail-open。
+    try {
+      await hub.fetch(new Request("http://hub/issues-updated", {
+        method: "POST",
+        body: JSON.stringify({
+          repo: payload.repository.full_name,
+          number: payload.issue.number,
+          state: payload.issue.state,
+        }),
+      }));
+    } catch { /* fail-open */ }
     return;
   }
 

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -319,6 +319,18 @@ describe("GET /issues", () => {
     expect(alcH2).toContain("mode-needs-tag");
   });
 
+  it("live reload script (issues-updated listener) を埋め込む (Refs #321)", async () => {
+    stubSearchIssues();
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request("http://localhost/issues"), testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    const html = await res.text();
+    expect(html).toContain('new WebSocket(proto + "//" + location.host + "/ws")');
+    expect(html).toContain("issues-updated");
+    expect(html).toContain("location.reload()");
+  });
+
   it("escapes HTML in issue titles (XSS guard)", async () => {
     stubSearchIssues();
     const req = new Request("http://localhost/issues");

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -836,6 +836,12 @@ describe("POST /webhook", () => {
     await waitOnExecutionContext(ctx);
     expect(res.status).toBe(200);
     expect(await env.CI_STATUS.get("rcache:v1:issue:ippoan/foo:42")).toBeNull();
+
+    // /issues live reload trigger (Refs #321): KV upsert 後に Hub へ
+    // /issues-updated が飛び、WS client に broadcast される。
+    const updates = hubCalls.filter((c) => c.path === "/issues-updated");
+    expect(updates).toHaveLength(1);
+    expect(updates[0].body).toEqual({ repo: "ippoan/foo", number: 42, state: "closed" });
   });
 });
 


### PR DESCRIPTION
## 概要 (Refs #321)

「これで /issues の WebSocket による自動更新・追加ができるか?」への回答実装。webhook queue 化 (#320) で issues event が数秒以内に確実に KV へ反映されるようになったため、/issues を開きっぱなしでも**新規 issue / close がリロードなしで自動反映**される。

## アーキテクチャ

```
issues webhook → queue consumer → KV upsert
  → Hub /issues-updated → {type:"issues-updated"} を全 WS client に broadcast
       ↓
/issues page の inline script (/ws 接続)
  → 1.5s debounce で location.reload() → SSR が更新後の KV を読む
```

- **Hub DO**: `/issues-updated` endpoint + `issues-updated` WsEnvelope を追加。dashboard JS は未知 type を無視する設計なので既存画面に影響なし
- **webhook (queue consumer)**: issues event の KV upsert **完了後**に broadcast — reload 時の SSR read は必ず更新後の KV を見る。通知失敗は fail-open (次の手動 reload で追い付く)
- **/issues page**: dashboard と同じ ping/pong keepalive + 3s reconnect。連続イベント (batch close 等) は debounce で 1 回の reload にまとめ、**非表示タブは reload を保留**して再表示時に 1 回だけ実施

## 検証

```
$ npm run typecheck   # green
$ npm test            # 782 tests passed
```

- webhook: issues event 処理後に Hub へ `/issues-updated` が飛ぶ (body 検証)
- issues-page: live reload script (WS 接続 + issues-updated listener) の埋め込み

Refs #321

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhkgxKWTehmnLWqffude3z)_