### PR TITLE
perf(issues): decorations (Project/PR チップ) で SSR をブロックしない — loading 表示 + 部分更新

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {
 import { AUTH_WORKER_ORIGIN } from "./github-api";
 import { handleWebhook, consumeWebhookBatch, type WebhookQueueMessage } from "./webhook";
 import { handleDashboard } from "./dashboard";
-import { handleIssuesPage } from "./issues-page";
+import { handleIssuesPage, handleIssuesDecorations } from "./issues-page";
 import { handleProjectsPage } from "./projects-page";
 import { handleReleasesPage } from "./releases-page";
 import { handleReleaseClose } from "./release-close";
@@ -128,6 +128,9 @@ app.get("/", () => handleDashboard());
 // Open issues (SSR, cross-org)。executionCtx は SWR の background
 // reconcile / PR map refresh 用 (Refs #304)。
 app.get("/issues", (c) => handleIssuesPage(c.env, c.executionCtx));
+
+// decorations (Project/PR チップ) の部分更新用 JSON (Refs #323)。KV read のみ。
+app.get("/issues/decorations", (c) => handleIssuesDecorations(c.env));
 
 // Projects v2 read-only listing (SSR, cross-org). Refs #72.
 app.get("/projects", (c) => handleProjectsPage(c.env));

--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -14,9 +14,11 @@ import {
 import { loadPrMap, type PrMapResult } from "./pr-map-cache";
 import { getRateLimitBackoff } from "./github-backoff";
 import {
-  getOrFetchProjectIssueMap,
-  type ProjectIssueMapResult,
+  loadProjectIssueMapSwr,
+  readProjectIssueMapBlob,
+  type ProjectIssueMapSwrResult,
 } from "./project-cache";
+import { readPrMapCache } from "./pr-map-cache";
 import { parseTaglessRepos } from "./tagless-repos";
 
 // Orgs fetched in full. Same allowlist as github-api.ts (not imported because
@@ -115,8 +117,11 @@ interface Freshness {
   reconcileAgeSec: number | null;
   /** warm path で background reconcile を waitUntil に投げた。 */
   issuesRefreshing: boolean;
-  /** PR map が stale を即返しして background refresh 中。 */
+  /** PR map / project map が stale を即返しして background refresh 中。 */
   prRefreshing: boolean;
+  /** decorations (Project/PR チップ) の cache が無く背景 fetch 中 (cold
+   *  start)。loading バナー + /issues/decorations poll で部分更新 (Refs #323)。 */
+  decoLoading: boolean;
   /** rate-limit backoff 中。値は再開予定時刻 (epoch ms)。 */
   backoffUntil: number | null;
   /** cold start で同期 reconcile が失敗した時のみ生エラーを表示する。 */
@@ -224,7 +229,7 @@ export async function handleIssuesPage(
   };
 
   const [project, prs, watermark, backoff] = await Promise.all([
-    getOrFetchProjectIssueMap(env, PROJECT_ORGS),
+    loadProjectIssueMapSwr(env, PROJECT_ORGS, ctx),
     loadPrMap(env, ORGS, YHONDA_REPOS, ctx),
     getIssuesWatermark(kv),
     getRateLimitBackoff(kv),
@@ -239,7 +244,8 @@ export async function handleIssuesPage(
     // no-op reconcile でバナーを出すとノイズになる)。
     issuesRefreshing: issuesRefreshing &&
       (reconcileAgeSec === null || reconcileAgeSec * 1000 >= FRESH_THRESHOLD_MS),
-    prRefreshing: prs.refreshing,
+    prRefreshing: prs.refreshing || project.refreshing,
+    decoLoading: project.loading || prs.loading,
     backoffUntil: backoff?.until ?? null,
     coldError: reconcileError,
   };
@@ -290,7 +296,7 @@ function renderHtml(
   incomplete: boolean,
   projectTagged: ReadonlyArray<{ issue: OrgIssue; projects: ProjectRef[] }>,
   repos: ReadonlyArray<readonly [string, OrgIssue[]]>,
-  project: ProjectIssueMapResult,
+  project: ProjectIssueMapSwrResult,
   prs: PrMapResult,
   freshness: Freshness,
   taglessSet: ReadonlySet<string>,
@@ -324,10 +330,11 @@ function renderHtml(
           : ""
       }</div>`
     : "";
-  const projectBanner = project.stale
-    ? `<div class="banner banner-info">📋 Project tags shown are from the last successful sync — fresh fetch failed (${escapeHtml(project.error ?? "")})</div>`
-    : project.error
-    ? `<div class="banner">⚠️ Project tags unavailable: ${escapeHtml(project.error)}</div>`
+  // decorations (Project/PR チップ) cold start: loading バナー + poll script で
+  // 部分更新する (Refs #323)。project map の stale/error は SWR blob 化に伴い
+  // refreshing 表示に集約 (層別 cache の stale fallback は blob 生成側が吸収)。
+  const decoLoadingBanner = freshness.decoLoading
+    ? `<div class="banner banner-info" id="deco-loading">🔄 Project / PR チップを読み込み中… (一覧は表示済み、チップは取得でき次第この場で反映されます)</div>`
     : "";
   const prBanner = prs.stale
     ? `<div class="banner banner-info">🔗 Related-PR links shown are from the last successful sync — fresh fetch failed (${escapeHtml(prs.error ?? "")})</div>`
@@ -581,7 +588,7 @@ function renderHtml(
   ${backoffBanner}
   ${refreshingBanner}
   ${issueStaleBanner}
-  ${projectBanner}
+  ${decoLoadingBanner}
   ${prBanner}
   ${projectSection}
   ${repos.length === 0 && projectTagged.length === 0
@@ -589,8 +596,96 @@ function renderHtml(
     : repoSections}
   ${PWA_REGISTER_SCRIPT}
   ${LIVE_RELOAD_SCRIPT}
+  ${freshness.decoLoading ? DECORATIONS_POLL_SCRIPT : ""}
 </body>
 </html>`;
+}
+
+// decorations (Project/PR チップ) の部分更新 (Refs #323)。cold start で SSR が
+// チップ無しで返った時だけ埋め込まれる。/issues/decorations (KV read のみ) を
+// poll し、両 cache が揃ったら data-ik 行の title cell にチップを DOM 注入する。
+// XSS 安全のため innerHTML は使わず createElement + textContent のみ。
+const DECORATIONS_POLL_SCRIPT = `
+  <script>
+    (() => {
+      const apply = (data) => {
+        document.querySelectorAll("tr[data-ik]").forEach((tr) => {
+          const ik = tr.getAttribute("data-ik");
+          const td = tr.querySelector("td.title");
+          if (!td) return;
+          const projects = data.projects[ik] || [];
+          if (projects.length > 0 && !td.querySelector(".project-chip")) {
+            const div = document.createElement("div");
+            div.className = "labels";
+            for (const p of projects) {
+              const a = document.createElement("a");
+              a.className = "project-chip";
+              a.href = p.url; a.target = "_blank"; a.rel = "noopener";
+              a.textContent = p.title;
+              div.appendChild(a);
+            }
+            td.appendChild(div);
+          }
+          const prs = data.prs[ik] || [];
+          if (prs.length > 0 && !td.querySelector(".pr-chips")) {
+            const div = document.createElement("div");
+            div.className = "pr-chips";
+            for (const p of prs) {
+              const a = document.createElement("a");
+              a.className = "pr-chip" + (p.state === "merged" ? " merged" : p.draft ? " draft" : "");
+              a.href = p.url; a.target = "_blank"; a.rel = "noopener";
+              a.title = "#" + p.number + ": " + p.title;
+              a.textContent = (p.state === "merged" ? "\u2705 " : "\ud83d\udd17 ") + "#" + p.number +
+                (p.state === "merged" ? " (merged)" : p.draft ? " (draft)" : "");
+              div.appendChild(a);
+            }
+            td.appendChild(div);
+          }
+        });
+      };
+      let tries = 0;
+      const poll = async () => {
+        tries++;
+        try {
+          const r = await fetch("/issues/decorations");
+          if (r.ok) {
+            const d = await r.json();
+            if (d.ready) {
+              apply(d);
+              const banner = document.getElementById("deco-loading");
+              if (banner) banner.remove();
+              return;
+            }
+          }
+        } catch { /* transient — retry */ }
+        if (tries < 16) setTimeout(poll, 2500);
+        else {
+          const banner = document.getElementById("deco-loading");
+          if (banner) banner.textContent = "\u26a0\ufe0f チップの取得に時間がかかっています — 後でリロードしてください";
+        }
+      };
+      setTimeout(poll, 2000);
+    })();
+  </script>`;
+
+/** GET /issues/decorations — 部分更新用の軽量 JSON (KV read 2 回のみ、GitHub
+ *  fetch なし)。両 cache (project map blob + pr map) が揃ったら ready:true。 */
+export async function handleIssuesDecorations(
+  env: AuthClientWorkerEnv,
+): Promise<Response> {
+  const kv = env.CI_STATUS;
+  const [projects, prs] = await Promise.all([
+    readProjectIssueMapBlob(kv),
+    readPrMapCache(kv),
+  ]);
+  return Response.json(
+    {
+      ready: projects !== null && prs !== null,
+      projects: projects ?? {},
+      prs: prs ?? {},
+    },
+    { headers: { "Cache-Control": "private, no-store" } },
+  );
 }
 
 // /issues の live 更新 (Refs #321)。Hub DO の /ws に接続し、webhook の issues
@@ -671,7 +766,7 @@ function renderProjectRow(
         `<span class="label">${escapeHtml(l)}</span>`).join("")}</div>`
     : "";
   const trClass = isFixtureIssue(i) ? ' class="fixture"' : "";
-  return `<tr${trClass}>
+  return `<tr${trClass} data-ik="${escapeHtml(`${i.repo}#${i.number}`)}">
     <td class="num"><a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">#${i.number}</a></td>
     <td class="repo"><a href="https://github.com/${escapeHtml(i.repo)}/issues" target="_blank" rel="noopener">${escapeHtml(i.repo)}</a>${renderReleaseModeBadge(i.repo, taglessSet)}</td>
     <td class="title">${renderFixtureBadge(i)}<a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">${escapeHtml(i.title)}</a><div class="labels">${chips}</div>${labelChips}${renderPrChips(i, prMap)}</td>
@@ -707,7 +802,7 @@ function renderRow(
         `<span class="label">${escapeHtml(l)}</span>`).join("")}</div>`
     : "";
   const trClass = isFixtureIssue(i) ? ' class="fixture"' : "";
-  return `<tr${trClass}>
+  return `<tr${trClass} data-ik="${escapeHtml(`${i.repo}#${i.number}`)}">
     <td class="num"><a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">#${i.number}</a></td>
     <td class="title">${renderFixtureBadge(i)}<a href="${escapeHtml(i.url)}" target="_blank" rel="noopener">${escapeHtml(i.title)}</a>${labelChips}${renderPrChips(i, prMap)}</td>
     <td class="author">@${escapeHtml(i.author)}</td>

--- a/src/pr-map-cache.ts
+++ b/src/pr-map-cache.ts
@@ -48,6 +48,9 @@ export interface PrMapResult {
   stale: boolean;
   /** cache を即返しして refresh を waitUntil に投げた (mild banner)。 */
   refreshing: boolean;
+  /** cache が無く背景 fetch 中 (= cold start)。page は loading 表示 +
+   *  /issues/decorations poll で部分更新する (Refs #323)。 */
+  loading: boolean;
   error: string | null;
 }
 
@@ -80,22 +83,30 @@ export async function loadPrMap(
       map: new Map(Object.entries(cached.data)),
       stale: false,
       refreshing: !fresh,
+      loading: false,
       error: null,
     };
   }
-  // Cold start: 同期 fetch。失敗は従来どおり error として返し hard banner。
-  try {
-    const fresh = await fetchAllOpenPrsByIssue(env, mainOrgs, yhondaRepos);
-    const entry: PrMapCacheEntry = { storedAt: now, data: Object.fromEntries(fresh) };
-    await kv.put(PR_MAP_CACHE_KEY, JSON.stringify(entry), {
-      expirationTtl: PR_MAP_STORE_SECONDS,
-    });
-    return { map: fresh, stale: false, refreshing: false, error: null };
-  } catch (err) {
-    if (isRateLimitError(err)) await setRateLimitBackoff(kv, err);
-    const message = err instanceof Error ? err.message : String(err);
-    return { map: new Map(), stale: false, refreshing: false, error: message };
-  }
+  // Cold start: 旧実装は同期 fetch (4 search) でページ全体を塞いでいた。
+  // SSR をブロックせず背景 refresh + loading flag を返し、page 側が
+  // /issues/decorations を poll して部分更新する (Refs #323)。
+  const p = refreshPrMap(env, mainOrgs, yhondaRepos).catch((err) => {
+    console.log(JSON.stringify({
+      msg: "pr-map-bg-refresh-failed",
+      error: err instanceof Error ? err.message : String(err),
+    }));
+  });
+  if (ctx) ctx.waitUntil(p);
+  else void p;
+  return { map: new Map(), stale: false, refreshing: true, loading: true, error: null };
+}
+
+/** /issues/decorations 用: cache を KV read だけで返す (GitHub fetch なし)。 */
+export async function readPrMapCache(
+  kv: KVNamespace,
+): Promise<Record<string, IssuePrRef[]> | null> {
+  const cached = await kv.get(PR_MAP_CACHE_KEY, "json") as PrMapCacheEntry | null;
+  return cached ? cached.data : null;
 }
 
 /** full 4-call Search fetch で cache を取り直す (background 実行前提)。

--- a/src/project-cache.ts
+++ b/src/project-cache.ts
@@ -238,11 +238,112 @@ export async function invalidateOrgItems(kv: KVNamespace, org: string): Promise<
   } while (cursor);
 }
 
-/** `/issues` page の project map cache (Phase 1 で既存) を flush。
- *  `projects_v2_item` event でカードが移動した時、/issues 側の 5min TTL を
- *  待たずに即反映するために併せて呼ぶ。 */
+/** `/issues` page の project map blob を stale 化する。delete ではなく
+ *  storedAt:0 への書き換えにするのは、webhook (projects_v2*) の度に /issues
+ *  が loading 状態 (= チップ無し) に戻るのを避けるため — 古いチップを出し
+ *  つつ背景 refresh で追い付く (Refs #323)。blob が無ければ no-op。 */
 export async function invalidateIssuesPageProjectMap(kv: KVNamespace): Promise<void> {
-  await kv.delete(ISSUES_PAGE_PROJECT_MAP_KEY);
+  const blob = await kv.get(ISSUES_PAGE_PROJECT_MAP_KEY, "json") as ProjectMapBlobEntry | null;
+  if (!blob) return;
+  await kv.put(
+    ISSUES_PAGE_PROJECT_MAP_KEY,
+    JSON.stringify({ ...blob, storedAt: 0 }),
+    { expirationTtl: PROJECT_MAP_STORE_SECONDS },
+  );
+}
+
+// ───── /issues page 向け SWR blob (Refs #323) ─────
+//
+// getOrFetchProjectIssueMap は層別 KV cache (org list 30min + per-board items)
+// を持つが、TTL 切れの SSR hit が GraphQL fan-out を**同期で**待っていた
+// (実測: /issues 平均 wall 13.8s / p90 35s、CPU 28ms = ほぼ全部この待ち)。
+// pr-map-cache と同じ SWR pattern で結合済み map を 1 blob として持ち、
+// warm/stale は即返し + 背景 refresh、cold は loading flag で SSR を
+// ブロックしない (page 側が /issues/decorations を poll して部分更新する)。
+
+interface ProjectMapBlobEntry {
+  storedAt: number;
+  data: Record<string, ProjectRef[]>;
+}
+
+const PROJECT_MAP_FRESH_SECONDS = 600;
+const PROJECT_MAP_STORE_SECONDS = 86400;
+const PROJECT_MAP_REFRESH_LOCK = "issues-page:project-map:refreshing";
+const PROJECT_MAP_REFRESH_LOCK_TTL = 60;
+
+export interface ProjectIssueMapSwrResult {
+  map: Map<string, ProjectRef[]>;
+  /** blob が無く背景 fetch 中 (= cold start)。page は loading 表示 +
+   *  /issues/decorations poll で部分更新する。 */
+  loading: boolean;
+  /** stale blob を即返しして背景 refresh 中 (mild banner)。 */
+  refreshing: boolean;
+}
+
+/** SWR 読み出し: blob があれば常に即返し (stale なら背景 refresh)。blob が
+ *  無い cold start も同期 fetch せず、背景 refresh + loading flag を返す。 */
+export async function loadProjectIssueMapSwr(
+  env: AuthClientWorkerEnv,
+  orgs: string[],
+  ctx?: ExecutionContext,
+): Promise<ProjectIssueMapSwrResult> {
+  const kv = env.CI_STATUS;
+  const blob = await kv.get(ISSUES_PAGE_PROJECT_MAP_KEY, "json") as ProjectMapBlobEntry | null;
+  const now = Date.now();
+  const kick = () => {
+    const p = refreshProjectIssueMapBlob(env, orgs).catch((err) => {
+      console.log(JSON.stringify({
+        msg: "project-map-bg-refresh-failed",
+        error: err instanceof Error ? err.message : String(err),
+      }));
+    });
+    if (ctx) ctx.waitUntil(p);
+    else void p;
+  };
+
+  if (blob) {
+    const fresh = now - blob.storedAt < PROJECT_MAP_FRESH_SECONDS * 1000;
+    if (!fresh) kick();
+    return {
+      map: new Map(Object.entries(blob.data)),
+      loading: false,
+      refreshing: !fresh,
+    };
+  }
+  kick();
+  return { map: new Map(), loading: true, refreshing: true };
+}
+
+/** blob を取り直す (背景実行前提)。層別 cache 持ちの
+ *  getOrFetchProjectIssueMap に委譲するので、warm な層は GraphQL 0 call。
+ *  backoff / lock / 既に fresh なら no-op。 */
+export async function refreshProjectIssueMapBlob(
+  env: AuthClientWorkerEnv,
+  orgs: string[],
+): Promise<void> {
+  const kv = env.CI_STATUS;
+  if (await getRateLimitBackoff(kv)) return;
+  if (await kv.get(PROJECT_MAP_REFRESH_LOCK)) return;
+  await kv.put(PROJECT_MAP_REFRESH_LOCK, "1", { expirationTtl: PROJECT_MAP_REFRESH_LOCK_TTL });
+  const recheck = await kv.get(ISSUES_PAGE_PROJECT_MAP_KEY, "json") as ProjectMapBlobEntry | null;
+  if (recheck && Date.now() - recheck.storedAt < PROJECT_MAP_FRESH_SECONDS * 1000) return;
+
+  const res = await getOrFetchProjectIssueMap(env, orgs);
+  const entry: ProjectMapBlobEntry = {
+    storedAt: Date.now(),
+    data: Object.fromEntries(res.map),
+  };
+  await kv.put(ISSUES_PAGE_PROJECT_MAP_KEY, JSON.stringify(entry), {
+    expirationTtl: PROJECT_MAP_STORE_SECONDS,
+  });
+}
+
+/** /issues/decorations 用: blob を KV read だけで返す (GitHub fetch なし)。 */
+export async function readProjectIssueMapBlob(
+  kv: KVNamespace,
+): Promise<Record<string, ProjectRef[]> | null> {
+  const blob = await kv.get(ISSUES_PAGE_PROJECT_MAP_KEY, "json") as ProjectMapBlobEntry | null;
+  return blob ? blob.data : null;
 }
 
 // ───── Webhook payload types ─────
@@ -302,6 +403,8 @@ export const __testing = {
   TTL_SECONDS,
   STORE_TTL_SECONDS,
   ISSUES_PAGE_PROJECT_MAP_KEY,
+  PROJECT_MAP_FRESH_SECONDS,
+  PROJECT_MAP_REFRESH_LOCK,
   orgListKey,
   itemsKey,
 };

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -15,6 +15,19 @@ function testEnv(): Env {
   };
 }
 
+// decorations (PR/Project チップ) は cold start で背景 fetch される (Refs #323)
+// ため、チップを SSR でアサートするテストは 1 回目の load で cache を温めて
+// から 2 回目の response を検証する。
+async function fetchIssuesWarmed(): Promise<Response> {
+  const ctx1 = createExecutionContext();
+  await worker.fetch(new Request("http://localhost/issues"), testEnv(), ctx1);
+  await waitOnExecutionContext(ctx1);
+  const ctx2 = createExecutionContext();
+  const res = await worker.fetch(new Request("http://localhost/issues"), testEnv(), ctx2);
+  await waitOnExecutionContext(ctx2);
+  return res;
+}
+
 // Stub /search/issues + /graphql. The page fires parallel calls:
 //   - /search/issues `is:issue` × 2 (main orgs + yhonda repo: filter)
 //   - /search/issues `is:pr`    × 4 (main orgs × {open, merged}
@@ -249,6 +262,7 @@ describe("GET /issues", () => {
     await env.CI_STATUS.delete("github:rl-backoff");
     await env.CI_STATUS.delete("issues:reconciling");
     await env.CI_STATUS.delete("issues-page:pr-map:refreshing");
+    await env.CI_STATUS.delete("issues-page:project-map:refreshing");
     // Refs #135: /issues も project-cache の KV (`project:*`) を共有するため
     // テスト間で flush しないと前テストの fixture が漏れる。
     for (const prefix of ["issue:", "project:"]) {
@@ -485,6 +499,7 @@ describe("GET /issues — Project section", () => {
     await env.CI_STATUS.delete("github:rl-backoff");
     await env.CI_STATUS.delete("issues:reconciling");
     await env.CI_STATUS.delete("issues-page:pr-map:refreshing");
+    await env.CI_STATUS.delete("issues-page:project-map:refreshing");
     // Refs #135: /issues も project-cache の KV (`project:*`) を共有するため
     // テスト間で flush しないと前テストの fixture が漏れる。
     for (const prefix of ["issue:", "project:"]) {
@@ -500,10 +515,7 @@ describe("GET /issues — Project section", () => {
 
   it("renders a 'Project 付き' section with project chips and excludes those issues from their repo section", async () => {
     stubFetch({ withProjects: true });
-    const req = new Request("http://localhost/issues");
-    const ctx = createExecutionContext();
-    const res = await worker.fetch(req, testEnv(), ctx);
-    await waitOnExecutionContext(ctx);
+    const res = await fetchIssuesWarmed();
 
     expect(res.status).toBe(200);
     const html = await res.text();
@@ -605,10 +617,7 @@ describe("GET /issues — Project section", () => {
       });
     });
 
-    const req = new Request("http://localhost/issues");
-    const ctx = createExecutionContext();
-    const res = await worker.fetch(req, testEnv(), ctx);
-    await waitOnExecutionContext(ctx);
+    const res = await fetchIssuesWarmed();
 
     const html = await res.text();
     // Both chips appear in the project row for #7.
@@ -666,6 +675,7 @@ describe("GET /issues — Claude Code launch button", () => {
     await env.CI_STATUS.delete("github:rl-backoff");
     await env.CI_STATUS.delete("issues:reconciling");
     await env.CI_STATUS.delete("issues-page:pr-map:refreshing");
+    await env.CI_STATUS.delete("issues-page:project-map:refreshing");
     // Refs #135: /issues も project-cache の KV (`project:*`) を共有するため
     // テスト間で flush しないと前テストの fixture が漏れる。
     for (const prefix of ["issue:", "project:"]) {
@@ -702,10 +712,7 @@ describe("GET /issues — Claude Code launch button", () => {
 
   it("renders a launch link in the Project section too", async () => {
     stubFetch({ withProjects: true });
-    const req = new Request("http://localhost/issues");
-    const ctx = createExecutionContext();
-    const res = await worker.fetch(req, testEnv(), ctx);
-    await waitOnExecutionContext(ctx);
+    const res = await fetchIssuesWarmed();
 
     const html = await res.text();
     const projectSection = html.match(
@@ -732,6 +739,7 @@ describe("GET /issues — Related-PR chips", () => {
     await env.CI_STATUS.delete("github:rl-backoff");
     await env.CI_STATUS.delete("issues:reconciling");
     await env.CI_STATUS.delete("issues-page:pr-map:refreshing");
+    await env.CI_STATUS.delete("issues-page:project-map:refreshing");
     // Refs #135: /issues も project-cache の KV (`project:*`) を共有するため
     // テスト間で flush しないと前テストの fixture が漏れる。
     for (const prefix of ["issue:", "project:"]) {
@@ -747,10 +755,7 @@ describe("GET /issues — Related-PR chips", () => {
 
   it("renders a pr-chip on issues that have an open PR referencing them via Refs #N", async () => {
     stubFetch({ withPrs: true });
-    const req = new Request("http://localhost/issues");
-    const ctx = createExecutionContext();
-    const res = await worker.fetch(req, testEnv(), ctx);
-    await waitOnExecutionContext(ctx);
+    const res = await fetchIssuesWarmed();
 
     const html = await res.text();
     // The seeded PR is rust-alc-api#42 referencing #7. We expect a pr-chip
@@ -765,10 +770,7 @@ describe("GET /issues — Related-PR chips", () => {
 
   it("renders a purple .merged pr-chip when only a merged PR references the issue", async () => {
     stubFetch({ withMergedPrs: true });
-    const req = new Request("http://localhost/issues");
-    const ctx = createExecutionContext();
-    const res = await worker.fetch(req, testEnv(), ctx);
-    await waitOnExecutionContext(ctx);
+    const res = await fetchIssuesWarmed();
 
     const html = await res.text();
     // Seeded merged PR is rust-alc-api#50 referencing #7.
@@ -779,10 +781,7 @@ describe("GET /issues — Related-PR chips", () => {
 
   it("renders both open and merged chips when both exist for the same issue", async () => {
     stubFetch({ withPrs: true, withMergedPrs: true });
-    const req = new Request("http://localhost/issues");
-    const ctx = createExecutionContext();
-    const res = await worker.fetch(req, testEnv(), ctx);
-    await waitOnExecutionContext(ctx);
+    const res = await fetchIssuesWarmed();
 
     const html = await res.text();
     // Open chip ordered before merged chip in the rendered HTML.
@@ -844,10 +843,7 @@ describe("GET /issues — Related-PR chips", () => {
         }],
       });
     });
-    const req = new Request("http://localhost/issues");
-    const ctx = createExecutionContext();
-    const res = await worker.fetch(req, testEnv(), ctx);
-    await waitOnExecutionContext(ctx);
+    const res = await fetchIssuesWarmed();
 
     const html = await res.text();
     expect(html).toContain('class="pr-chip draft"');
@@ -875,14 +871,16 @@ describe("GET /issues — Related-PR chips", () => {
       }
       return Response.json({ total_count: 0, incomplete_results: false, items: [] });
     });
-    const req = new Request("http://localhost/issues");
     const ctx = createExecutionContext();
-    const res = await worker.fetch(req, testEnv(), ctx);
+    const res = await worker.fetch(new Request("http://localhost/issues"), testEnv(), ctx);
     await waitOnExecutionContext(ctx);
 
+    // Refs #323: cold start は同期 fetch しないので 403 でも page は塞がれず、
+    // loading 状態のまま 200 で render される (チップは poll script が後追い、
+    // 失敗時は client 側 message に落ちる)。
     expect(res.status).toBe(200);
     const html = await res.text();
-    expect(html).toContain("Related-PR links unavailable");
+    expect(html).toContain('id="deco-loading"');
   });
 });
 
@@ -907,6 +905,7 @@ describe("GET /issues — CI fixture rows", () => {
     await env.CI_STATUS.delete("github:rl-backoff");
     await env.CI_STATUS.delete("issues:reconciling");
     await env.CI_STATUS.delete("issues-page:pr-map:refreshing");
+    await env.CI_STATUS.delete("issues-page:project-map:refreshing");
     for (const prefix of ["issue:", "project:"]) {
       let cursor: string | undefined;
       do {
@@ -965,7 +964,7 @@ describe("GET /issues — CI fixture rows", () => {
     // clickable cc-launch anchor.
     expect(html).toContain("🔒 保全");
     expect(html).toContain('class="fixture-badge"');
-    expect(html).toContain('<tr class="fixture">');
+    expect(html).toContain('<tr class="fixture"');
     expect(html).toContain('class="cc-launch-disabled"');
     expect(html).not.toContain('<a class="cc-launch"');
   });
@@ -995,6 +994,7 @@ describe("GET /issues — SWR (Refs #304)", () => {
     await env.CI_STATUS.delete("github:rl-backoff");
     await env.CI_STATUS.delete("issues:reconciling");
     await env.CI_STATUS.delete("issues-page:pr-map:refreshing");
+    await env.CI_STATUS.delete("issues-page:project-map:refreshing");
     for (const prefix of ["issue:", "project:"]) {
       let cursor: string | undefined;
       do {
@@ -1030,6 +1030,12 @@ describe("GET /issues — SWR (Refs #304)", () => {
     await seedIssue("ippoan/rust-alc-api", 7, "cached issue");
     await env.CI_STATUS.put("issues:watermark", new Date(Date.now() - 5_000).toISOString());
     await seedPrMap(Date.now());
+    // project map blob も fresh seed (Refs #323: 無いと cold 扱いで
+    // decoLoading + 背景 refresh が走り banner 判定が変わる)
+    await env.CI_STATUS.put(
+      "issues-page:project-map",
+      JSON.stringify({ storedAt: Date.now(), data: {} }),
+    );
 
     const ctx = createExecutionContext();
     const res = await worker.fetch(new Request("http://localhost/issues"), testEnv(), ctx);
@@ -1142,5 +1148,81 @@ describe("GET /issues — SWR (Refs #304)", () => {
     expect(res.headers.get("Retry-After")).toBeTruthy();
     expect(await res.text()).toContain("rate-limit cooldown");
     expect(searchCalls(fetchSpy as never)).toBe(0);
+  });
+});
+
+// ───── decorations 部分更新 (Refs #323) ─────
+describe("GET /issues — decorations 部分更新 (Refs #323)", () => {
+  beforeEach(async () => {
+    await env.CI_STATUS.delete("issues-page:project-map");
+    await env.CI_STATUS.delete("issues-page:project-map:refreshing");
+    await env.CI_STATUS.delete("issues-page:pr-map:v2");
+    await env.CI_STATUS.delete("issues-page:pr-map:refreshing");
+    await env.CI_STATUS.delete("issues:watermark");
+    await env.CI_STATUS.delete("github:rl-backoff");
+    await env.CI_STATUS.delete("issues:reconciling");
+    for (const prefix of ["issue:", "project:"]) {
+      let cursor: string | undefined;
+      do {
+        const page = await env.CI_STATUS.list({ prefix, cursor });
+        await Promise.all(page.keys.map((k) => env.CI_STATUS.delete(k.name)));
+        cursor = page.list_complete ? undefined : page.cursor;
+      } while (cursor);
+    }
+  });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("cold start は一覧を即 render し、loading バナー + data-ik + poll script を出す (チップ無し)", async () => {
+    stubFetch({ withPrs: true, withProjects: true });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request("http://localhost/issues"), testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // 一覧自体は出ている
+    expect(html).toContain("ippoan/rust-alc-api");
+    // loading 表示 + 部分更新の配線
+    expect(html).toContain('id="deco-loading"');
+    expect(html).toContain("/issues/decorations");
+    expect(html).toContain('data-ik="ippoan/rust-alc-api#7"');
+    // SSR にはチップは含まれない (poll script が後追いで注入)
+    expect(html).not.toContain('<a class="pr-chip"');
+    expect(html).not.toContain('<a class="project-chip"');
+  });
+
+  it("/issues/decorations: cold は ready:false、warm 後は ready:true で chips data を返す", async () => {
+    stubFetch({ withPrs: true, withProjects: true });
+
+    const ctx1 = createExecutionContext();
+    const r1 = await worker.fetch(new Request("http://localhost/issues/decorations"), testEnv(), ctx1);
+    await waitOnExecutionContext(ctx1);
+    expect((await r1.json() as { ready: boolean }).ready).toBe(false);
+
+    // /issues の cold load が背景 fetch を waitUntil で完走させ cache を温める
+    const ctx2 = createExecutionContext();
+    await worker.fetch(new Request("http://localhost/issues"), testEnv(), ctx2);
+    await waitOnExecutionContext(ctx2);
+
+    const ctx3 = createExecutionContext();
+    const r3 = await worker.fetch(new Request("http://localhost/issues/decorations"), testEnv(), ctx3);
+    await waitOnExecutionContext(ctx3);
+    const d3 = await r3.json() as {
+      ready: boolean;
+      prs: Record<string, unknown[]>;
+      projects: Record<string, unknown[]>;
+    };
+    expect(d3.ready).toBe(true);
+    expect(Object.keys(d3.prs)).toContain("ippoan/rust-alc-api#7");
+    expect(Object.keys(d3.projects)).toContain("ippoan/rust-alc-api#7");
+  });
+
+  it("warm な 2 回目の load はチップを SSR で inline render する (loading バナー無し)", async () => {
+    stubFetch({ withPrs: true, withProjects: true });
+    const res = await fetchIssuesWarmed();
+    const html = await res.text();
+    expect(html).not.toContain('id="deco-loading"');
+    expect(html).toContain('<a class="pr-chip"');
+    expect(html).toContain('class="project-chip"');
   });
 });

--- a/test/pr-map-cache.test.ts
+++ b/test/pr-map-cache.test.ts
@@ -144,15 +144,32 @@ describe("loadPrMap (SWR)", () => {
     expect(entry!.storedAt).toBe(oldStoredAt);
   });
 
-  it("cold start (cache 無し): 同期 fetch、失敗は error として返す (従来挙動)", async () => {
+  it("cold start (cache 無し): 同期 fetch せず loading flag + 背景 refresh (Refs #323)", async () => {
     stubPrSearch({ status: 403, bodyText: "API rate limit exceeded" });
     const ctx = createExecutionContext();
     const res = await loadPrMap(testEnv(), ORGS, YHONDA, ctx);
-    await waitOnExecutionContext(ctx);
+    // SSR をブロックしない: 即 loading で返る
     expect(res.map.size).toBe(0);
-    expect(res.error).toContain("403");
-    // cold start の rate limit も backoff を立てる
+    expect(res.loading).toBe(true);
+    expect(res.error).toBeNull();
+    // 背景 refresh の失敗 (403) は backoff を立てる (waitUntil reject しない)
+    await waitOnExecutionContext(ctx);
     expect(await getRateLimitBackoff(env.CI_STATUS)).not.toBeNull();
+  });
+
+  it("cold start: 背景 refresh 成功後の 2 回目は cache から chips を返す (Refs #323)", async () => {
+    stubPrSearch();
+    const ctx1 = createExecutionContext();
+    const cold = await loadPrMap(testEnv(), ORGS, YHONDA, ctx1);
+    expect(cold.loading).toBe(true);
+    await waitOnExecutionContext(ctx1);
+
+    const ctx2 = createExecutionContext();
+    const warm = await loadPrMap(testEnv(), ORGS, YHONDA, ctx2);
+    await waitOnExecutionContext(ctx2);
+    // 背景 refresh が cache を作っているので 2 回目は loading しない
+    expect(warm.loading).toBe(false);
+    expect(await readMap()).not.toBeNull();
   });
 });
 

--- a/test/project-cache.test.ts
+++ b/test/project-cache.test.ts
@@ -205,8 +205,21 @@ describe("project-cache", () => {
       expect(await env.CI_STATUS.get(itemsKey("ohishi-exp", 1))).toBe('[]');
     });
 
-    it("invalidateIssuesPageProjectMap は issues-page の project-map key を消す", async () => {
-      await env.CI_STATUS.put(ISSUES_PAGE_PROJECT_MAP_KEY, '{}');
+    it("invalidateIssuesPageProjectMap は blob を stale 化する (delete ではなく storedAt:0、Refs #323)", async () => {
+      await env.CI_STATUS.put(
+        ISSUES_PAGE_PROJECT_MAP_KEY,
+        JSON.stringify({ storedAt: Date.now(), data: { "ippoan/x#1": [] } }),
+      );
+      await invalidateIssuesPageProjectMap(env.CI_STATUS);
+      const blob = await env.CI_STATUS.get(ISSUES_PAGE_PROJECT_MAP_KEY, "json") as
+        { storedAt: number; data: Record<string, unknown[]> } | null;
+      // data は保持したまま storedAt:0 = 次の load で古いチップを出しつつ背景 refresh
+      expect(blob).not.toBeNull();
+      expect(blob!.storedAt).toBe(0);
+      expect(Object.keys(blob!.data)).toContain("ippoan/x#1");
+    });
+
+    it("invalidateIssuesPageProjectMap は blob 不在なら no-op", async () => {
       await invalidateIssuesPageProjectMap(env.CI_STATUS);
       expect(await env.CI_STATUS.get(ISSUES_PAGE_PROJECT_MAP_KEY)).toBeNull();
     });
@@ -216,7 +229,10 @@ describe("project-cache", () => {
     it("organization.login から org を引いて list + items + project-map を flush", async () => {
       await env.CI_STATUS.put(orgListKey("ippoan"), '[]');
       await env.CI_STATUS.put(itemsKey("ippoan", 1), '[]');
-      await env.CI_STATUS.put(ISSUES_PAGE_PROJECT_MAP_KEY, '{}');
+      await env.CI_STATUS.put(
+        ISSUES_PAGE_PROJECT_MAP_KEY,
+        JSON.stringify({ storedAt: Date.now(), data: {} }),
+      );
       await applyProjectsV2Event(env.CI_STATUS, {
         action: "edited",
         projects_v2: { id: 1, node_id: "PVT_1" },
@@ -224,7 +240,9 @@ describe("project-cache", () => {
       });
       expect(await env.CI_STATUS.get(orgListKey("ippoan"))).toBeNull();
       expect(await env.CI_STATUS.get(itemsKey("ippoan", 1))).toBeNull();
-      expect(await env.CI_STATUS.get(ISSUES_PAGE_PROJECT_MAP_KEY)).toBeNull();
+      // blob は stale 化 (storedAt:0) — loading に戻さない (Refs #323)
+      const blob = await env.CI_STATUS.get(ISSUES_PAGE_PROJECT_MAP_KEY, "json") as { storedAt: number } | null;
+      expect(blob!.storedAt).toBe(0);
     });
 
     it("organization が無くても projects_v2.owner.login で fallback", async () => {
@@ -342,7 +360,10 @@ describe("project-cache", () => {
     it("items + issues-page project-map だけ flush し、list は保つ", async () => {
       await env.CI_STATUS.put(orgListKey("ippoan"), '[]');
       await env.CI_STATUS.put(itemsKey("ippoan", 1), '[]');
-      await env.CI_STATUS.put(ISSUES_PAGE_PROJECT_MAP_KEY, '{}');
+      await env.CI_STATUS.put(
+        ISSUES_PAGE_PROJECT_MAP_KEY,
+        JSON.stringify({ storedAt: Date.now(), data: {} }),
+      );
       await applyProjectsV2ItemEvent(env.CI_STATUS, {
         action: "created",
         projects_v2_item: {
@@ -353,7 +374,9 @@ describe("project-cache", () => {
       });
       expect(await env.CI_STATUS.get(orgListKey("ippoan"))).toBe('[]'); // 残る
       expect(await env.CI_STATUS.get(itemsKey("ippoan", 1))).toBeNull(); // 消える
-      expect(await env.CI_STATUS.get(ISSUES_PAGE_PROJECT_MAP_KEY)).toBeNull(); // 消える
+      // blob は stale 化 (storedAt:0、Refs #323)
+      const blob = await env.CI_STATUS.get(ISSUES_PAGE_PROJECT_MAP_KEY, "json") as { storedAt: number } | null;
+      expect(blob!.storedAt).toBe(0);
     });
 
     it("organization が無い (user-owned projects 等) なら no-op", async () => {


### PR DESCRIPTION
## 背景 (Refs #323 — operator 提案「cold start ならある分だけ表示 + loading + 部分更新」)

observability 実測 (直近 7 日): GET /issues は **平均 wall 13.8s / p90 34.8s** に対し **CPU 28ms** — ほぼ全部 GitHub 待ち。render パスの

- project map: 30 分 TTL 切れで **3 org × 〜10 board の GraphQL を同期 fan-out**
- PR map: cold start のみ **同期 4 search**

が SSR を塞いでいた (issue 一覧自体は KV read で即出せるのに)。

## 変更

```
GET /issues → KV の issue 一覧で即 render
  ├ チップ cache warm/stale → inline render (stale は背景 refresh)
  └ チップ cache 無し (cold) → 🔄 loading バナー + 背景 fetch
       ↓
     page script が GET /issues/decorations (KV read 2 回のみ) を poll
       → 揃い次第チップを行に DOM 注入 (reload なし・スクロール維持)
```

- **project map を SWR blob 化** (`issues-page:project-map` を `{storedAt, data}` で再利用、fresh 10 分) — pr-map-cache と同一パターン
- **PR map cold start も非ブロック化** (loading flag + 背景 refresh)
- **部分更新**: 各行に `data-ik="repo#N"`、poll script は `createElement` + `textContent` のみで注入 (XSS 安全)。16 回 / 40 秒で諦めて再読込を促す
- **webhook invalidation** (`projects_v2*`): blob を delete ではなく `storedAt:0` に書き換え — event の度に loading に戻さず、古いチップを出しつつ背景 refresh

## 効果

- warm/stale: **KV read のみで即 render** (今まで通りチップ inline)
- cold: 一覧は即表示、チップは数秒後にその場で出現
- 14 秒ブロックの経路が消える (#322 の WS auto-reload の体感にも直結)

## 検証

```
$ npm run typecheck   # green
$ npm test            # 787 tests passed
```

- 新規: cold start の loading バナー + data-ik + poll script / decorations endpoint の ready 遷移 / warm 2 回目の inline render / pr-map cold 非ブロック化 / blob stale 化 invalidation
- 既存のチップ系テストは「1 回目で cache を温め 2 回目を検証」する `fetchIssuesWarmed()` に移行

Refs #323

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhkgxKWTehmnLWqffude3z)_