### PR TITLE
fix(releases): 再集計 pipeline の liveness 穴を塞ぐ — lock 即解放 + self-reschedule + attempt log

### DIFF
--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -245,33 +245,62 @@ async function kickReleasesIndexRefresh(
 
 /** index views を取り直して blob に書く (背景実行前提、queue consumer から
  *  も呼ばれる)。lock / fresh 再確認で重複 fan-out を排除。 */
-/** @returns true = 集計が実際に走って blob を書いた / false = lock or fresh
- *  recheck で bail した no-op (この時は WS reload を発火しない、Refs #327)。 */
-export async function refreshReleasesIndex(env: ReleasesIndexEnv): Promise<boolean> {
+/** refresh attempt の結末 (Refs #337)。"done" = 集計して blob を書いた
+ *  (= WS reload を発火して良い)。"fresh" = blob が既に新しい (停止して良い)。
+ *  それ以外は「blob はまだ stale なのに集計できなかった」= caller (queue
+ *  consumer) が self-reschedule して liveness を保つ。 */
+export type ReleasesIndexRefreshOutcome =
+  | "done" | "fresh" | "backoff" | "lock" | "empty-skip";
+
+export async function refreshReleasesIndex(
+  env: ReleasesIndexEnv,
+): Promise<ReleasesIndexRefreshOutcome> {
+  const started = Date.now();
+  const outcome = await refreshReleasesIndexInner(env);
+  // bail 経路が無 log だと「🔄 更新中」のまま無言で停止した時に観測不能に
+  // なる (2026-06-11 実害、Refs #337)。attempt ごとに必ず 1 行出す。
+  console.log(JSON.stringify({
+    msg: "releases-index-refresh-attempt",
+    outcome,
+    ms: Date.now() - started,
+  }));
+  return outcome;
+}
+
+async function refreshReleasesIndexInner(
+  env: ReleasesIndexEnv,
+): Promise<ReleasesIndexRefreshOutcome> {
   const kv = env.CI_STATUS;
   // Rate-limit cooldown 中は fan-out しない (Refs #329 — reconcile / pr-map /
-  // project-map と同じガード。ここだけ漏れていて cooldown 中も ~100+ call の
-  // 集計を試み、limit を悪化させていた)。stale blob + staleRepos は維持され、
-  // cooldown 明けの次の kick で追い付く。
-  if (await getRateLimitBackoff(kv)) return false;
-  if (await kv.get(RELEASES_INDEX_REFRESH_LOCK)) return false;
+  // project-map と同じガード)。stale blob + staleRepos は維持され、cooldown
+  // 明けの reschedule で追い付く。
+  if (await getRateLimitBackoff(kv)) return "backoff";
+  if (await kv.get(RELEASES_INDEX_REFRESH_LOCK)) return "lock";
   await kv.put(RELEASES_INDEX_REFRESH_LOCK, "1", {
     expirationTtl: RELEASES_INDEX_REFRESH_LOCK_TTL,
   });
-  const recheck = await readReleasesIndexBlob<RepoView[]>(kv);
-  if (recheck && Date.now() - recheck.storedAt < RELEASES_INDEX_FRESH_SECONDS * 1000) return false;
-  const views = await computeIndexViews(env);
-  // 全 repo の loadRepoView が落ちた (rate limit / 障害) 時に正常な blob を
-  // 空で上書きしない invariant (Refs #329)。空 index が正しいのは「監視 repo
-  // が本当にゼロ」の時だけで、その場合 recheck も空のはず。
-  if (views.length === 0 && recheck && (recheck.views?.length ?? 0) > 0) {
-    console.log(JSON.stringify({ msg: "releases-index-refresh-skipped-empty" }));
-    return false;
+  try {
+    const recheck = await readReleasesIndexBlob<RepoView[]>(kv);
+    if (recheck && Date.now() - recheck.storedAt < RELEASES_INDEX_FRESH_SECONDS * 1000) {
+      return "fresh";
+    }
+    const views = await computeIndexViews(env);
+    // 全 repo の loadRepoView が落ちた (rate limit / 障害) 時に正常な blob を
+    // 空で上書きしない invariant (Refs #329)。空 index が正しいのは「監視 repo
+    // が本当にゼロ」の時だけで、その場合 recheck も空のはず。
+    if (views.length === 0 && recheck && (recheck.views?.length ?? 0) > 0) {
+      return "empty-skip";
+    }
+    await writeReleasesIndexBlob(kv, views);
+    // token 取得が成功した = 認証は生きている。失効 banner を自動回復 (Refs #334)。
+    await clearGitHubAuthBroken(kv);
+    return "done";
+  } finally {
+    // Lock は「compute 実行中」だけを守る。TTL 任せにすると完了/bail 後も
+    // 最大 120s 残り、その間の refresh job が全部 bail → ack 捨てされて
+    // 「stale のまま停止」する liveness 穴になっていた (Refs #337)。
+    await kv.delete(RELEASES_INDEX_REFRESH_LOCK);
   }
-  await writeReleasesIndexBlob(kv, views);
-  // token 取得が成功した = 認証は生きている。失効 banner を自動回復 (Refs #334)。
-  await clearGitHubAuthBroken(kv);
-  return true;
 }
 
 async function computeIndexViews(env: ReleasesIndexEnv): Promise<RepoView[]> {

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -41,6 +41,24 @@ export interface ReleasesIndexRefreshMessage {
 
 export type QueueMessage = WebhookQueueMessage | ReleasesIndexRefreshMessage;
 
+// Self-reschedule の重複防止 marker (Refs #337)。60s 遅延 job が既に予約済み
+// なら積み増さない。KV expirationTtl の最小値 60s に合わせる。
+const REKICK_MARKER = "releases:index:rekick-scheduled";
+
+/** stale なのに集計できなかった時の自己再投函 (Refs #337)。queue binding が
+ *  無い環境 (dev / test) は no-op — 次の event / page view の enqueue が拾う。 */
+async function scheduleReleasesIndexRekick(env: Env): Promise<void> {
+  if (!env.WEBHOOK_QUEUE) return;
+  if (await env.CI_STATUS.get(REKICK_MARKER)) return;
+  await env.CI_STATUS.put(REKICK_MARKER, "1", { expirationTtl: 60 });
+  try {
+    await env.WEBHOOK_QUEUE.send(
+      { kind: "releases-index-refresh" },
+      { delaySeconds: 60 },
+    );
+  } catch { /* 次の event / page view の enqueue に任せる */ }
+}
+
 /** /releases index の stale 化 + refresh job の即時投函 (Refs #327)。
  *  page view を待たずに consumer が再集計を始めるので、WS reload が届く頃には
  *  fresh blob が出来ている。queue binding 無し環境では stale 化のみ (次の
@@ -303,14 +321,19 @@ export async function consumeWebhookBatch(
 
   if (refreshMessages.length === 0) return;
   try {
-    const refreshed = await refreshReleasesIndex(env);
+    const outcome = await refreshReleasesIndex(env);
     // 集計が実際に走った時だけ /releases の WS reload を発火する (Refs #327)。
-    // lock / fresh recheck で bail した no-op では reload させない。
-    if (refreshed) {
+    if (outcome === "done") {
       await hub.fetch(new Request("http://hub/releases-updated", {
         method: "POST",
         body: JSON.stringify({ repo: "*" }),
       }));
+    } else if (outcome !== "fresh") {
+      // blob はまだ stale なのに集計できなかった (backoff / lock / empty-skip)。
+      // 60s 後の refresh job を自分で再投函して「stale な blob はいつか必ず
+      // 集計される」invariant を保つ (Refs #337 — 旧実装はここで ack 捨てして
+      // おり、deploy に殺された compute の残 lock に当たると停止していた)。
+      await scheduleReleasesIndexRekick(env);
     }
     for (const m of refreshMessages) m.ack();
   } catch (err) {

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -1370,11 +1370,11 @@ describe("refreshReleasesIndex guards (Refs #329)", () => {
     await env.CI_STATUS.put("releases:index:v1", seeded);
     const fetchSpy = vi.spyOn(globalThis, "fetch");
 
-    const refreshed = await refreshReleasesIndex(testEnv());
+    const outcome = await refreshReleasesIndex(testEnv());
 
-    expect(refreshed).toBe(false);
+    expect(outcome).toBe("backoff");
     expect(fetchSpy).not.toHaveBeenCalled();
-    // blob は stale のまま温存 (cooldown 明けの kick で追い付く)
+    // blob は stale のまま温存 (cooldown 明けの reschedule で追い付く)
     expect(await env.CI_STATUS.get("releases:index:v1")).toBe(seeded);
   });
 
@@ -1387,9 +1387,34 @@ describe("refreshReleasesIndex guards (Refs #329)", () => {
     await env.CI_STATUS.put("releases:index:v1", seeded);
 
     // watched に repo を入れて compute が空に潰れる状況を作る
-    const refreshed = await refreshReleasesIndex(testEnv({ watched: ["ippoan/x"] }));
+    const outcome = await refreshReleasesIndex(testEnv({ watched: ["ippoan/x"] }));
 
-    expect(refreshed).toBe(false);
+    expect(outcome).toBe("empty-skip");
+    expect(await env.CI_STATUS.get("releases:index:v1")).toBe(seeded);
+    // lock は finally で解放される (Refs #337 — TTL 残存が liveness 穴だった)
+    expect(await env.CI_STATUS.get("releases:index:refreshing")).toBeNull();
+  });
+
+  it("done の後も lock は即解放される (Refs #337)", async () => {
+    const { refreshReleasesIndex } = await import("../src/releases-page");
+    // watched 空 → views [] / recheck 無し → 正常 write の "done" 経路
+    const outcome = await refreshReleasesIndex(testEnv());
+    expect(outcome).toBe("done");
+    expect(await env.CI_STATUS.get("releases:index:v1")).not.toBeNull();
+    expect(await env.CI_STATUS.get("releases:index:refreshing")).toBeNull();
+  });
+
+  it("lock 残存中は 'lock' を返し blob に触らない", async () => {
+    const { refreshReleasesIndex } = await import("../src/releases-page");
+    await env.CI_STATUS.put("releases:index:refreshing", "1", { expirationTtl: 60 });
+    const seeded = JSON.stringify({ storedAt: 0, views: [] });
+    await env.CI_STATUS.put("releases:index:v1", seeded);
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const outcome = await refreshReleasesIndex(testEnv());
+
+    expect(outcome).toBe("lock");
+    expect(fetchSpy).not.toHaveBeenCalled();
     expect(await env.CI_STATUS.get("releases:index:v1")).toBe(seeded);
   });
 });

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -1274,3 +1274,66 @@ describe("consumeWebhookBatch — event-first (Refs #335)", () => {
     expect(updates.length).toBeLessThanOrEqual(1);
   });
 });
+
+// ───── refresh bail 時の self-reschedule (Refs #337) ─────
+describe("consumeWebhookBatch — refresh self-reschedule (Refs #337)", () => {
+  beforeEach(async () => {
+    resetHubCalls();
+    await env.CI_STATUS.delete("releases:index:v1");
+    await env.CI_STATUS.delete("releases:index:refreshing");
+    await env.CI_STATUS.delete("releases:index:rekick-scheduled");
+    await env.CI_STATUS.delete("github:rl-backoff");
+  });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  function refreshBatch(acked: string[]) {
+    return {
+      messages: [{
+        body: { kind: "releases-index-refresh" },
+        attempts: 1,
+        ack: () => acked.push("r"),
+        retry: () => { throw new Error("should not retry"); },
+      }],
+    } as unknown as MessageBatch<import("../src/webhook").QueueMessage>;
+  }
+
+  it("lock bail 時は 60s 遅延の refresh job を再投函してから ack する", async () => {
+    // deploy に殺された compute の残 lock を再現
+    await env.CI_STATUS.put("releases:index:refreshing", "1", { expirationTtl: 60 });
+    await env.CI_STATUS.put("releases:index:v1", JSON.stringify({ storedAt: 0, views: [] }));
+
+    const sent: Array<{ msg: unknown; opts: unknown }> = [];
+    const queueEnv = {
+      ...testEnv(),
+      WEBHOOK_QUEUE: { send: async (msg: unknown, opts: unknown) => { sent.push({ msg, opts }); } },
+    } as unknown as Env;
+    const acked: string[] = [];
+
+    await consumeWebhookBatch(refreshBatch(acked), queueEnv);
+
+    expect(acked).toEqual(["r"]);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].msg).toEqual({ kind: "releases-index-refresh" });
+    expect(sent[0].opts).toEqual({ delaySeconds: 60 });
+    // 重複防止 marker が立つ → 2 通目の bail では再投函しない
+    const acked2: string[] = [];
+    await consumeWebhookBatch(refreshBatch(acked2), queueEnv);
+    expect(acked2).toEqual(["r"]);
+    expect(sent).toHaveLength(1);
+  });
+
+  it("fresh 時は再投函しない (停止条件)", async () => {
+    await env.CI_STATUS.put("releases:index:v1", JSON.stringify({ storedAt: Date.now(), views: [] }));
+    const sent: unknown[] = [];
+    const queueEnv = {
+      ...testEnv(),
+      WEBHOOK_QUEUE: { send: async (msg: unknown) => { sent.push(msg); } },
+    } as unknown as Env;
+    const acked: string[] = [];
+
+    await consumeWebhookBatch(refreshBatch(acked), queueEnv);
+
+    expect(acked).toEqual(["r"]);
+    expect(sent).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## 概要 (Refs #337 — operator 報告「🔄 更新中 での停止はのこってる」)

blob が古い内容のまま「🔄 更新中」が永遠に消えない実害の根治。再ログイン (auth) は無関係で、原因は **silent bail × ack 捨ての liveness 穴**:

1. 再集計 (12〜35s の GitHub fan-out) の最中に deploy が走ると consumer invocation ごと kill され、**lock (TTL 120s) だけが残る** (昨日は短時間に 6+ deploy)
2. 再配送 / 新規の refresh job は lock に当たって**無 log で false → ack 捨て** (job 消滅)
3. 以後、新しい markStale event が来るまで誰も再集計せず、page view の kick も lock 残存中に当たれば同様に消える → **stale のまま停止、log ゼロで観測も不能**

## 変更

- **`refreshReleasesIndex` を outcome 化** (`done` / `fresh` / `backoff` / `lock` / `empty-skip`) し、**lock を try/finally で即解放** — lock は「compute 実行中」だけを守る。完了/bail 後の TTL 残存が retry を無意味に弾いていた
- **self-reschedule**: consumer は outcome が `done` でも `fresh` でもない時 (= blob はまだ stale なのに集計できなかった時) に **60s 遅延の refresh job を自己再投函** (重複防止 marker TTL 60s 付き) — 「**stale な blob はいつか必ず集計される**」invariant になり、deploy kill・backoff・auth 断などどんな一時障害でも自走で回復する
- **attempt ごとに必ず 1 行 log** (`releases-index-refresh-attempt` {outcome, ms}) — 二度と無言で詰まらない

## 検証

```
$ npm run typecheck   # green
$ npm test            # 811 tests passed
```

- 新規: lock bail で 60s 遅延 job を再投函してから ack (+重複防止 marker) / fresh では再投函しない (停止条件) / done・empty-skip 後の lock 即解放 / lock 中は blob に触らない

merge (= deploy) 後、現在残っている stale 状態も自走で回復します: 次の page view か event が refresh job を投函 → 旧 lock はもう無い (本 PR の deploy で worker が入れ替わり、残 lock も 120s で期限切れ済み) → 集計完了 → WS reload で「🔄 更新中」が消えます。

Refs #337

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhkgxKWTehmnLWqffude3z)_