### PR TITLE
feat(releases): 更新中表示を repo 単位に + PR merge / tag push を WS で live 反映

### DIFF
--- a/src/hub.ts
+++ b/src/hub.ts
@@ -19,7 +19,11 @@ type WsEnvelope =
   | { type: "release-alerts"; data: ReleaseAlert[] }
   // /issues page の live reload trigger (Refs #321)。webhook の issues event
   // 処理後に webhook.ts が /issues-updated 経由で broadcast する。
-  | { type: "issues-updated"; data: { repo: string; number: number; state: string } };
+  | { type: "issues-updated"; data: { repo: string; number: number; state: string } }
+  // /releases page の live reload trigger (Refs #327)。index blob の refresh
+  // 完了後に webhook.ts (queue consumer) が /releases-updated 経由で broadcast
+  // する — 「集計完了後」なので reload 直後は必ず fresh blob を読む。
+  | { type: "releases-updated"; data: { repo: string } };
 
 const ALERT_KEY_PREFIX = "release-alert:";
 const ALERT_TTL_SECONDS = 7 * 86400;
@@ -254,6 +258,13 @@ export class CIDashboardHub extends DurableObject<Env> {
     if (url.pathname === "/issues-updated") {
       const data = await request.json<{ repo: string; number: number; state: string }>();
       this.broadcastEnvelope({ type: "issues-updated", data });
+      return new Response("OK");
+    }
+
+    // /releases page の live reload trigger (Refs #327)。
+    if (url.pathname === "/releases-updated") {
+      const data = await request.json<{ repo: string }>();
+      this.broadcastEnvelope({ type: "releases-updated", data });
       return new Response("OK");
     }
 

--- a/src/release-close-batch.ts
+++ b/src/release-close-batch.ts
@@ -147,7 +147,11 @@ export async function handleReleaseCloseBatch(
     );
     // /releases index blob も stale 化 (Refs #325)。redirect 先の表示自体は
     // flash 整合 (closed= の row を closed 扱いに変換) が担保する。
-    if (closedByRepo.size > 0) await markReleasesIndexStale(env.CI_STATUS);
+    if (closedByRepo.size > 0) {
+      for (const repo of closedByRepo.keys()) {
+        await markReleasesIndexStale(env.CI_STATUS, repo);
+      }
+    }
   }
 
   // Kick Hub to recompute alert state for each repo that had a successful close.

--- a/src/release-close.ts
+++ b/src/release-close.ts
@@ -115,7 +115,7 @@ export async function handleReleaseClose(
     );
     // /releases index blob も stale 化 (Refs #325)。redirect 先の表示自体は
     // flash 整合 (closed= の row を closed 扱いに変換) が担保する。
-    if (closed.length > 0) await markReleasesIndexStale(env.CI_STATUS);
+    if (closed.length > 0) await markReleasesIndexStale(env.CI_STATUS, repoParam);
   }
 
   // Kick the Hub to recompute the banner alert state for this repo when at

--- a/src/releases-index-cache.ts
+++ b/src/releases-index-cache.ts
@@ -13,7 +13,13 @@
 export interface ReleasesIndexBlob<T = unknown> {
   storedAt: number;
   views: T;
+  /** stale 化の原因 repo (Refs #327)。/releases が「🔄 更新中」バッジを
+   *  repo card 単位で出すのに使う。refresh 完了 (blob 再生成) でリセット。 */
+  staleRepos?: string[];
 }
+
+// staleRepos の肥大防止 (CI burst で merge が連発しても note が溢れない)。
+const STALE_REPOS_CAP = 20;
 
 export const RELEASES_INDEX_KEY = "releases:index:v1";
 export const RELEASES_INDEX_FRESH_SECONDS = 60;
@@ -42,13 +48,24 @@ export async function writeReleasesIndexBlob(
 
 /** blob を stale 化する (storedAt:0 へ書き換え)。delete にしないのは、close /
  *  merge の度に index が cold start (同期 16s 生成) へ戻るのを避けるため —
- *  古い表示を即出しして背景 refresh で追い付く。blob 不在は no-op。 */
-export async function markReleasesIndexStale(kv: KVNamespace): Promise<void> {
+ *  古い表示を即出しして背景 refresh で追い付く。blob 不在は no-op。
+ *  `repo` を渡すと staleRepos に記録され、/releases が該当 card に
+ *  「🔄 更新中」バッジを出す (Refs #327)。 */
+export async function markReleasesIndexStale(
+  kv: KVNamespace,
+  repo?: string,
+): Promise<void> {
   const blob = await kv.get(RELEASES_INDEX_KEY, "json") as ReleasesIndexBlob | null;
   if (!blob) return;
+  const staleRepos = new Set(blob.staleRepos ?? []);
+  if (repo) staleRepos.add(repo);
   await kv.put(
     RELEASES_INDEX_KEY,
-    JSON.stringify({ ...blob, storedAt: 0 }),
+    JSON.stringify({
+      ...blob,
+      storedAt: 0,
+      staleRepos: [...staleRepos].slice(0, STALE_REPOS_CAP),
+    }),
     { expirationTtl: RELEASES_INDEX_STORE_SECONDS },
   );
 }

--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -167,11 +167,13 @@ async function handleIndexPage(
   const blob = await readReleasesIndexBlob<RepoView[]>(kv);
   let views: RepoView[];
   let refreshing = false;
+  let staleRepos: string[] = [];
   if (blob) {
     views = blob.views;
     const fresh = Date.now() - blob.storedAt < RELEASES_INDEX_FRESH_SECONDS * 1000;
     if (!fresh) {
       refreshing = true;
+      staleRepos = blob.staleRepos ?? [];
       await kickReleasesIndexRefresh(env, ctx);
     }
   } else {
@@ -194,7 +196,7 @@ async function handleIndexPage(
   }
 
   return html(
-    renderIndex(views, closedFlash, failedFlash, failedReasons, flashRepo, refreshing),
+    renderIndex(views, closedFlash, failedFlash, failedReasons, flashRepo, refreshing, staleRepos),
     200,
     cacheControlFor(hasFlash, /* detail */ false),
   );
@@ -230,16 +232,19 @@ async function kickReleasesIndexRefresh(
 
 /** index views を取り直して blob に書く (背景実行前提、queue consumer から
  *  も呼ばれる)。lock / fresh 再確認で重複 fan-out を排除。 */
-export async function refreshReleasesIndex(env: ReleasesIndexEnv): Promise<void> {
+/** @returns true = 集計が実際に走って blob を書いた / false = lock or fresh
+ *  recheck で bail した no-op (この時は WS reload を発火しない、Refs #327)。 */
+export async function refreshReleasesIndex(env: ReleasesIndexEnv): Promise<boolean> {
   const kv = env.CI_STATUS;
-  if (await kv.get(RELEASES_INDEX_REFRESH_LOCK)) return;
+  if (await kv.get(RELEASES_INDEX_REFRESH_LOCK)) return false;
   await kv.put(RELEASES_INDEX_REFRESH_LOCK, "1", {
     expirationTtl: RELEASES_INDEX_REFRESH_LOCK_TTL,
   });
   const recheck = await readReleasesIndexBlob<RepoView[]>(kv);
-  if (recheck && Date.now() - recheck.storedAt < RELEASES_INDEX_FRESH_SECONDS * 1000) return;
+  if (recheck && Date.now() - recheck.storedAt < RELEASES_INDEX_FRESH_SECONDS * 1000) return false;
   const views = await computeIndexViews(env);
   await writeReleasesIndexBlob(kv, views);
+  return true;
 }
 
 async function computeIndexViews(env: ReleasesIndexEnv): Promise<RepoView[]> {
@@ -991,6 +996,7 @@ function renderIndex(
   failedReasons: Map<number, string>,
   flashRepo: string | null,
   refreshing = false,
+  staleRepos: string[] = [],
 ): string {
   // Show every watched repo as a card — including ones with no referenced
   // issues yet or whose refs are all closed. The operator asked for the full
@@ -998,17 +1004,22 @@ function renderIndex(
   // with a "no referenced issues" note (see renderIndexRepo) instead of being
   // dropped as noise. The bottom empty-state copy only kicks in when nothing
   // is watched at all (views is empty), so a fresh env still reads cleanly.
+  const staleSet = new Set(staleRepos);
   const body = views.length === 0
     ? `<div class="empty">🤷 No releases with referenced issues in the recent window. Look one up below.</div>`
-    : views.map(renderIndexRepo).join("\n");
+    : views.map((v) => renderIndexRepo(v, staleSet.has(v.repo))).join("\n");
 
   // Banner sits above the cards so a successful batch close redirect always
   // lands the operator on the list with confirmation of what got closed.
   const flash = renderFlash(closedFlash, failedFlash, failedReasons, flashRepo);
 
-  // SWR で stale blob を即返しした時の控えめな注記 (Refs #325)。
+  // SWR で stale blob を即返しした時の注記 (Refs #325 / #327)。stale 化の
+  // 原因 repo が分かる時はそれを列挙し、該当 card には 🔄 バッジが付く。
+  // 更新完了は WS (releases-updated) が reload で反映する。
   const refreshingNote = refreshing
-    ? `<div class="refreshing-note">🔄 background で集計を更新中 — 表示は直近の cache です</div>`
+    ? (staleRepos.length > 0
+      ? `<div class="refreshing-note">🔄 更新待ち: ${staleRepos.map((r) => `<code>${escapeHtml(r)}</code>`).join(" ")} — background で集計中、完了すると自動で再読込されます</div>`
+      : `<div class="refreshing-note">🔄 background で集計を更新中 — 表示は直近の cache です (完了すると自動で再読込)</div>`)
     : "";
 
   return `<!DOCTYPE html>
@@ -1027,8 +1038,54 @@ ${body}
 <h2 class="lookup-header">Look up another release</h2>
 ${renderLookupForm(null, null)}
 ${PWA_REGISTER_SCRIPT}
+${RELEASES_LIVE_RELOAD_SCRIPT}
 </body></html>`;
 }
+
+// /releases の live 更新 (Refs #327)。index blob の refresh 完了時に Hub が
+// broadcast する releases-updated を受けて debounce reload する。「集計完了後」
+// の通知なので reload 直後は必ず fresh blob を読む。issues-updated でも
+// close 候補の状態が変わるので併せて reload する。非表示タブは保留。
+const RELEASES_LIVE_RELOAD_SCRIPT = `
+  <script>
+    (() => {
+      let pending = false;
+      let timer = null;
+      const doReload = () => {
+        if (document.visibilityState !== "visible") { pending = true; return; }
+        location.reload();
+      };
+      document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState === "visible" && pending) { pending = false; doReload(); }
+      });
+      const connect = () => {
+        const proto = location.protocol === "https:" ? "wss:" : "ws:";
+        const ws = new WebSocket(proto + "//" + location.host + "/ws");
+        let ping = null;
+        ws.onopen = () => {
+          ping = setInterval(() => {
+            if (ws.readyState === WebSocket.OPEN) ws.send("ping");
+          }, 30000);
+        };
+        ws.onmessage = (e) => {
+          if (e.data === "pong") return;
+          try {
+            const msg = JSON.parse(e.data);
+            if (msg && (msg.type === "releases-updated" || msg.type === "issues-updated")) {
+              if (timer) clearTimeout(timer);
+              timer = setTimeout(doReload, 1500);
+            }
+          } catch { /* ignore */ }
+        };
+        ws.onclose = () => {
+          if (ping) clearInterval(ping);
+          setTimeout(connect, 3000);
+        };
+        ws.onerror = () => { ws.close(); };
+      };
+      connect();
+    })();
+  </script>`;
 
 // repo の release 運用 badge (Refs #312)。close するのに tag を打つ必要が
 // あるか (要 tag) / merge がそのまま release か (tagless) を card 見出しで
@@ -1040,7 +1097,12 @@ function renderModeBadge(tagless: boolean): string {
     : `<span class="mode-badge mode-needs-tag" title="tag-release 運用 — close 候補を出すには release tag を打つ (/tag-release)">🏷️ 要 tag</span>`;
 }
 
-function renderIndexRepo(view: RepoView): string {
+function renderIndexRepo(view: RepoView, updating = false): string {
+  // stale 化の原因 repo に出す「更新中」バッジ (Refs #327)。refresh 完了で
+  // blob が再生成され staleRepos が消える → WS reload 後は出ない。
+  const updatingBadge = updating
+    ? `<span class="updating-badge">🔄 更新中</span>`
+    : "";
   // Only tag blocks with at least one OPEN (actionable) issue get the full
   // table+form treatment. Closed-only blocks are pure noise on the landing
   // page — the operator already released them. Refs #226.
@@ -1063,7 +1125,7 @@ function renderIndexRepo(view: RepoView): string {
       : `<span class="no-refs">No referenced issues in the recent release window.</span>`;
     return `<section class="repo-card repo-card-compact">
       <a class="repo-link" href="https://github.com/${escapeHtml(view.repo)}/releases" target="_blank" rel="noopener">${escapeHtml(view.repo)}</a>
-      ${renderModeBadge(view.tagless)}
+      ${renderModeBadge(view.tagless)}${updatingBadge}
       ${summary}
     </section>`;
   }
@@ -1091,7 +1153,7 @@ function renderIndexRepo(view: RepoView): string {
   // close them in one shot; the POST handler groups by tag for comment
   // attribution.
   return `<section class="repo-card">
-    <h2><a href="https://github.com/${escapeHtml(view.repo)}/releases" target="_blank" rel="noopener">${escapeHtml(view.repo)}</a>${renderModeBadge(view.tagless)}</h2>
+    <h2><a href="https://github.com/${escapeHtml(view.repo)}/releases" target="_blank" rel="noopener">${escapeHtml(view.repo)}</a>${renderModeBadge(view.tagless)}${updatingBadge}</h2>
     <form method="POST" action="/api/release-close-batch" class="batch-close-form">
       <input type="hidden" name="repo" value="${escapeHtml(view.repo)}">
       ${tagSections}
@@ -1297,6 +1359,12 @@ const STYLES = `
   }
   .repo-card-compact .repo-link:hover { color: #58a6ff; }
   .repo-card-compact .closed-summary { font-size: 12px; color: #8b949e; }
+  .updating-badge {
+    display: inline-block; font-size: 11px; font-weight: 400;
+    padding: 1px 8px; border-radius: 10px; margin-left: 8px;
+    vertical-align: middle; white-space: nowrap;
+    background: #1f6feb22; color: #79c0ff; border: 1px solid #1f6feb88;
+  }
   .refreshing-note {
     background: #1c2433; border: 1px solid #1f6feb88; color: #a5d6ff;
     border-radius: 6px; padding: 8px 14px; font-size: 12px; margin-bottom: 12px;

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -40,6 +40,20 @@ export interface ReleasesIndexRefreshMessage {
 
 export type QueueMessage = WebhookQueueMessage | ReleasesIndexRefreshMessage;
 
+/** /releases index の stale 化 + refresh job の即時投函 (Refs #327)。
+ *  page view を待たずに consumer が再集計を始めるので、WS reload が届く頃には
+ *  fresh blob が出来ている。queue binding 無し環境では stale 化のみ (次の
+ *  page view の waitUntil fallback が拾う)。enqueue の重複は refresh 側の
+ *  lock / fresh recheck が無駄撃ちに落とす。 */
+async function staleAndKickReleasesIndex(env: Env, repo: string): Promise<void> {
+  await markReleasesIndexStale(env.CI_STATUS, repo);
+  if (env.WEBHOOK_QUEUE) {
+    try {
+      await env.WEBHOOK_QUEUE.send({ kind: "releases-index-refresh" });
+    } catch { /* enqueue 失敗は次の page view の fallback に任せる */ }
+  }
+}
+
 interface ReleaseWebhookPayload {
   action: string;
   release: {
@@ -258,7 +272,15 @@ export async function consumeWebhookBatch(
     // 内部 job (Refs #325): /releases index の再集計。webhook event ではない。
     if ("kind" in message.body && message.body.kind === "releases-index-refresh") {
       try {
-        await refreshReleasesIndex(env);
+        const refreshed = await refreshReleasesIndex(env);
+        // 集計が実際に走った時だけ /releases の WS reload を発火する (Refs #327)。
+        // lock / fresh recheck で bail した no-op では reload させない。
+        if (refreshed) {
+          await hub.fetch(new Request("http://hub/releases-updated", {
+            method: "POST",
+            body: JSON.stringify({ repo: "*" }),
+          }));
+        }
         message.ack();
       } catch (err) {
         console.log(JSON.stringify({
@@ -371,8 +393,20 @@ async function processWebhookEvent(
         await invalidateRepoCommits(env.CI_STATUS, owner, name);
       }
       // merge は Unreleased zone / synthetic block の中身を変える → /releases
-      // index blob を stale 化 (Refs #325)。
-      await markReleasesIndexStale(env.CI_STATUS);
+      // index の stale 化 + refresh job 投函 (Refs #325 / #327)。
+      await staleAndKickReleasesIndex(env, repo);
+      // /issues の merged 紫チップも変わる (pr-map は applyPullRequestEvent で
+      // patch 済み) → live reload を発火 (Refs #327)。
+      try {
+        await hub.fetch(new Request("http://hub/issues-updated", {
+          method: "POST",
+          body: JSON.stringify({
+            repo,
+            number: payload.pull_request.number,
+            state: "merged",
+          }),
+        }));
+      } catch { /* fail-open */ }
       if (parseTaglessRepos(env.TAGLESS_REPOS).has(repo)) {
         await hub.fetch(new Request("http://hub/release-alert-detect-pr", {
           method: "POST",
@@ -404,8 +438,8 @@ async function processWebhookEvent(
       await invalidateReleaseCacheIssue(env.CI_STATUS, owner, name, payload.issue.number);
     }
     // /releases index は issue の open/close で close 候補の表示が変わる。
-    // blob を stale 化して次 load で背景 refresh させる (Refs #325)。
-    await markReleasesIndexStale(env.CI_STATUS);
+    // stale 化 + refresh job 投函 (Refs #325 / #327)。
+    await staleAndKickReleasesIndex(env, payload.repository.full_name);
     // /issues page の live reload trigger (Refs #321)。KV upsert 完了後に
     // broadcast するので、reload 時の SSR read は必ず更新後の KV を見る。
     // 通知失敗は page 側の問題に留まる (次の手動 reload で追い付く) ため
@@ -475,15 +509,15 @@ async function processWebhookEvent(
       if (owner && name) {
         if (ref.startsWith("refs/tags/")) {
           await invalidateRepoTags(env.CI_STATUS, owner, name);
-          // 新 tag は index の tag blocks を変える (Refs #325)。
-          await markReleasesIndexStale(env.CI_STATUS);
+          // 新 tag は index の tag blocks を変える (Refs #325 / #327)。
+          await staleAndKickReleasesIndex(env, fullName);
         } else if (defaultBranch && ref === `refs/heads/${defaultBranch}`) {
           await invalidateRepoCommits(env.CI_STATUS, owner, name);
           // "Unreleased" ゾーンの `<tag>...<defaultBranch>` compare も flush。
           // squash merge は default branch への push として届くので、これで
           // merge 単位の即時反映になる (60s TTL を待たない)。Refs #231。
           await invalidateRepoCompare(env.CI_STATUS, owner, name);
-          await markReleasesIndexStale(env.CI_STATUS);
+          await staleAndKickReleasesIndex(env, fullName);
         }
       }
     }

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -1273,3 +1273,64 @@ describe("GET /releases — index SWR blob (Refs #325)", () => {
     expect(await env.CI_STATUS.get("releases:index:v1")).not.toBeNull();
   });
 });
+
+// ───── repo 単位の更新中表示 + WS live reload (Refs #327) ─────
+describe("GET /releases — 更新中バッジ + live reload (Refs #327)", () => {
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await clearReleaseCache(env.CI_STATUS);
+    await env.CI_STATUS.delete("direct-push-allowlist:v1");
+    await env.CI_STATUS.delete("releases:index:v1");
+    await env.CI_STATUS.delete("releases:index:refreshing");
+  });
+
+  const view = (repo: string) => ({
+    repo, tagless: true, olderTags: [],
+    tagBlocks: [{
+      tag: "main@abc1234", prevTag: null, synthetic: true,
+      issues: [{
+        number: 1, title: "t", state: "open",
+        labels: [], assignees: [], warnings: [],
+        url: `https://github.com/${repo}/issues/1`,
+        updated_at: "2026-06-11T00:00:00Z",
+      }],
+    }],
+  });
+
+  it("staleRepos の repo card に 🔄 更新中バッジ + note に repo 列挙", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response("not stubbed", { status: 500 }));
+    await env.CI_STATUS.put("releases:index:v1", JSON.stringify({
+      storedAt: 0,
+      views: [view("ippoan/foo"), view("ippoan/bar")],
+      staleRepos: ["ippoan/foo"],
+    }));
+
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request("http://localhost/releases"), testEnv(), ctx);
+    const html = await res.text();
+    await waitOnExecutionContext(ctx);
+
+    // note に原因 repo が列挙される
+    expect(html).toContain("更新待ち");
+    expect(html).toContain("<code>ippoan/foo</code>");
+    // 該当 card のみバッジ
+    const fooCard = html.split("ippoan/bar")[0];
+    expect(fooCard).toContain("🔄 更新中");
+    const barCard = html.split("ippoan/bar")[1];
+    expect(barCard).not.toContain("🔄 更新中");
+  });
+
+  it("live reload script (releases-updated listener) を埋め込む", async () => {
+    await env.CI_STATUS.put("releases:index:v1", JSON.stringify({
+      storedAt: Date.now(), views: [],
+    }));
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request("http://localhost/releases"), testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+    const html = await res.text();
+    expect(html).toContain("releases-updated");
+    expect(html).toContain('new WebSocket(proto + "//" + location.host + "/ws")');
+    expect(html).toContain("location.reload()");
+  });
+});

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -1103,6 +1103,60 @@ describe("releases index blob (Refs #325)", () => {
     return blob ? blob.storedAt : null;
   }
 
+  it("PR merged で issues-updated broadcast + staleRepos に repo が積まれる (Refs #327)", async () => {
+    await seedBlob();
+    const body = JSON.stringify({
+      action: "closed",
+      pull_request: {
+        number: 9, merged: true, merge_commit_sha: "abc",
+        base: { ref: "main" }, title: "feat", body: "Refs #1",
+        draft: false, html_url: "https://github.com/ippoan/foo/pull/9",
+        updated_at: "2026-06-11T00:00:00Z",
+      },
+      repository: { full_name: "ippoan/foo", default_branch: "main" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST", body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "pull_request" },
+      }),
+      testEnv(), ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    const blob = await env.CI_STATUS.get("releases:index:v1", "json") as
+      { storedAt: number; staleRepos?: string[] };
+    expect(blob.storedAt).toBe(0);
+    expect(blob.staleRepos).toContain("ippoan/foo");
+    // merged 紫チップ反映用の /issues live reload も発火する
+    const updates = hubCalls.filter((c) => c.path === "/issues-updated");
+    expect(updates).toHaveLength(1);
+    expect(updates[0].body).toEqual({ repo: "ippoan/foo", number: 9, state: "merged" });
+  });
+
+  it("refresh job 完了で releases-updated が broadcast される (Refs #327)", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response("not stubbed", { status: 500 }));
+    const acked: string[] = [];
+    const batch = {
+      messages: [{
+        body: { kind: "releases-index-refresh" },
+        attempts: 1,
+        ack: () => acked.push("refresh"),
+        retry: () => { throw new Error("should not retry"); },
+      }],
+    } as unknown as MessageBatch<import("../src/webhook").QueueMessage>;
+
+    await consumeWebhookBatch(batch, testEnv());
+
+    expect(acked).toEqual(["refresh"]);
+    const updates = hubCalls.filter((c) => c.path === "/releases-updated");
+    expect(updates).toHaveLength(1);
+    expect(updates[0].body).toEqual({ repo: "*" });
+  });
+
   it("issues event で blob が stale 化される (storedAt:0)", async () => {
     await seedBlob();
     const body = JSON.stringify({


### PR DESCRIPTION
## 概要 (Refs #327 — operator 要望 2 件)

### 1. 「どの repo を更新中か」を repo 単位で表示

#326 の全体 note「🔄 background で集計を更新中」を改善:

- stale 化の時点で原因 repo が分かる (close した repo / merge が来た repo / tag を push した repo) ので、blob の `staleRepos[]` に記録
- /releases では**該当 repo の card header に「🔄 更新中」バッジ**、top note は「🔄 更新待ち: `ippoan/foo` `ohishi-exp/bar` — background で集計中、完了すると自動で再読込されます」
- refresh 完了 (blob 再生成) でリセット

### 2. PR merge / tag push の WebSocket live 反映

```
PR merged / tag push / default-branch push / issues webhook (queue consumer)
  → markStale(repo) + refresh job を即 enqueue (page view を待たない)
  → consumer: 集計完了 → Hub /releases-updated → {type:"releases-updated"} broadcast
  → /releases page (WS client 新設) が 1.5s debounce で reload → fresh blob を即 render
PR merged → 併せて Hub /issues-updated も発火
  → /issues の merged 紫チップが既存 listener (#322) で即反映
```

- **「集計完了後」に broadcast** するのが肝 — reload した瞬間に必ず新しい表示 (refreshing note が出ない)
- 集計が実際に走った時だけ broadcast (lock / fresh recheck の no-op では reload させない)
- enqueue の重複は refresh 側の lock + fresh recheck が無駄撃ちに落とす
- dashboard JS は未知 envelope type を無視する設計のため既存画面に影響なし

## 検証

```
$ npm run typecheck   # green
$ npm test            # 798 tests passed
```

- 新規: staleRepos の card バッジ + note 列挙 / /releases の WS script 埋め込み / PR merged で issues-updated broadcast + staleRepos 記録 / refresh job 完了で releases-updated broadcast

Refs #327

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhkgxKWTehmnLWqffude3z)_