### PR TITLE
perf(cache): webhook-primary 化 — Search ベースの reconcile / full refresh を 1h の安全網に格下げ

### DIFF
--- a/src/issue-cache.ts
+++ b/src/issue-cache.ts
@@ -23,11 +23,13 @@ import {
 const KEY_WATERMARK = "issues:watermark";
 const KEY_PREFIX = "issue:";
 
-// SSR 連続リロード時の thundering herd を吸収しつつ「stale すぎる」と
-// 感じさせない値。書き込みは webhook が数秒以内に届くので 60s 内の更新
-// ラグは webhook 側でほぼ埋まる。issues-page のバナー (「裏で更新中」判定)
-// からも参照するため export (Refs #304)。
-export const FRESH_THRESHOLD_MS = 60 * 1000;
+// Reconcile (Search full snapshot) の最短間隔。webhook-primary 化 (Refs #332):
+// リアルタイム反映は webhook (queue + retry #320) + WS reload が担うため、
+// Search は「webhook 欠落の healing」専用の安全網 — 1h に 1 回で足りる。
+// 旧値 60s は WS 自動 reload (#322/#327) と組み合わさると reload のたびに
+// full snapshot が走り、rate limit の構造要因になっていた (Refs #329)。
+// issues-page のバナー (「裏で更新中」判定) からも参照するため export。
+export const FRESH_THRESHOLD_MS = 60 * 60 * 1000;
 
 // Watermark は `now - SAFETY_WINDOW_MS` でセット。full snapshot 方式では
 // delta query が無いので overlap の意味は無く、次 reconcile の fresh 判定を

--- a/src/pr-map-cache.ts
+++ b/src/pr-map-cache.ts
@@ -27,7 +27,10 @@ export const PR_MAP_CACHE_KEY = "issues-page:pr-map:v2";
 // Webhook patch (applyPullRequestEvent) が PR の open/merge を秒で反映する
 // ようになったので、full refresh は安全網に格下げして 120s → 600s に拡大
 // (= Search ×4 の頻度を 1/5 に。Refs #304 の rate limit 対策本体)。
-const PR_MAP_FRESH_SECONDS = 600;
+// Full 4-search refresh の最短間隔。webhook-primary 化 (Refs #332): chips の
+// リアルタイム反映は applyPullRequestEvent (+ recentPatches #330) が担い、
+// Search は欠落 healing 用の安全網 — 1h で足りる。
+const PR_MAP_FRESH_SECONDS = 3600;
 const PR_MAP_STORE_SECONDS = 86400;
 
 // SWR の background refresh が同一 fresh window 内で重複しないための

--- a/src/project-cache.ts
+++ b/src/project-cache.ts
@@ -266,7 +266,10 @@ interface ProjectMapBlobEntry {
   data: Record<string, ProjectRef[]>;
 }
 
-const PROJECT_MAP_FRESH_SECONDS = 600;
+// Blob 再構築の最短間隔。webhook-primary 化 (Refs #332): projects_v2* event
+// が層別 cache + blob を invalidation する (= 変化は即 stale 化される) ため、
+// 時間ベースの取り直しは安全網 — 1h で足りる。
+const PROJECT_MAP_FRESH_SECONDS = 3600;
 const PROJECT_MAP_STORE_SECONDS = 86400;
 const PROJECT_MAP_REFRESH_LOCK = "issues-page:project-map:refreshing";
 const PROJECT_MAP_REFRESH_LOCK_TTL = 60;

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -1051,9 +1051,9 @@ describe("GET /issues — SWR (Refs #304)", () => {
   it("warm + stale: 旧データを即返しして background で 6 call refresh", async () => {
     const fetchSpy = stubSearchIssues();
     await seedIssue("ippoan/rust-alc-api", 7, "old cached title");
-    const oldWm = new Date(Date.now() - 120_000).toISOString();
+    const oldWm = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
     await env.CI_STATUS.put("issues:watermark", oldWm);
-    await seedPrMap(Date.now() - 700_000);
+    await seedPrMap(Date.now() - 2 * 60 * 60 * 1000);
 
     const ctx = createExecutionContext();
     const res = await worker.fetch(new Request("http://localhost/issues"), testEnv(), ctx);
@@ -1083,8 +1083,8 @@ describe("GET /issues — SWR (Refs #304)", () => {
       return new Response("API rate limit exceeded", { status: 403 });
     });
     await seedIssue("ippoan/rust-alc-api", 7, "survives rate limit");
-    await env.CI_STATUS.put("issues:watermark", new Date(Date.now() - 120_000).toISOString());
-    await seedPrMap(Date.now() - 700_000);
+    await env.CI_STATUS.put("issues:watermark", new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString());
+    await seedPrMap(Date.now() - 2 * 60 * 60 * 1000);
 
     const ctx = createExecutionContext();
     const res = await worker.fetch(new Request("http://localhost/issues"), testEnv(), ctx);
@@ -1120,7 +1120,7 @@ describe("GET /issues — SWR (Refs #304)", () => {
   it("warm + auth error: 302 せず 200 で cache を返す (background では redirect 不可)", async () => {
     stubSearchIssues();
     await seedIssue("ippoan/rust-alc-api", 7, "warm survives auth expiry");
-    await env.CI_STATUS.put("issues:watermark", new Date(Date.now() - 120_000).toISOString());
+    await env.CI_STATUS.put("issues:watermark", new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString());
     await seedPrMap(Date.now());
     // token cache を落とす → background reconcile が auth error で fail する
     await env.CI_STATUS.delete("auth-client-worker:gh-token");


### PR DESCRIPTION
## 背景 (Refs #332 — operator 提案「search index をもっと減らして webhooks を主に」)

2026-06-11 の不具合は全部「webhook が書いた KV の真実を、Search ベースの取り直しが壊す / 浪費する」構図だった:

- #311: issues reconcile の evict が作成直後の issue を消す (index lag)
- #330: pr-map full refresh が merged チップ patch を巻き戻す (index lag)
- #329: rate limit — WS 自動 reload (#322/#327) が page load 起点の reconcile / refresh を増幅 (60s / 600s 窓が reload のたびに発火)

webhook 経路は queue + retry (#320) + 両 org hook 修理で信頼できるため、**Search は欠落 healing 専用の安全網に格下げ**する。

## 変更

| cache | 旧窓 | 新窓 |
|---|---|---|
| issues reconcile (`FRESH_THRESHOLD_MS`) | 60s | **1h** |
| pr-map full refresh (`PR_MAP_FRESH_SECONDS`) | 600s | **1h** |
| project map blob (`PROJECT_MAP_FRESH_SECONDS`) | 600s | **1h** |

- リアルタイム反映は webhook patch + WS reload が担う (issues upsert / pr-map patch + recentPatches / projects_v2 invalidation はすべて即時)
- **Search 呼び出し ~98% 減** — rate limit の構造要因を除去
- webhook 欠落時の最大遅延は 1h (#311 の evict grace / #330 の recentPatches も継続)
- 層別 GraphQL cache (org list 30min) は据え置き

## 検証

```
$ npm run typecheck   # green
$ npm test            # 803 tests passed
```

stale を期待するテストの seed を 2h 前に更新 (pr-map テストは `__testing.PR_MAP_FRESH_SECONDS` 由来なので自動追従)。

Refs #332

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhkgxKWTehmnLWqffude3z)_