### PR TITLE
fix(cache): rate-limit backoff ガード + webhook patch の index-lag 巻き戻し防止

### DIFF
--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -314,8 +314,11 @@ function renderHtml(
     : "";
   // Rate-limit cooldown 中: 生の GitHub エラーは出さず、cache 表示 + 再開
   // 予定だけを穏当に伝える (Refs #304)。
+  // 文言注意 (Refs #329): cooldown で止まるのは「検索ベースの安全網 reconcile」
+  // だけ。webhook → KV → WS reload の経路は GitHub API を呼ばないため、issue の
+  // 作成/close は cooldown 中も反映され続ける — そう読める文言にする。
   const backoffBanner = freshness.backoffUntil
-    ? `<div class="banner banner-info">⏳ GitHub rate-limit cooldown — serving cached data; auto-refresh resumes by ${new Date(freshness.backoffUntil).toISOString().slice(11, 16)} UTC</div>`
+    ? `<div class="banner banner-info">⏳ GitHub rate-limit cooldown — webhook による更新は継続中です (検索ベースの安全網 reconcile のみ ${new Date(freshness.backoffUntil).toISOString().slice(11, 16)} UTC 頃まで休止)</div>`
     : "";
   // Cold start で同期 reconcile が fail したが cache はあった時のみ生エラー。
   const issueStaleBanner = freshness.coldError
@@ -650,8 +653,10 @@ const DECORATIONS_POLL_SCRIPT = `
           const r = await fetch("/issues/decorations");
           if (r.ok) {
             const d = await r.json();
+            // 揃っている分だけ先に注入する (Refs #330 — project map が rate
+            // limit で組めない間も PR チップは出す)。apply は idempotent。
+            apply(d);
             if (d.ready) {
-              apply(d);
               const banner = document.getElementById("deco-loading");
               if (banner) banner.remove();
               return;

--- a/src/pr-map-cache.ts
+++ b/src/pr-map-cache.ts
@@ -40,6 +40,25 @@ interface PrMapCacheEntry {
   storedAt: number;
   patchedAt?: number;
   data: Record<string, IssuePrRef[]>;
+  /** webhook patch の直近履歴 (Refs #330)。full refresh は GitHub Search
+   *  ベースで、merge 直後の PR は index 未反映のことがある — 取り直した結果で
+   *  blob を上書きすると patch したばかりのチップが巻き戻る。refreshPrMap は
+   *  fresh 結果を組んだ後にこの履歴 (10 分窓) を再適用する。 */
+  recentPatches?: Array<{ key: string; ref: IssuePrRef; at: number }>;
+}
+
+// recentPatches の保持窓と上限。窓は GitHub Search index lag の実測上限
+// (#311 と同じ 10 分)、上限は CI burst でも entry が肥大しない保険。
+const RECENT_PATCH_WINDOW_MS = 10 * 60 * 1000;
+const RECENT_PATCH_CAP = 50;
+
+function pruneRecentPatches(
+  patches: Array<{ key: string; ref: IssuePrRef; at: number }> | undefined,
+  now: number,
+): Array<{ key: string; ref: IssuePrRef; at: number }> {
+  return (patches ?? [])
+    .filter((p) => now - p.at < RECENT_PATCH_WINDOW_MS)
+    .slice(-RECENT_PATCH_CAP);
 }
 
 export interface PrMapResult {
@@ -126,9 +145,23 @@ export async function refreshPrMap(
   if (recheck && Date.now() - recheck.storedAt < PR_MAP_FRESH_SECONDS * 1000) return;
   try {
     const fresh = await fetchAllOpenPrsByIssue(env, mainOrgs, yhondaRepos);
+    // Search index lag ガード (Refs #330): merge/open 直後の PR は search に
+    // まだ載っていないことがある。直近 10 分の webhook patch を fresh 結果に
+    // 再適用してから書く (= lag 窓内は patch が full refresh に勝つ)。
+    const now = Date.now();
+    const recentPatches = pruneRecentPatches(recheck?.recentPatches, now);
+    for (const p of recentPatches) {
+      const list = (fresh.get(p.key) ?? []).filter(
+        (r) => !(r.repo === p.ref.repo && r.number === p.ref.number),
+      );
+      list.push(p.ref);
+      list.sort(sortPrRefs);
+      fresh.set(p.key, list);
+    }
     const entry: PrMapCacheEntry = {
-      storedAt: Date.now(),
+      storedAt: now,
       data: Object.fromEntries(fresh),
+      recentPatches,
     };
     await kv.put(PR_MAP_CACHE_KEY, JSON.stringify(entry), {
       expirationTtl: PR_MAP_STORE_SECONDS,
@@ -204,6 +237,8 @@ export async function applyPullRequestEvent(
   // ので除去のみ (実配信では title は常に載る)。
   const removeOnly =
     (payload.action === "closed" && !pr.merged) || pr.title === undefined;
+  let patchedRef: IssuePrRef | null = null;
+  const patchedKeys: string[] = [];
   if (!removeOnly) {
     const state: IssuePrRef["state"] =
       payload.action === "closed" && pr.merged ? "merged" : "open";
@@ -216,19 +251,32 @@ export async function applyPullRequestEvent(
       updated_at: pr.updated_at ?? new Date().toISOString(),
       state,
     };
+    patchedRef = ref;
     const refs = extractIssueRefs(repo, `${pr.title}\n${pr.body ?? ""}`);
     for (const key of refs) {
       const list = data[key] ?? [];
       list.push(ref);
       list.sort(sortPrRefs);
       data[key] = list;
+      patchedKeys.push(key);
+    }
+  }
+
+  // 直近 patch を記録 (Refs #330)。removeOnly (closed-unmerged) は記録しない —
+  // search lag で復活しても最大 10 分チップが残るだけで実害が小さい。
+  const now = Date.now();
+  const recentPatches = pruneRecentPatches(cached.recentPatches, now);
+  if (!removeOnly) {
+    for (const key of patchedKeys) {
+      recentPatches.push({ key, ref: patchedRef!, at: now });
     }
   }
 
   const entry: PrMapCacheEntry = {
     storedAt: cached.storedAt,
-    patchedAt: Date.now(),
+    patchedAt: now,
     data,
+    recentPatches: recentPatches.slice(-RECENT_PATCH_CAP),
   };
   await kv.put(PR_MAP_CACHE_KEY, JSON.stringify(entry), {
     expirationTtl: PR_MAP_STORE_SECONDS,

--- a/src/releases-index-cache.ts
+++ b/src/releases-index-cache.ts
@@ -22,7 +22,11 @@ export interface ReleasesIndexBlob<T = unknown> {
 const STALE_REPOS_CAP = 20;
 
 export const RELEASES_INDEX_KEY = "releases:index:v1";
-export const RELEASES_INDEX_FRESH_SECONDS = 60;
+// 鮮度は WS event 起点の refresh (#327) が担保するため、この window は
+// 「refresh の最短間隔」としてだけ機能する。60s だと CI ラッシュ時に
+// 全集計 (~30 repo × 100+ GitHub call) が時間 30 回走り quota を食い潰した
+// (2026-06-11 実害、Refs #329) ので 180s に緩和。
+export const RELEASES_INDEX_FRESH_SECONDS = 180;
 const RELEASES_INDEX_STORE_SECONDS = 86400;
 
 // refresh の重複排除 lock。fan-out は 35s かかり得るので余裕を持って 120s。

--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -25,6 +25,7 @@ import {
 } from "./release-cache";
 import { loadDirectPushAllowlist } from "./direct-push-allowlist";
 import { parseTaglessRepos } from "./tagless-repos";
+import { getRateLimitBackoff } from "./github-backoff";
 import {
   readReleasesIndexBlob,
   writeReleasesIndexBlob,
@@ -236,6 +237,11 @@ async function kickReleasesIndexRefresh(
  *  recheck で bail した no-op (この時は WS reload を発火しない、Refs #327)。 */
 export async function refreshReleasesIndex(env: ReleasesIndexEnv): Promise<boolean> {
   const kv = env.CI_STATUS;
+  // Rate-limit cooldown 中は fan-out しない (Refs #329 — reconcile / pr-map /
+  // project-map と同じガード。ここだけ漏れていて cooldown 中も ~100+ call の
+  // 集計を試み、limit を悪化させていた)。stale blob + staleRepos は維持され、
+  // cooldown 明けの次の kick で追い付く。
+  if (await getRateLimitBackoff(kv)) return false;
   if (await kv.get(RELEASES_INDEX_REFRESH_LOCK)) return false;
   await kv.put(RELEASES_INDEX_REFRESH_LOCK, "1", {
     expirationTtl: RELEASES_INDEX_REFRESH_LOCK_TTL,
@@ -243,6 +249,13 @@ export async function refreshReleasesIndex(env: ReleasesIndexEnv): Promise<boole
   const recheck = await readReleasesIndexBlob<RepoView[]>(kv);
   if (recheck && Date.now() - recheck.storedAt < RELEASES_INDEX_FRESH_SECONDS * 1000) return false;
   const views = await computeIndexViews(env);
+  // 全 repo の loadRepoView が落ちた (rate limit / 障害) 時に正常な blob を
+  // 空で上書きしない invariant (Refs #329)。空 index が正しいのは「監視 repo
+  // が本当にゼロ」の時だけで、その場合 recheck も空のはず。
+  if (views.length === 0 && recheck && (recheck.views?.length ?? 0) > 0) {
+    console.log(JSON.stringify({ msg: "releases-index-refresh-skipped-empty" }));
+    return false;
+  }
   await writeReleasesIndexBlob(kv, views);
   return true;
 }

--- a/test/pr-map-cache.test.ts
+++ b/test/pr-map-cache.test.ts
@@ -279,3 +279,61 @@ describe("applyPullRequestEvent (pull_request webhook patch)", () => {
     expect(entry!.data["ippoan/x#7"]![0]!.repo).toBe("ippoan/other");
   });
 });
+
+// ───── full refresh が直近 patch を巻き戻さない (Refs #330) ─────
+describe("recentPatches carry-over (Refs #330)", () => {
+  it("merge patch 直後の full refresh で patch が温存される (search index lag)", async () => {
+    // 1. blob seed (古い storedAt = refresh が走る状態)
+    const oldStoredAt = Date.now() - (__testing.PR_MAP_FRESH_SECONDS + 10) * 1000;
+    await seedMap({}, oldStoredAt);
+
+    // 2. merge event を patch (merged 紫チップ + recentPatches 記録)
+    await applyPullRequestEvent(env.CI_STATUS, {
+      action: "closed",
+      pull_request: {
+        number: 328, merged: true,
+        title: "feat: x", body: "Refs #327",
+        draft: false,
+        html_url: "https://github.com/ippoan/ci-dashboard/pull/328",
+        updated_at: "2026-06-11T10:52:00Z",
+      },
+      repository: { full_name: "ippoan/ci-dashboard" },
+    });
+
+    // 3. full refresh — search は index lag で空を返す
+    stubPrSearch();
+    const ctx = createExecutionContext();
+    await loadPrMap(testEnv(), ORGS, YHONDA, ctx);
+    await waitOnExecutionContext(ctx);
+
+    // 4. patch が fresh 結果に再適用されて残っている
+    const entry = await readMap();
+    const refs = entry!.data["ippoan/ci-dashboard#327"];
+    expect(refs).toBeDefined();
+    expect(refs![0].number).toBe(328);
+    expect(refs![0].state).toBe("merged");
+  });
+
+  it("10 分より古い patch は再適用されない (search 結果が正)", async () => {
+    const oldStoredAt = Date.now() - (__testing.PR_MAP_FRESH_SECONDS + 10) * 1000;
+    // recentPatches に 11 分前の patch を直接 seed
+    await env.CI_STATUS.put("issues-page:pr-map:v2", JSON.stringify({
+      storedAt: oldStoredAt,
+      data: { "ippoan/x#1": [prRef({ number: 99, state: "merged" })] },
+      recentPatches: [{
+        key: "ippoan/x#1",
+        ref: prRef({ number: 99, state: "merged" }),
+        at: Date.now() - 11 * 60 * 1000,
+      }],
+    }));
+
+    stubPrSearch();
+    const ctx = createExecutionContext();
+    await loadPrMap(testEnv(), ORGS, YHONDA, ctx);
+    await waitOnExecutionContext(ctx);
+
+    const entry = await readMap();
+    // 期限切れ patch は再適用されず、search 結果 (空) が正
+    expect(entry!.data["ippoan/x#1"]).toBeUndefined();
+  });
+});

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -1220,26 +1220,42 @@ describe("GET /releases — index SWR blob (Refs #325)", () => {
   });
 
   it("stale blob は即返し + refreshing note + 背景 refresh (waitUntil fallback)", async () => {
-    // 背景 refresh の compute は空 fixture (watched なし) で即完走させる
+    // 背景 refresh の compute は空 fixture (watched なし) で即完走させる。
+    // Refs #329: 空 views で non-empty blob を上書きしない invariant が入った
+    // ため、blob 更新の検証は空 blob を seed して行う。
     vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
       new Response("not stubbed", { status: 500 }));
-    const oldStoredAt = Date.now() - 120_000;
-    await seedIndexBlob(oldStoredAt, [seededView]);
+    const oldStoredAt = Date.now() - 300_000;
+    await seedIndexBlob(oldStoredAt, []);
 
     const ctx = createExecutionContext();
     const res = await worker.fetch(new Request("http://localhost/releases"), testEnv(), ctx);
 
     expect(res.status).toBe(200);
     const html = await res.text();
-    // 旧 blob の中身を即返し + 更新中 note
-    expect(html).toContain("blob から出た issue");
+    // stale 即返し中の note
     expect(html).toContain('<div class="refreshing-note">');
 
-    // waitUntil の背景 refresh が blob を書き直す (watched 空 → views [])
+    // waitUntil の背景 refresh が blob を書き直す (空 → 空なので invariant 非該当)
     await waitOnExecutionContext(ctx);
     const blob = await env.CI_STATUS.get("releases:index:v1", "json") as
       { storedAt: number; views: unknown[] };
     expect(blob.storedAt).toBeGreaterThan(oldStoredAt);
+  });
+
+  it("stale blob (non-empty) の即返し時も中身が render される", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response("not stubbed", { status: 500 }));
+    await seedIndexBlob(Date.now() - 300_000, [seededView]);
+
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request("http://localhost/releases"), testEnv(), ctx);
+    const html = await res.text();
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    expect(html).toContain("blob から出た issue");
+    expect(html).toContain('<div class="refreshing-note">');
   });
 
   it("flash 整合: closed= の issue は stale blob でも candidate から消える", async () => {
@@ -1332,5 +1348,48 @@ describe("GET /releases — 更新中バッジ + live reload (Refs #327)", () =>
     expect(html).toContain("releases-updated");
     expect(html).toContain('new WebSocket(proto + "//" + location.host + "/ws")');
     expect(html).toContain("location.reload()");
+  });
+});
+
+// ───── refresh の rate-limit / 空上書きガード (Refs #329) ─────
+describe("refreshReleasesIndex guards (Refs #329)", () => {
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await clearReleaseCache(env.CI_STATUS);
+    await env.CI_STATUS.delete("releases:index:v1");
+    await env.CI_STATUS.delete("releases:index:refreshing");
+    await env.CI_STATUS.delete("github:rl-backoff");
+  });
+
+  it("rate-limit backoff 中は fan-out せず blob を温存する", async () => {
+    const { setRateLimitBackoff } = await import("../src/github-backoff");
+    const { GitHubApiError } = await import("../src/github-api");
+    const { refreshReleasesIndex } = await import("../src/releases-page");
+    await setRateLimitBackoff(env.CI_STATUS, new GitHubApiError(403, "rate limit"));
+    const seeded = JSON.stringify({ storedAt: 0, views: [{ repo: "ippoan/x", tagless: true, olderTags: [], tagBlocks: [] }], staleRepos: ["ippoan/x"] });
+    await env.CI_STATUS.put("releases:index:v1", seeded);
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const refreshed = await refreshReleasesIndex(testEnv());
+
+    expect(refreshed).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    // blob は stale のまま温存 (cooldown 明けの kick で追い付く)
+    expect(await env.CI_STATUS.get("releases:index:v1")).toBe(seeded);
+  });
+
+  it("compute が全滅して views 空でも non-empty blob を上書きしない", async () => {
+    const { refreshReleasesIndex } = await import("../src/releases-page");
+    // 全 GitHub 呼び出しを fail させる → loadRepoView は全 repo null → views []
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response("boom", { status: 500 }));
+    const seeded = JSON.stringify({ storedAt: 0, views: [{ repo: "ippoan/x", tagless: true, olderTags: [], tagBlocks: [] }] });
+    await env.CI_STATUS.put("releases:index:v1", seeded);
+
+    // watched に repo を入れて compute が空に潰れる状況を作る
+    const refreshed = await refreshReleasesIndex(testEnv({ watched: ["ippoan/x"] }));
+
+    expect(refreshed).toBe(false);
+    expect(await env.CI_STATUS.get("releases:index:v1")).toBe(seeded);
   });
 });


### PR DESCRIPTION
## 概要

rate-limit cooldown 中の operator 報告 2 件への対応 (commit は 1 つ、論点は 2 つ):

### #329 — 「なぜ webhooks から更新されない?」

実際には **webhook 経路は cooldown 中も動いている** (KV 直 write + WS reload、GitHub API 不使用) が、バナー文言が全停止に見えた + 実バグもあった:

- **`refreshReleasesIndex` に backoff ガードが漏れていた** (reconcile / pr-map / project-map はガード済み)。cooldown 中も ~100+ call の index 集計を試み、limit を悪化させていた → 冒頭で bail (stale blob + staleRepos は維持、cooldown 明けの kick で追い付く)
- **空 blob 上書き防止**: 全 repo の loadRepoView が 403 で fail すると views=[] になり正常な blob を空で上書きし得た → non-empty blob は empty views で上書きしない invariant
- **fresh window 60s → 180s**: 鮮度は WS event 起点 (#327) で担保されるため、window は refresh 頻度の上限としてだけ機能。CI ラッシュ時の quota 消費を ~1/3 に (今回の rate limit の主因対策)
- **バナー文言修正**: 「⏳ cooldown — webhook による更新は継続中です (検索ベースの安全網 reconcile のみ HH:MM UTC 頃まで休止)」

### #330 — 「/issues に merged タグが出ない (/releases には出ている)」

#311 と同型の **GitHub Search index lag race が pr-map にもあった**:

1. merge event → webhook patch が merged 紫チップを KV に書く ✓
2. 直後の full refresh (4-search 取り直し) — **merge 直後の PR は search index 未反映** → 取り直した結果で blob 上書き → **patch が巻き戻る**

/releases は compare ベース (search 不使用) なので影響なし = 「こっちは出てる」と一致。

- `PrMapCacheEntry.recentPatches[]` (10 分窓 / cap 50) を追加し、`applyPullRequestEvent` が記録、`refreshPrMap` が fresh 結果に**再適用** — lag 窓内は patch が full refresh に勝つ
- `/issues/decorations` の all-or-nothing 解消: poll 毎に**揃っている分だけ注入** (project map が rate limit で組めない間も PR チップは出る)

## 検証

```
$ npm run typecheck   # green
$ npm test            # 803 tests passed
```

- 新規: backoff 中の refresh bail (blob 温存) / 空 views の上書き拒否 / merge patch が full refresh (search 空) 後も残る / 10 分超の patch は再適用されない

Refs #329 / Refs #330

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhkgxKWTehmnLWqffude3z)_