### PR TITLE
fix(queue): event-first batch 処理 + GitHub 認証失効の可視化と自動回復

### DIFF
--- a/src/github-backoff.ts
+++ b/src/github-backoff.ts
@@ -54,3 +54,53 @@ export const __testing = {
   BACKOFF_KEY,
   BACKOFF_TTL_SECONDS,
 };
+
+// ───── GitHub 認証失効 marker (Refs #334) ─────
+//
+// auth-worker delegation の refresh_token が失効 (invalid_grant — 並列 refresh
+// race、ippoan/auth-worker#270) すると background refresh が全断するが、
+// background では /oauth/login へ 302 できず log にしか出ない。marker を立てて
+// /issues・/releases が「再ログインが必要」banner を出せるようにする。
+// token 取得が成功する経路 (reconcile / refresh 成功) で消す。
+
+const AUTH_BROKEN_KEY = "github:auth-broken";
+const AUTH_BROKEN_TTL_SECONDS = 6 * 60 * 60;
+
+/** auth-worker delegation 系のエラーか (= 再ログインで解決するか)。
+ *  issues-page の cold start 302 判定と同じ規約 (@ippoan/auth-client-worker
+ *  は Error.message に常に診断文字列を入れる)。 */
+export function isAuthError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return (
+    /No (DCR client registered|OAuth tokens stored)/.test(msg) ||
+    /auth-worker \/mcp\/(introspect|token).*failed \((400|401|403)/.test(msg) ||
+    /invalid_grant/.test(msg) ||
+    /JWT inactive/.test(msg)
+  );
+}
+
+export interface AuthBrokenMarker {
+  at: number;
+  message: string;
+}
+
+/** auth error を観測した background 経路から呼ぶ。non-auth エラーは no-op。 */
+export async function noteGitHubAuthBroken(kv: KVNamespace, err: unknown): Promise<void> {
+  if (!isAuthError(err)) return;
+  const marker: AuthBrokenMarker = {
+    at: Date.now(),
+    message: (err instanceof Error ? err.message : String(err)).slice(0, 200),
+  };
+  await kv.put(AUTH_BROKEN_KEY, JSON.stringify(marker), {
+    expirationTtl: AUTH_BROKEN_TTL_SECONDS,
+  });
+}
+
+export async function getGitHubAuthBroken(kv: KVNamespace): Promise<AuthBrokenMarker | null> {
+  return await kv.get(AUTH_BROKEN_KEY, "json") as AuthBrokenMarker | null;
+}
+
+/** token 取得が成功した経路 (refresh / reconcile 完走) から呼んで自動回復。 */
+export async function clearGitHubAuthBroken(kv: KVNamespace): Promise<void> {
+  await kv.delete(AUTH_BROKEN_KEY);
+}

--- a/src/issue-cache.ts
+++ b/src/issue-cache.ts
@@ -5,6 +5,7 @@ import {
   getRateLimitBackoff,
   isRateLimitError,
   setRateLimitBackoff,
+  clearGitHubAuthBroken,
 } from "./github-backoff";
 
 // KV schema:
@@ -204,6 +205,8 @@ export async function reconcileIssues(
 
   const newWm = new Date(now - SAFETY_WINDOW_MS).toISOString();
   await kv.put(KEY_WATERMARK, newWm);
+  // token 取得が成功した = 認証は生きている。失効 banner を自動回復 (Refs #334)。
+  await clearGitHubAuthBroken(kv);
 
   return { patched: fresh.length, fetched: true, removed };
 }

--- a/src/issues-page.ts
+++ b/src/issues-page.ts
@@ -12,7 +12,12 @@ import {
   type ReconcileResult,
 } from "./issue-cache";
 import { loadPrMap, type PrMapResult } from "./pr-map-cache";
-import { getRateLimitBackoff } from "./github-backoff";
+import {
+  getRateLimitBackoff,
+  isAuthError,
+  noteGitHubAuthBroken,
+  getGitHubAuthBroken,
+} from "./github-backoff";
 import {
   loadProjectIssueMapSwr,
   readProjectIssueMapBlob,
@@ -90,14 +95,8 @@ export function buildClaudeCodeLaunchUrl(repo: string, issueNumber: number): str
 // 判定して `/oauth/login` にリダイレクトする (= ユーザーは 502 ページではなく
 // GitHub 同意画面に飛ぶ)。それ以外 (GitHub rate limit など) は従来通り 502 を
 // 表示する。
-function isAuthError(err: unknown): boolean {
-  const msg = err instanceof Error ? err.message : String(err);
-  return (
-    /No (DCR client registered|OAuth tokens stored)/.test(msg) ||
-    /auth-worker \/mcp\/(introspect|token).*failed \((401|403)/.test(msg) ||
-    /JWT inactive/.test(msg)
-  );
-}
+// isAuthError は github-backoff.ts に共通化 (Refs #334 — background の auth
+// 失効 marker 判定と同一規約にするため。invalid_grant も拾う)。
 
 // KV には過去設定の repo が残っている可能性があるので allowlist で filter。
 // mainOrgs 配下は全 repo 許可、yhonda-ohishi は YHONDA_REPOS のみ。
@@ -124,6 +123,9 @@ interface Freshness {
   decoLoading: boolean;
   /** rate-limit backoff 中。値は再開予定時刻 (epoch ms)。 */
   backoffUntil: number | null;
+  /** GitHub 認証失効 (auth-worker delegation の invalid_grant 等)。再ログイン
+   *  banner を出す (Refs #334)。 */
+  authBroken: boolean;
   /** cold start で同期 reconcile が失敗した時のみ生エラーを表示する。 */
   coldError: string | null;
 }
@@ -157,7 +159,10 @@ export async function handleIssuesPage(
       .then((r) => {
         console.log(JSON.stringify({ msg: "issues-page-bg-reconcile", reconcile: r }));
       })
-      .catch((err) => {
+      .catch(async (err) => {
+        // 認証失効は background では 302 できないため marker を立てて
+        // banner で operator に知らせる (Refs #334)。
+        await noteGitHubAuthBroken(kv, err);
         console.log(JSON.stringify({
           msg: "issues-page-bg-reconcile-failed",
           isAuth: isAuthError(err),
@@ -228,11 +233,12 @@ export async function handleIssuesPage(
     items: filtered,
   };
 
-  const [project, prs, watermark, backoff] = await Promise.all([
+  const [project, prs, watermark, backoff, authBroken] = await Promise.all([
     loadProjectIssueMapSwr(env, PROJECT_ORGS, ctx),
     loadPrMap(env, ORGS, YHONDA_REPOS, ctx),
     getIssuesWatermark(kv),
     getRateLimitBackoff(kv),
+    getGitHubAuthBroken(kv),
   ]);
 
   const reconcileAgeSec = watermark
@@ -247,6 +253,7 @@ export async function handleIssuesPage(
     prRefreshing: prs.refreshing || project.refreshing,
     decoLoading: project.loading || prs.loading,
     backoffUntil: backoff?.until ?? null,
+    authBroken: authBroken !== null,
     coldError: reconcileError,
   };
   const projectMap = project.map;
@@ -314,6 +321,12 @@ function renderHtml(
     : "";
   // Rate-limit cooldown 中: 生の GitHub エラーは出さず、cache 表示 + 再開
   // 予定だけを穏当に伝える (Refs #304)。
+  // GitHub 認証失効 (Refs #334): background refresh は 302 できないので、
+  // banner で再ログインに誘導する。token 再取得が成功した経路が marker を
+  // 消すので、ログイン後は自動で消える。
+  const authBrokenBanner = freshness.authBroken
+    ? `<div class="banner">🔑 GitHub 認証が失効しています — <a href="/oauth/login?return_to=/issues" style="color:#ffa198;text-decoration:underline">/oauth/login</a> で再ログインすると自動復旧します (それまで background 更新は停止、webhook 反映は継続)</div>`
+    : "";
   // 文言注意 (Refs #329): cooldown で止まるのは「検索ベースの安全網 reconcile」
   // だけ。webhook → KV → WS reload の経路は GitHub API を呼ばないため、issue の
   // 作成/close は cooldown 中も反映され続ける — そう読める文言にする。
@@ -588,6 +601,7 @@ function renderHtml(
     </div>
   </header>
   ${incompleteBanner}
+  ${authBrokenBanner}
   ${backoffBanner}
   ${refreshingBanner}
   ${issueStaleBanner}

--- a/src/pr-map-cache.ts
+++ b/src/pr-map-cache.ts
@@ -112,7 +112,9 @@ export async function loadPrMap(
   // Cold start: 旧実装は同期 fetch (4 search) でページ全体を塞いでいた。
   // SSR をブロックせず背景 refresh + loading flag を返し、page 側が
   // /issues/decorations を poll して部分更新する (Refs #323)。
-  const p = refreshPrMap(env, mainOrgs, yhondaRepos).catch((err) => {
+  const p = refreshPrMap(env, mainOrgs, yhondaRepos).catch(async (err) => {
+    const { noteGitHubAuthBroken } = await import("./github-backoff");
+    await noteGitHubAuthBroken(kv, err);
     console.log(JSON.stringify({
       msg: "pr-map-bg-refresh-failed",
       error: err instanceof Error ? err.message : String(err),

--- a/src/project-cache.ts
+++ b/src/project-cache.ts
@@ -294,7 +294,9 @@ export async function loadProjectIssueMapSwr(
   const blob = await kv.get(ISSUES_PAGE_PROJECT_MAP_KEY, "json") as ProjectMapBlobEntry | null;
   const now = Date.now();
   const kick = () => {
-    const p = refreshProjectIssueMapBlob(env, orgs).catch((err) => {
+    const p = refreshProjectIssueMapBlob(env, orgs).catch(async (err) => {
+      const { noteGitHubAuthBroken } = await import("./github-backoff");
+      await noteGitHubAuthBroken(env.CI_STATUS, err);
       console.log(JSON.stringify({
         msg: "project-map-bg-refresh-failed",
         error: err instanceof Error ? err.message : String(err),

--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -25,7 +25,12 @@ import {
 } from "./release-cache";
 import { loadDirectPushAllowlist } from "./direct-push-allowlist";
 import { parseTaglessRepos } from "./tagless-repos";
-import { getRateLimitBackoff } from "./github-backoff";
+import {
+  getRateLimitBackoff,
+  noteGitHubAuthBroken,
+  getGitHubAuthBroken,
+  clearGitHubAuthBroken,
+} from "./github-backoff";
 import {
   readReleasesIndexBlob,
   writeReleasesIndexBlob,
@@ -165,7 +170,10 @@ async function handleIndexPage(
   // では fan-out が切られ得る)、cold start (blob 無し = deploy 直後のみ) だけ
   // 従来どおり同期生成する。
   const kv = env.CI_STATUS;
-  const blob = await readReleasesIndexBlob<RepoView[]>(kv);
+  const [blob, authBroken] = await Promise.all([
+    readReleasesIndexBlob<RepoView[]>(kv),
+    getGitHubAuthBroken(kv),
+  ]);
   let views: RepoView[];
   let refreshing = false;
   let staleRepos: string[] = [];
@@ -197,7 +205,10 @@ async function handleIndexPage(
   }
 
   return html(
-    renderIndex(views, closedFlash, failedFlash, failedReasons, flashRepo, refreshing, staleRepos),
+    renderIndex(
+      views, closedFlash, failedFlash, failedReasons, flashRepo,
+      refreshing, staleRepos, authBroken !== null,
+    ),
     200,
     cacheControlFor(hasFlash, /* detail */ false),
   );
@@ -221,7 +232,8 @@ async function kickReleasesIndexRefresh(
       }));
     }
   }
-  const p = refreshReleasesIndex(env).catch((err) => {
+  const p = refreshReleasesIndex(env).catch(async (err) => {
+    await noteGitHubAuthBroken(env.CI_STATUS, err);
     console.log(JSON.stringify({
       msg: "releases-index-bg-refresh-failed",
       error: err instanceof Error ? err.message : String(err),
@@ -257,6 +269,8 @@ export async function refreshReleasesIndex(env: ReleasesIndexEnv): Promise<boole
     return false;
   }
   await writeReleasesIndexBlob(kv, views);
+  // token 取得が成功した = 認証は生きている。失効 banner を自動回復 (Refs #334)。
+  await clearGitHubAuthBroken(kv);
   return true;
 }
 
@@ -1010,6 +1024,7 @@ function renderIndex(
   flashRepo: string | null,
   refreshing = false,
   staleRepos: string[] = [],
+  authBroken = false,
 ): string {
   // Show every watched repo as a card — including ones with no referenced
   // issues yet or whose refs are all closed. The operator asked for the full
@@ -1029,6 +1044,10 @@ function renderIndex(
   // SWR で stale blob を即返しした時の注記 (Refs #325 / #327)。stale 化の
   // 原因 repo が分かる時はそれを列挙し、該当 card には 🔄 バッジが付く。
   // 更新完了は WS (releases-updated) が reload で反映する。
+  // GitHub 認証失効 (Refs #334): 「🔄 更新中」のまま無言で詰まる事故の対策。
+  const authBrokenNote = authBroken
+    ? `<div class="auth-broken-note">🔑 GitHub 認証が失効しています — <a href="/oauth/login?return_to=/releases">/oauth/login</a> で再ログインすると自動復旧します (それまで集計の background 更新は停止)</div>`
+    : "";
   const refreshingNote = refreshing
     ? (staleRepos.length > 0
       ? `<div class="refreshing-note">🔄 更新待ち: ${staleRepos.map((r) => `<code>${escapeHtml(r)}</code>`).join(" ")} — background で集計中、完了すると自動で再読込されます</div>`
@@ -1046,6 +1065,7 @@ function renderIndex(
   <div class="summary">Tick the issues that this release actually closed; one button per repo closes them all.</div>
 </header>
 ${flash}
+${authBrokenNote}
 ${refreshingNote}
 ${body}
 <h2 class="lookup-header">Look up another release</h2>
@@ -1378,6 +1398,11 @@ const STYLES = `
     vertical-align: middle; white-space: nowrap;
     background: #1f6feb22; color: #79c0ff; border: 1px solid #1f6feb88;
   }
+  .auth-broken-note {
+    background: #341a1f; border: 1px solid #f85149; color: #ffa198;
+    border-radius: 6px; padding: 10px 14px; font-size: 13px; margin-bottom: 12px;
+  }
+  .auth-broken-note a { color: #ffa198; text-decoration: underline; }
   .refreshing-note {
     background: #1c2433; border: 1px solid #1f6feb88; color: #a5d6ff;
     border-radius: 6px; padding: 8px 14px; font-size: 12px; margin-bottom: 12px;

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -21,6 +21,7 @@ import {
 } from "./release-cache";
 import { applyPullRequestEvent } from "./pr-map-cache";
 import { markReleasesIndexStale } from "./releases-index-cache";
+import { noteGitHubAuthBroken } from "./github-backoff";
 import { refreshReleasesIndex } from "./releases-page";
 
 // Queue 経由で consumer に渡す raw event (Refs #318)。body は署名検証済みの
@@ -268,30 +269,22 @@ export async function consumeWebhookBatch(
   env: Env,
 ): Promise<void> {
   const hub = env.CI_HUB.get(env.CI_HUB.idFromName("singleton"));
+
+  // Event-first (Refs #335): 重い index 再集計 (12〜35s の GitHub fan-out) が
+  // 同 batch の webhook event (即時 KV write) を塞がないよう、event を先に
+  // 全部処理してから refresh job を最後に 1 回だけ実行する。同 batch に
+  // refresh message が複数あってもまとめて 1 回 (残りはまとめて ack)。
+  const eventMessages: Message<QueueMessage>[] = [];
+  const refreshMessages: Message<QueueMessage>[] = [];
   for (const message of batch.messages) {
-    // 内部 job (Refs #325): /releases index の再集計。webhook event ではない。
     if ("kind" in message.body && message.body.kind === "releases-index-refresh") {
-      try {
-        const refreshed = await refreshReleasesIndex(env);
-        // 集計が実際に走った時だけ /releases の WS reload を発火する (Refs #327)。
-        // lock / fresh recheck で bail した no-op では reload させない。
-        if (refreshed) {
-          await hub.fetch(new Request("http://hub/releases-updated", {
-            method: "POST",
-            body: JSON.stringify({ repo: "*" }),
-          }));
-        }
-        message.ack();
-      } catch (err) {
-        console.log(JSON.stringify({
-          msg: "releases-index-refresh-failed",
-          attempts: message.attempts,
-          error: err instanceof Error ? err.message : String(err),
-        }));
-        message.retry();
-      }
-      continue;
+      refreshMessages.push(message);
+    } else {
+      eventMessages.push(message);
     }
+  }
+
+  for (const message of eventMessages) {
     const { event, body, delivery } = message.body as WebhookQueueMessage;
     try {
       await processWebhookEvent(event, body, env, hub);
@@ -306,6 +299,29 @@ export async function consumeWebhookBatch(
       }));
       message.retry();
     }
+  }
+
+  if (refreshMessages.length === 0) return;
+  try {
+    const refreshed = await refreshReleasesIndex(env);
+    // 集計が実際に走った時だけ /releases の WS reload を発火する (Refs #327)。
+    // lock / fresh recheck で bail した no-op では reload させない。
+    if (refreshed) {
+      await hub.fetch(new Request("http://hub/releases-updated", {
+        method: "POST",
+        body: JSON.stringify({ repo: "*" }),
+      }));
+    }
+    for (const m of refreshMessages) m.ack();
+  } catch (err) {
+    // 認証失効なら marker を立てて page banner で operator に知らせる (Refs #334)。
+    await noteGitHubAuthBroken(env.CI_STATUS, err);
+    console.log(JSON.stringify({
+      msg: "releases-index-refresh-failed",
+      attempts: refreshMessages[0]?.attempts,
+      error: err instanceof Error ? err.message : String(err),
+    }));
+    for (const m of refreshMessages) m.retry();
   }
 }
 

--- a/test/issues-page.test.ts
+++ b/test/issues-page.test.ts
@@ -1226,3 +1226,36 @@ describe("GET /issues — decorations 部分更新 (Refs #323)", () => {
     expect(html).toContain('class="project-chip"');
   });
 });
+
+// ───── GitHub 認証失効 banner (Refs #334) ─────
+describe("GET /issues — auth-broken banner (Refs #334)", () => {
+  beforeEach(async () => {
+    await env.CI_STATUS.delete("github:auth-broken");
+    await env.CI_STATUS.delete("issues:watermark");
+    await env.CI_STATUS.delete("github:rl-backoff");
+    await env.CI_STATUS.delete("issues:reconciling");
+  });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("marker があれば再ログイン banner を出す", async () => {
+    stubFetch();
+    await env.CI_STATUS.put("github:auth-broken", JSON.stringify({ at: Date.now(), message: "invalid_grant" }));
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request("http://localhost/issues"), testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    const html = await res.text();
+    expect(html).toContain("GitHub 認証が失効しています");
+    expect(html).toContain("/oauth/login?return_to=/issues");
+  });
+
+  it("reconcile 成功で marker が消える (自動回復)", async () => {
+    stubFetch();
+    await env.CI_STATUS.put("github:auth-broken", JSON.stringify({ at: Date.now(), message: "invalid_grant" }));
+    const ctx = createExecutionContext();
+    await worker.fetch(new Request("http://localhost/issues"), testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+    // cold reconcile が完走 → marker クリア
+    expect(await env.CI_STATUS.get("github:auth-broken")).toBeNull();
+  });
+});

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -1393,3 +1393,26 @@ describe("refreshReleasesIndex guards (Refs #329)", () => {
     expect(await env.CI_STATUS.get("releases:index:v1")).toBe(seeded);
   });
 });
+
+// ───── GitHub 認証失効 note (Refs #334) ─────
+describe("GET /releases — auth-broken note (Refs #334)", () => {
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await clearReleaseCache(env.CI_STATUS);
+    await env.CI_STATUS.delete("releases:index:v1");
+    await env.CI_STATUS.delete("releases:index:refreshing");
+    await env.CI_STATUS.delete("github:auth-broken");
+  });
+
+  it("marker があれば再ログイン note を出す", async () => {
+    await env.CI_STATUS.put("releases:index:v1", JSON.stringify({ storedAt: Date.now(), views: [] }));
+    await env.CI_STATUS.put("github:auth-broken", JSON.stringify({ at: Date.now(), message: "invalid_grant" }));
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request("http://localhost/releases"), testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    const html = await res.text();
+    expect(html).toContain("GitHub 認証が失効しています");
+    expect(html).toContain("/oauth/login?return_to=/releases");
+  });
+});

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -1222,3 +1222,55 @@ describe("releases index blob (Refs #325)", () => {
     expect(await env.CI_STATUS.get("releases:index:v1")).not.toBeNull();
   });
 });
+
+// ───── event-first batch (Refs #335) ─────
+describe("consumeWebhookBatch — event-first (Refs #335)", () => {
+  beforeEach(async () => {
+    resetHubCalls();
+    await env.CI_STATUS.delete("releases:index:v1");
+    await env.CI_STATUS.delete("releases:index:refreshing");
+    await env.CI_STATUS.delete("issue:ippoan/foo#88");
+    await env.CI_STATUS.delete("github:rl-backoff");
+  });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("refresh job が同 batch にあっても event は処理され、重複 refresh は 1 回にまとまる", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response("not stubbed", { status: 500 }));
+    const issueBody = JSON.stringify({
+      action: "opened",
+      issue: {
+        number: 88, title: "batched", state: "open", user: { login: "y" },
+        labels: [], assignees: [], comments: 0,
+        created_at: "2026-06-11T00:00:00Z", updated_at: "2026-06-11T00:00:00Z",
+        html_url: "https://github.com/ippoan/foo/issues/88",
+      },
+      repository: { full_name: "ippoan/foo" },
+    });
+    const acked: string[] = [];
+    const make = (id: string, body: unknown) => ({
+      body, attempts: 1,
+      ack: () => acked.push(id),
+      retry: () => { throw new Error("should not retry: " + id); },
+    });
+    const batch = {
+      messages: [
+        make("r1", { kind: "releases-index-refresh" }),
+        make("ev", { event: "issues", body: issueBody, delivery: "d1" }),
+        make("r2", { kind: "releases-index-refresh" }),
+      ],
+    } as unknown as MessageBatch<import("../src/webhook").QueueMessage>;
+
+    await consumeWebhookBatch(batch, testEnv());
+
+    // event は refresh より先に処理される (ack 順で検証)
+    expect(acked[0]).toBe("ev");
+    expect(acked.sort()).toEqual(["ev", "r1", "r2"]);
+    // event の効果 (KV upsert)
+    const stored = await env.CI_STATUS.get("issue:ippoan/foo#88", "json") as { number: number } | null;
+    expect(stored?.number).toBe(88);
+    // refresh は 1 回だけ (= /releases-updated broadcast も最大 1 回)
+    const updates = hubCalls.filter((c) => c.path === "/releases-updated");
+    expect(updates.length).toBeLessThanOrEqual(1);
+  });
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -173,13 +173,15 @@
         "consumers": [
           {
             "queue": "ci-dashboard-webhooks",
-            // 順序を概ね保ちつつ burst を平滑化する設定: 直列 1 consumer、
-            // 小 batch、最大 5 回 retry (超過は drop — webhook-process-failed
-            // log に attempts 付きで残る)。
+            // 重い index 再集計 (12〜35s) を含む batch が webhook event の
+            // batch を塞がないよう並走を許可する (Refs #335)。順序の緩みは
+            // 許容 — GitHub の配信自体に順序保証は無く、handler は
+            // last-write-wins の upsert / invalidation で冪等。retry 最大 5 回
+            // (超過は drop — webhook-process-failed log に attempts 付き)。
             "max_batch_size": 10,
             "max_batch_timeout": 1,
             "max_retries": 5,
-            "max_concurrency": 1
+            "max_concurrency": 3
           }
         ]
       },


### PR DESCRIPTION
## 概要 — operator 報告 2 件への対応

### #335 「バックグランド更新が webhooks より優先されてて支障がある」

重い index 再集計 (12〜35s の GitHub fan-out) と軽い webhook event が同じ queue を直列 (max_concurrency 1) で流れており、再集計中は issue open/close などの即時反映が待たされていた:

- **event-first 化**: `consumeWebhookBatch` で webhook event を先に全部処理し、refresh job は batch の最後に **1 回だけ** (同 batch の重複 refresh message はまとめて ack)
- **max_concurrency 1 → 3**: 長い refresh を含む batch と新しい event batch が並走可能に。順序の緩みは許容 (GitHub の配信自体に順序保証は無く、handler は last-write-wins で冪等)

### #334 「🔄 更新中 がいつまでも消えない」の根本対応

実害の正体は rate limit ではなく **auth-worker delegation の refresh_token 失効** (`invalid_grant: already used` — 並列 refresh race、ippoan/auth-worker#270 起票済) で、background refresh が全断していたが log にしか出ていなかった:

- `isAuthError` を github-backoff.ts に共通化 (`invalid_grant` も判定)
- background refresh の catch (reconcile / pr-map / project map / releases index) が auth error 時に KV marker (`github:auth-broken`、TTL 6h) を設置
- **/issues・/releases に「🔑 GitHub 認証が失効しています — /oauth/login で再ログインすると自動復旧します」banner を表示** (webhook 反映は継続している旨も明記)
- token 取得が成功する経路 (reconcile / refresh 完走) が marker を削除 = **再ログイン後は banner も「🔄 更新中」も自動で消える**

## 検証

```
$ npm run typecheck   # green
$ npm test            # 807 tests passed
```

- 新規: refresh job が同 batch にあっても event が先に処理され KV に反映される / 重複 refresh は 1 回に集約 / marker → banner 表示 (/issues・/releases) / reconcile 成功で marker 自動クリア

⚠️ **今回の停止の復旧自体は operator 操作が必要です**: https://ci-dashboard.ippoan.org/oauth/login を 1 回開いて再ログインしてください (本 PR はその状態を「見える化 + 自動回復」する変更)。

Refs #334 / Refs #335

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhkgxKWTehmnLWqffude3z)_