### PR TITLE
perf(releases): index を SWR blob 化して即 render (refresh は queue consumer で実行)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import {
   type AuthClientWorkerEnv,
 } from "@ippoan/auth-client-worker";
 import { AUTH_WORKER_ORIGIN } from "./github-api";
-import { handleWebhook, consumeWebhookBatch, type WebhookQueueMessage } from "./webhook";
+import { handleWebhook, consumeWebhookBatch, type QueueMessage } from "./webhook";
 import { handleDashboard } from "./dashboard";
 import { handleIssuesPage, handleIssuesDecorations } from "./issues-page";
 import { handleProjectsPage } from "./projects-page";
@@ -93,7 +93,7 @@ export interface Env extends AuthClientWorkerEnv {
    * 200 のみ行い、処理は本 worker の queue consumer が担う。binding 未設定の
    * 環境 (wrangler dev / test) は waitUntil fallback で inline 処理される。
    */
-  WEBHOOK_QUEUE?: Queue<WebhookQueueMessage>;
+  WEBHOOK_QUEUE?: Queue<QueueMessage>;
 }
 
 // OAuth flow config — shared between /oauth/login, /oauth/callback, and the
@@ -148,7 +148,7 @@ app.get("/cc", (c) => handleLaunch(c.req.raw));
 
 // Release confirmation view (SSR + POST close action)
 // See issue #35 + CLAUDE.md `release / close フロー`.
-app.get("/releases", (c) => handleReleasesPage(c.req.raw, c.env));
+app.get("/releases", (c) => handleReleasesPage(c.req.raw, c.env, c.executionCtx));
 // Pass hub + executionCtx so the close handlers can fire-and-forget a
 // `/release-alert-recompute` to refresh the dashboard banner.
 app.post("/api/release-close",
@@ -379,6 +379,6 @@ app.post("/api/release-wave/backend-rollback", (c) =>
 // `fetch` は従来どおり app に委譲 (tests の worker.fetch も互換)。
 export default {
   fetch: app.fetch,
-  queue: (batch: MessageBatch<WebhookQueueMessage>, env: Env) =>
+  queue: (batch: MessageBatch<QueueMessage>, env: Env) =>
     consumeWebhookBatch(batch, env),
 };

--- a/src/release-close-batch.ts
+++ b/src/release-close-batch.ts
@@ -2,6 +2,7 @@ import { githubApi, parseRepo, tokenForOrg } from "./github-api";
 import { formatCloseFailureReason } from "./release-close";
 import type { AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
 import { invalidateIssue } from "./release-cache";
+import { markReleasesIndexStale } from "./releases-index-cache";
 
 // POST /api/release-close-batch
 //
@@ -144,6 +145,9 @@ export async function handleReleaseCloseBatch(
         }
       }),
     );
+    // /releases index blob も stale 化 (Refs #325)。redirect 先の表示自体は
+    // flash 整合 (closed= の row を closed 扱いに変換) が担保する。
+    if (closedByRepo.size > 0) await markReleasesIndexStale(env.CI_STATUS);
   }
 
   // Kick Hub to recompute alert state for each repo that had a successful close.

--- a/src/release-close.ts
+++ b/src/release-close.ts
@@ -1,6 +1,7 @@
 import { GitHubApiError, githubApi, parseRepo, tokenForOrg } from "./github-api";
 import type { AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
 import { invalidateIssue } from "./release-cache";
+import { markReleasesIndexStale } from "./releases-index-cache";
 
 // failure 理由を URL flash param に safely 載せるための整形。
 // GitHubApiError は `GitHub API 403: {"message":"Repository was archived so
@@ -112,6 +113,9 @@ export async function handleReleaseClose(
     await Promise.all(
       closed.map((n) => invalidateIssue(env.CI_STATUS, owner, name, n)),
     );
+    // /releases index blob も stale 化 (Refs #325)。redirect 先の表示自体は
+    // flash 整合 (closed= の row を closed 扱いに変換) が担保する。
+    if (closed.length > 0) await markReleasesIndexStale(env.CI_STATUS);
   }
 
   // Kick the Hub to recompute the banner alert state for this repo when at

--- a/src/releases-index-cache.ts
+++ b/src/releases-index-cache.ts
@@ -1,0 +1,54 @@
+// /releases index page の SWR blob cache (Refs #325)。
+//
+// index page は監視 repo (~30) × (repo meta + tags + compare + per-issue
+// fetch + PR follow-up) を fan-out するため、同期生成は実測で平均 16s /
+// p90 35s かかっていた。生成済みの RepoView[] を 1 blob として持ち、SSR は
+// blob を即 render する。refresh は #320 の queue consumer (15 分上限) で
+// 実行する — waitUntil の 30s 上限では fan-out が切られ得るため。
+//
+// このモジュールは KV の read/write/stale 化だけを持つ (views の中身は
+// 関知しない generic)。compute は releases-page.ts 側 — webhook.ts が
+// stale 化のためにここだけ import しても page 描画コードを引き込まない。
+
+export interface ReleasesIndexBlob<T = unknown> {
+  storedAt: number;
+  views: T;
+}
+
+export const RELEASES_INDEX_KEY = "releases:index:v1";
+export const RELEASES_INDEX_FRESH_SECONDS = 60;
+const RELEASES_INDEX_STORE_SECONDS = 86400;
+
+// refresh の重複排除 lock。fan-out は 35s かかり得るので余裕を持って 120s。
+export const RELEASES_INDEX_REFRESH_LOCK = "releases:index:refreshing";
+export const RELEASES_INDEX_REFRESH_LOCK_TTL = 120;
+
+export async function readReleasesIndexBlob<T>(
+  kv: KVNamespace,
+): Promise<ReleasesIndexBlob<T> | null> {
+  return await kv.get(RELEASES_INDEX_KEY, "json") as ReleasesIndexBlob<T> | null;
+}
+
+export async function writeReleasesIndexBlob(
+  kv: KVNamespace,
+  views: unknown,
+): Promise<void> {
+  await kv.put(
+    RELEASES_INDEX_KEY,
+    JSON.stringify({ storedAt: Date.now(), views }),
+    { expirationTtl: RELEASES_INDEX_STORE_SECONDS },
+  );
+}
+
+/** blob を stale 化する (storedAt:0 へ書き換え)。delete にしないのは、close /
+ *  merge の度に index が cold start (同期 16s 生成) へ戻るのを避けるため —
+ *  古い表示を即出しして背景 refresh で追い付く。blob 不在は no-op。 */
+export async function markReleasesIndexStale(kv: KVNamespace): Promise<void> {
+  const blob = await kv.get(RELEASES_INDEX_KEY, "json") as ReleasesIndexBlob | null;
+  if (!blob) return;
+  await kv.put(
+    RELEASES_INDEX_KEY,
+    JSON.stringify({ ...blob, storedAt: 0 }),
+    { expirationTtl: RELEASES_INDEX_STORE_SECONDS },
+  );
+}

--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -25,6 +25,13 @@ import {
 } from "./release-cache";
 import { loadDirectPushAllowlist } from "./direct-push-allowlist";
 import { parseTaglessRepos } from "./tagless-repos";
+import {
+  readReleasesIndexBlob,
+  writeReleasesIndexBlob,
+  RELEASES_INDEX_FRESH_SECONDS,
+  RELEASES_INDEX_REFRESH_LOCK,
+  RELEASES_INDEX_REFRESH_LOCK_TTL,
+} from "./releases-index-cache";
 import { renderTabs, TAB_STYLES } from "./nav-tabs";
 import { PWA_HEAD_TAGS, PWA_REGISTER_SCRIPT } from "./pwa";
 
@@ -44,12 +51,8 @@ import { PWA_HEAD_TAGS, PWA_REGISTER_SCRIPT } from "./pwa";
 
 export async function handleReleasesPage(
   req: Request,
-  env: {
-    INTERNAL_SHARED_SECRET: SecretsStoreSecret;
-    CI_HUB: DurableObjectNamespace;
-    CI_STATUS: KVNamespace;
-    TAGLESS_REPOS?: string;
-  },
+  env: ReleasesIndexEnv,
+  ctx?: ExecutionContext,
 ): Promise<Response> {
   const url = new URL(req.url);
   const repoParam = url.searchParams.get("repo");
@@ -90,7 +93,7 @@ export async function handleReleasesPage(
 
   // Index page; `repoParam` (when set without tag, e.g. from the batch-close
   // redirect) tags along so flash links can point at the right GitHub repo.
-  return await handleIndexPage(env, closedFlash, failedFlash, failedReasons, repoParam, hasFlash);
+  return await handleIndexPage(env, closedFlash, failedFlash, failedReasons, repoParam, hasFlash, ctx);
 }
 
 // Cache-Control policy:
@@ -136,19 +139,110 @@ interface TagBlock {
 // Older tags collapse to a link strip pointing at the detail page.
 const TOP_TAGS_INLINE = 5;
 
+// /releases index 用の env 形 (Refs #325 で WEBHOOK_QUEUE を追加 —
+// 背景 refresh を queue consumer に流すための optional binding)。
+interface ReleasesIndexEnv {
+  INTERNAL_SHARED_SECRET: SecretsStoreSecret;
+  CI_HUB: DurableObjectNamespace;
+  CI_STATUS: KVNamespace;
+  TAGLESS_REPOS?: string;
+  WEBHOOK_QUEUE?: Queue<{ kind: "releases-index-refresh" }>;
+}
+
 async function handleIndexPage(
-  env: {
-    INTERNAL_SHARED_SECRET: SecretsStoreSecret;
-    CI_HUB: DurableObjectNamespace;
-    CI_STATUS: KVNamespace;
-    TAGLESS_REPOS?: string;
-  },
+  env: ReleasesIndexEnv,
   closedFlash: number[],
   failedFlash: number[],
   failedReasons: Map<number, string>,
   flashRepo: string | null,
   hasFlash: boolean,
+  ctx?: ExecutionContext,
 ): Promise<Response> {
+  // SWR (Refs #325): 生成済み views の blob を即 render する。index の同期
+  // 生成は監視 repo (~30) の GitHub fan-out で実測 平均 16s / p90 35s かかる
+  // ため、stale は背景 refresh (queue consumer 経由 — waitUntil の 30s 上限
+  // では fan-out が切られ得る)、cold start (blob 無し = deploy 直後のみ) だけ
+  // 従来どおり同期生成する。
+  const kv = env.CI_STATUS;
+  const blob = await readReleasesIndexBlob<RepoView[]>(kv);
+  let views: RepoView[];
+  let refreshing = false;
+  if (blob) {
+    views = blob.views;
+    const fresh = Date.now() - blob.storedAt < RELEASES_INDEX_FRESH_SECONDS * 1000;
+    if (!fresh) {
+      refreshing = true;
+      await kickReleasesIndexRefresh(env, ctx);
+    }
+  } else {
+    views = await computeIndexViews(env);
+    await writeReleasesIndexBlob(kv, views);
+  }
+
+  // Flash 整合 (Refs #325): close 直後の redirect は blob がまだ古い可能性が
+  // あるので、closed= の issue を view 上 closed 扱いに変換して表示を一致させる
+  // (renderTagBlock の visible filter が拾って closed-details 側に落ちる)。
+  if (flashRepo && closedFlash.length > 0) {
+    for (const v of views) {
+      if (v.repo !== flashRepo) continue;
+      for (const b of v.tagBlocks) {
+        for (const r of b.issues) {
+          if (closedFlash.includes(r.number)) r.state = "closed";
+        }
+      }
+    }
+  }
+
+  return html(
+    renderIndex(views, closedFlash, failedFlash, failedReasons, flashRepo, refreshing),
+    200,
+    cacheControlFor(hasFlash, /* detail */ false),
+  );
+}
+
+/** 背景 refresh を投げる。queue binding があれば consumer (15 分上限) へ、
+ *  無い環境 (wrangler dev / test) は waitUntil fallback。lock は
+ *  refreshReleasesIndex 側で取るので二重投函しても無駄撃ちで済む。 */
+async function kickReleasesIndexRefresh(
+  env: ReleasesIndexEnv,
+  ctx?: ExecutionContext,
+): Promise<void> {
+  if (env.WEBHOOK_QUEUE) {
+    try {
+      await env.WEBHOOK_QUEUE.send({ kind: "releases-index-refresh" });
+      return;
+    } catch (err) {
+      console.log(JSON.stringify({
+        msg: "releases-index-enqueue-failed",
+        error: err instanceof Error ? err.message : String(err),
+      }));
+    }
+  }
+  const p = refreshReleasesIndex(env).catch((err) => {
+    console.log(JSON.stringify({
+      msg: "releases-index-bg-refresh-failed",
+      error: err instanceof Error ? err.message : String(err),
+    }));
+  });
+  if (ctx) ctx.waitUntil(p);
+  else void p;
+}
+
+/** index views を取り直して blob に書く (背景実行前提、queue consumer から
+ *  も呼ばれる)。lock / fresh 再確認で重複 fan-out を排除。 */
+export async function refreshReleasesIndex(env: ReleasesIndexEnv): Promise<void> {
+  const kv = env.CI_STATUS;
+  if (await kv.get(RELEASES_INDEX_REFRESH_LOCK)) return;
+  await kv.put(RELEASES_INDEX_REFRESH_LOCK, "1", {
+    expirationTtl: RELEASES_INDEX_REFRESH_LOCK_TTL,
+  });
+  const recheck = await readReleasesIndexBlob<RepoView[]>(kv);
+  if (recheck && Date.now() - recheck.storedAt < RELEASES_INDEX_FRESH_SECONDS * 1000) return;
+  const views = await computeIndexViews(env);
+  await writeReleasesIndexBlob(kv, views);
+}
+
+async function computeIndexViews(env: ReleasesIndexEnv): Promise<RepoView[]> {
   // 1. Watched repos come from three sources:
   //   (a) Hub status cache — every repo that has ever fired a CI run.
   //   (b) Direct-push-OK allowlist — repos that never auto-merge a PR and
@@ -194,17 +288,7 @@ async function handleIndexPage(
     }
   }));
 
-  return html(
-    renderIndex(
-      views.filter((v): v is RepoView => v !== null),
-      closedFlash,
-      failedFlash,
-      failedReasons,
-      flashRepo,
-    ),
-    200,
-    cacheControlFor(hasFlash, /* detail */ false),
-  );
+  return views.filter((v): v is RepoView => v !== null);
 }
 
 async function loadRepoView(
@@ -906,6 +990,7 @@ function renderIndex(
   failedFlash: number[],
   failedReasons: Map<number, string>,
   flashRepo: string | null,
+  refreshing = false,
 ): string {
   // Show every watched repo as a card — including ones with no referenced
   // issues yet or whose refs are all closed. The operator asked for the full
@@ -921,6 +1006,11 @@ function renderIndex(
   // lands the operator on the list with confirmation of what got closed.
   const flash = renderFlash(closedFlash, failedFlash, failedReasons, flashRepo);
 
+  // SWR で stale blob を即返しした時の控えめな注記 (Refs #325)。
+  const refreshingNote = refreshing
+    ? `<div class="refreshing-note">🔄 background で集計を更新中 — 表示は直近の cache です</div>`
+    : "";
+
   return `<!DOCTYPE html>
 <html lang="en"><head>
 <meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -932,6 +1022,7 @@ function renderIndex(
   <div class="summary">Tick the issues that this release actually closed; one button per repo closes them all.</div>
 </header>
 ${flash}
+${refreshingNote}
 ${body}
 <h2 class="lookup-header">Look up another release</h2>
 ${renderLookupForm(null, null)}
@@ -1206,6 +1297,10 @@ const STYLES = `
   }
   .repo-card-compact .repo-link:hover { color: #58a6ff; }
   .repo-card-compact .closed-summary { font-size: 12px; color: #8b949e; }
+  .refreshing-note {
+    background: #1c2433; border: 1px solid #1f6feb88; color: #a5d6ff;
+    border-radius: 6px; padding: 8px 14px; font-size: 12px; margin-bottom: 12px;
+  }
   .mode-badge {
     display: inline-block; font-size: 11px; font-weight: 400;
     padding: 1px 8px; border-radius: 10px; margin-left: 8px;

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -20,6 +20,8 @@ import {
   invalidateRepoCompare,
 } from "./release-cache";
 import { applyPullRequestEvent } from "./pr-map-cache";
+import { markReleasesIndexStale } from "./releases-index-cache";
+import { refreshReleasesIndex } from "./releases-page";
 
 // Queue 経由で consumer に渡す raw event (Refs #318)。body は署名検証済みの
 // raw JSON 文字列をそのまま積む (consumer 側で event 別に parse する)。
@@ -28,6 +30,15 @@ export interface WebhookQueueMessage {
   body: string;
   delivery: string;
 }
+
+/** 同じ queue に流す内部 job (Refs #325)。/releases index の再集計は GitHub
+ *  fan-out で 35s かかり得るため、waitUntil (30s 上限) ではなく consumer
+ *  (15 分上限) で実行する。 */
+export interface ReleasesIndexRefreshMessage {
+  kind: "releases-index-refresh";
+}
+
+export type QueueMessage = WebhookQueueMessage | ReleasesIndexRefreshMessage;
 
 interface ReleaseWebhookPayload {
   action: string;
@@ -239,12 +250,27 @@ export async function handleWebhook(
 // event の相対順序を概ね保つ (GitHub の配信自体に厳密順序は無い)。失敗 message
 // は retry() で Queues の再配送に任せる (max_retries 超過で drop + log 済み)。
 export async function consumeWebhookBatch(
-  batch: MessageBatch<WebhookQueueMessage>,
+  batch: MessageBatch<QueueMessage>,
   env: Env,
 ): Promise<void> {
   const hub = env.CI_HUB.get(env.CI_HUB.idFromName("singleton"));
   for (const message of batch.messages) {
-    const { event, body, delivery } = message.body;
+    // 内部 job (Refs #325): /releases index の再集計。webhook event ではない。
+    if ("kind" in message.body && message.body.kind === "releases-index-refresh") {
+      try {
+        await refreshReleasesIndex(env);
+        message.ack();
+      } catch (err) {
+        console.log(JSON.stringify({
+          msg: "releases-index-refresh-failed",
+          attempts: message.attempts,
+          error: err instanceof Error ? err.message : String(err),
+        }));
+        message.retry();
+      }
+      continue;
+    }
+    const { event, body, delivery } = message.body as WebhookQueueMessage;
     try {
       await processWebhookEvent(event, body, env, hub);
       message.ack();
@@ -344,6 +370,9 @@ async function processWebhookEvent(
         await invalidateRepoCompare(env.CI_STATUS, owner, name);
         await invalidateRepoCommits(env.CI_STATUS, owner, name);
       }
+      // merge は Unreleased zone / synthetic block の中身を変える → /releases
+      // index blob を stale 化 (Refs #325)。
+      await markReleasesIndexStale(env.CI_STATUS);
       if (parseTaglessRepos(env.TAGLESS_REPOS).has(repo)) {
         await hub.fetch(new Request("http://hub/release-alert-detect-pr", {
           method: "POST",
@@ -374,6 +403,9 @@ async function processWebhookEvent(
     if (owner && name) {
       await invalidateReleaseCacheIssue(env.CI_STATUS, owner, name, payload.issue.number);
     }
+    // /releases index は issue の open/close で close 候補の表示が変わる。
+    // blob を stale 化して次 load で背景 refresh させる (Refs #325)。
+    await markReleasesIndexStale(env.CI_STATUS);
     // /issues page の live reload trigger (Refs #321)。KV upsert 完了後に
     // broadcast するので、reload 時の SSR read は必ず更新後の KV を見る。
     // 通知失敗は page 側の問題に留まる (次の手動 reload で追い付く) ため
@@ -443,12 +475,15 @@ async function processWebhookEvent(
       if (owner && name) {
         if (ref.startsWith("refs/tags/")) {
           await invalidateRepoTags(env.CI_STATUS, owner, name);
+          // 新 tag は index の tag blocks を変える (Refs #325)。
+          await markReleasesIndexStale(env.CI_STATUS);
         } else if (defaultBranch && ref === `refs/heads/${defaultBranch}`) {
           await invalidateRepoCommits(env.CI_STATUS, owner, name);
           // "Unreleased" ゾーンの `<tag>...<defaultBranch>` compare も flush。
           // squash merge は default branch への push として届くので、これで
           // merge 単位の即時反映になる (60s TTL を待たない)。Refs #231。
           await invalidateRepoCompare(env.CI_STATUS, owner, name);
+          await markReleasesIndexStale(env.CI_STATUS);
         }
       }
     }

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -114,6 +114,9 @@ describe("GET /releases", () => {
     vi.restoreAllMocks();
     await clearReleaseCache(env.CI_STATUS);
     await env.CI_STATUS.delete("direct-push-allowlist:v1");
+    // /releases index の SWR blob (Refs #325) もテスト間で leak しないよう flush。
+    await env.CI_STATUS.delete("releases:index:v1");
+    await env.CI_STATUS.delete("releases:index:refreshing");
   });
 
   it("renders the empty-state landing page when nothing is watched yet", async () => {
@@ -1163,5 +1166,110 @@ describe("GET /releases", () => {
     // enforced by the throw in the stub above).
     expect(html).not.toContain("direct push");
     expect(html).not.toMatch(/name="pair"/);
+  });
+});
+
+// ───── /releases index SWR blob (Refs #325) ─────
+describe("GET /releases — index SWR blob (Refs #325)", () => {
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await clearReleaseCache(env.CI_STATUS);
+    await env.CI_STATUS.delete("direct-push-allowlist:v1");
+    await env.CI_STATUS.delete("releases:index:v1");
+    await env.CI_STATUS.delete("releases:index:refreshing");
+  });
+
+  function seedIndexBlob(storedAt: number, views: unknown[]): Promise<void> {
+    return env.CI_STATUS.put(
+      "releases:index:v1",
+      JSON.stringify({ storedAt, views }),
+    );
+  }
+
+  const seededView = {
+    repo: "ippoan/ci-dashboard",
+    tagless: true,
+    olderTags: [],
+    tagBlocks: [{
+      tag: "main@abc1234",
+      prevTag: null,
+      synthetic: true,
+      issues: [{
+        number: 7, title: "blob から出た issue", state: "open",
+        labels: [], assignees: [], warnings: [],
+        url: "https://github.com/ippoan/ci-dashboard/issues/7",
+        updated_at: "2026-06-11T00:00:00Z",
+      }],
+    }],
+  };
+
+  it("fresh blob は GitHub を 1 回も叩かず即 render する", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await seedIndexBlob(Date.now(), [seededView]);
+
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request("http://localhost/releases"), testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("blob から出た issue");
+    // CSS 定義は常に含まれるので note の実 HTML でアサートする
+    expect(html).not.toContain('<div class="refreshing-note">');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("stale blob は即返し + refreshing note + 背景 refresh (waitUntil fallback)", async () => {
+    // 背景 refresh の compute は空 fixture (watched なし) で即完走させる
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response("not stubbed", { status: 500 }));
+    const oldStoredAt = Date.now() - 120_000;
+    await seedIndexBlob(oldStoredAt, [seededView]);
+
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request("http://localhost/releases"), testEnv(), ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // 旧 blob の中身を即返し + 更新中 note
+    expect(html).toContain("blob から出た issue");
+    expect(html).toContain('<div class="refreshing-note">');
+
+    // waitUntil の背景 refresh が blob を書き直す (watched 空 → views [])
+    await waitOnExecutionContext(ctx);
+    const blob = await env.CI_STATUS.get("releases:index:v1", "json") as
+      { storedAt: number; views: unknown[] };
+    expect(blob.storedAt).toBeGreaterThan(oldStoredAt);
+  });
+
+  it("flash 整合: closed= の issue は stale blob でも candidate から消える", async () => {
+    await seedIndexBlob(Date.now(), [seededView]);
+
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      new Request("http://localhost/releases?repo=ippoan%2Fci-dashboard&closed=7"),
+      testEnv(),
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // flash banner には ✅ Closed: #7
+    expect(html).toContain("✅ Closed");
+    // candidate checkbox (visible table) には出ない — closed 扱いに変換され
+    // closed-details 側へ落ちる
+    const beforeDetails = html.split('<details class="closed-details">')[0];
+    expect(beforeDetails).not.toMatch(/name="pair" value="main@abc1234:7"/);
+  });
+
+  it("cold start (blob 無し) は従来どおり同期生成して blob を書く", async () => {
+    // watched 空 → 空 index。生成後に blob が存在する。
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request("http://localhost/releases"), testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    expect(await env.CI_STATUS.get("releases:index:v1")).not.toBeNull();
   });
 });

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -1080,3 +1080,91 @@ describe("webhook queue ingest (Refs #318)", () => {
     expect(acked).toEqual(["good"]);
   });
 });
+
+// ───── /releases index blob の stale 化 + queue refresh job (Refs #325) ─────
+describe("releases index blob (Refs #325)", () => {
+  beforeEach(async () => {
+    resetHubCalls();
+    await env.CI_STATUS.delete("releases:index:v1");
+    await env.CI_STATUS.delete("releases:index:refreshing");
+  });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  async function seedBlob(): Promise<void> {
+    await env.CI_STATUS.put(
+      "releases:index:v1",
+      JSON.stringify({ storedAt: Date.now(), views: [] }),
+    );
+  }
+
+  async function blobStoredAt(): Promise<number | null> {
+    const blob = await env.CI_STATUS.get("releases:index:v1", "json") as
+      { storedAt: number } | null;
+    return blob ? blob.storedAt : null;
+  }
+
+  it("issues event で blob が stale 化される (storedAt:0)", async () => {
+    await seedBlob();
+    const body = JSON.stringify({
+      action: "opened",
+      issue: {
+        number: 5, title: "t", state: "open", user: { login: "y" },
+        labels: [], assignees: [], comments: 0,
+        created_at: "2026-06-11T00:00:00Z", updated_at: "2026-06-11T00:00:00Z",
+        html_url: "https://github.com/ippoan/foo/issues/5",
+      },
+      repository: { full_name: "ippoan/foo" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST", body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "issues" },
+      }),
+      testEnv(), ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(await blobStoredAt()).toBe(0);
+  });
+
+  it("tag push で blob が stale 化される", async () => {
+    await seedBlob();
+    const body = JSON.stringify({
+      ref: "refs/tags/v1.0.0",
+      repository: { full_name: "ippoan/foo", default_branch: "main" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST", body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "push" },
+      }),
+      testEnv(), ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(await blobStoredAt()).toBe(0);
+  });
+
+  it("queue の releases-index-refresh job で blob が再生成される", async () => {
+    // compute は watched 空 fixture (mockHub の /statuses は非 JSON → catch で
+    // 空扱い、allowlist fetch も 500 → catch) で即完走する。
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response("not stubbed", { status: 500 }));
+    const acked: string[] = [];
+    const batch = {
+      messages: [{
+        body: { kind: "releases-index-refresh" },
+        attempts: 1,
+        ack: () => acked.push("refresh"),
+        retry: () => { throw new Error("should not retry"); },
+      }],
+    } as unknown as MessageBatch<import("../src/webhook").QueueMessage>;
+
+    await consumeWebhookBatch(batch, testEnv());
+
+    expect(acked).toEqual(["refresh"]);
+    expect(await env.CI_STATUS.get("releases:index:v1")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## 背景 (Refs #325)

observability 実測 (直近 7 日, n=150): GET /releases は **平均 16.0s / p50 12.6s / p90 34.9s**。index が監視 repo (~30) × (repo meta + tags + compare + per-issue fetch + PR follow-up) を毎 load **同期 fan-out** していた (release-cache の issue TTL は 60s なのでほぼ毎回 GitHub 行き)。

## 変更 (/issues #323 と同じ SWR、ただし refresh は queue で)

```
GET /releases → blob (releases:index:v1) を KV read 1 回で即 render
  ├ stale (>60s) → 「🔄 background で集計を更新中」note + refresh job を enqueue
  │     ↓ (#320 の ci-dashboard-webhooks queue、kind: releases-index-refresh)
  │   queue consumer (15 分上限) が computeIndexViews → blob 更新
  └ cold (blob 無し = deploy 直後のみ) → 従来どおり同期生成
```

- **queue に流す理由**: 集計 fan-out は 12〜35s かかり **waitUntil の 30s 上限を超え得る**。consumer なら切られない。binding 無し環境 (dev/test) は waitUntil fallback、lock (120s) で重複 fan-out を排除
- **stale 化 trigger**: release-close{,-batch} 実行後 / webhook の push (tag・default branch)・pull_request merged・issues event。delete ではなく `storedAt:0` 化 — event の度に cold start (同期 16s) へ戻さない
- **flash 整合**: close 直後の redirect は blob が古くても、`closed=` の issue を view 上 closed 扱いに変換 → candidate から即消える (詳細表示は closed-details 側へ)

## 効果

通常の load: **16s → KV read 1 回 (数百 ms 台)**。close → redirect も即。

## 検証

```
$ npm run typecheck   # green
$ npm test            # 794 tests passed
```

- 新規: fresh blob は GitHub 0 call / stale 即返し + note + 背景 refresh / flash 整合 / cold start 同期生成 / webhook (issues・tag push) の stale 化 / queue job での blob 再生成

Refs #325

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhkgxKWTehmnLWqffude3z)_