### PR TITLE
feat(releases): index を webhook payload で直接 patch — 全集計は tag push と 1h 安全網のみに

### DIFF
--- a/src/release-close-batch.ts
+++ b/src/release-close-batch.ts
@@ -2,7 +2,6 @@ import { githubApi, parseRepo, tokenForOrg } from "./github-api";
 import { formatCloseFailureReason } from "./release-close";
 import type { AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
 import { invalidateIssue } from "./release-cache";
-import { markReleasesIndexStale } from "./releases-index-cache";
 
 // POST /api/release-close-batch
 //
@@ -145,13 +144,9 @@ export async function handleReleaseCloseBatch(
         }
       }),
     );
-    // /releases index blob も stale 化 (Refs #325)。redirect 先の表示自体は
-    // flash 整合 (closed= の row を closed 扱いに変換) が担保する。
-    if (closedByRepo.size > 0) {
-      for (const repo of closedByRepo.keys()) {
-        await markReleasesIndexStale(env.CI_STATUS, repo);
-      }
-    }
+    // /releases index は close で発火する issues webhook の直接 patch
+    // (Refs #339) が反映する — ここでの stale 化 (= 全集計の引き金) は不要に
+    // なった。redirect 直後の表示は flash 整合が担保する。
   }
 
   // Kick Hub to recompute alert state for each repo that had a successful close.

--- a/src/release-close.ts
+++ b/src/release-close.ts
@@ -1,7 +1,6 @@
 import { GitHubApiError, githubApi, parseRepo, tokenForOrg } from "./github-api";
 import type { AuthClientWorkerEnv } from "@ippoan/auth-client-worker";
 import { invalidateIssue } from "./release-cache";
-import { markReleasesIndexStale } from "./releases-index-cache";
 
 // failure 理由を URL flash param に safely 載せるための整形。
 // GitHubApiError は `GitHub API 403: {"message":"Repository was archived so
@@ -113,9 +112,9 @@ export async function handleReleaseClose(
     await Promise.all(
       closed.map((n) => invalidateIssue(env.CI_STATUS, owner, name, n)),
     );
-    // /releases index blob も stale 化 (Refs #325)。redirect 先の表示自体は
-    // flash 整合 (closed= の row を closed 扱いに変換) が担保する。
-    if (closed.length > 0) await markReleasesIndexStale(env.CI_STATUS, repoParam);
+    // /releases index は close で発火する issues webhook の直接 patch
+    // (Refs #339) が反映する — ここでの stale 化 (= 全集計の引き金) は不要に
+    // なった。redirect 直後の表示は flash 整合が担保する。
   }
 
   // Kick the Hub to recompute the banner alert state for this repo when at

--- a/src/releases-index-cache.ts
+++ b/src/releases-index-cache.ts
@@ -26,7 +26,10 @@ export const RELEASES_INDEX_KEY = "releases:index:v1";
 // 「refresh の最短間隔」としてだけ機能する。60s だと CI ラッシュ時に
 // 全集計 (~30 repo × 100+ GitHub call) が時間 30 回走り quota を食い潰した
 // (2026-06-11 実害、Refs #329) ので 180s に緩和。
-export const RELEASES_INDEX_FRESH_SECONDS = 180;
+// Webhook 直接 patch (#339) 導入後は、merge / close は patch が即反映する
+// ため、全集計は「tag push の引き金 + 1h の答え合わせ」だけになる
+// (#332 の webhook-primary と同思想)。
+export const RELEASES_INDEX_FRESH_SECONDS = 3600;
 const RELEASES_INDEX_STORE_SECONDS = 86400;
 
 // refresh の重複排除 lock。fan-out は 35s かかり得るので余裕を持って 120s。
@@ -48,6 +51,18 @@ export async function writeReleasesIndexBlob(
     JSON.stringify({ storedAt: Date.now(), views }),
     { expirationTtl: RELEASES_INDEX_STORE_SECONDS },
   );
+}
+
+/** webhook 直接 patch (Refs #339) 用の書き戻し。storedAt / staleRepos を
+ *  変えない — storedAt は「最後の full snapshot 時刻」の意味を保ち、patch は
+ *  内容を現にするだけなので更新中バッジも出さない。 */
+export async function writePatchedReleasesIndexBlob(
+  kv: KVNamespace,
+  blob: ReleasesIndexBlob,
+): Promise<void> {
+  await kv.put(RELEASES_INDEX_KEY, JSON.stringify(blob), {
+    expirationTtl: RELEASES_INDEX_STORE_SECONDS,
+  });
 }
 
 /** blob を stale 化する (storedAt:0 へ書き換え)。delete にしないのは、close /

--- a/src/releases-index-patch.ts
+++ b/src/releases-index-patch.ts
@@ -1,0 +1,132 @@
+// /releases index blob の webhook 直接 patch (Refs #339)。
+//
+// #325〜#338 の SWR + queue 再集計では、webhook は「全集計 (12〜35s の GitHub
+// fan-out) の引き金」でしかなかった。merge / close のたびに重い再集計が走り、
+// deploy kill・rate limit・auth 断の影響を受け続ける。/issues (upsertIssue) や
+// PR チップ (applyPullRequestEvent) と同じく、webhook payload の情報で blob を
+// その場で書き換え、全集計は tag push と 1h の安全網だけに格下げする。
+//
+// 設計上の不変条件:
+// - patch は storedAt / staleRepos を**変えない** (storedAt = 最後の full
+//   snapshot 時刻という意味を保つ。patch 成功時は内容が現になるので
+//   更新中バッジも出ない)
+// - 行データは GitHub API を呼ばず /issues KV cache (`issue:repo#N`) から組む
+// - patch できない時は caller が従来の stale 化 + 全集計に fallback する
+
+import type { OrgIssue } from "./mcp/tools/issues";
+import type { IssueRow, RepoView, TagBlock } from "./releases-page";
+import type { IssueWebhookPayload } from "./issue-cache";
+import { issueKey } from "./issue-cache";
+import { computeWarnings } from "./release-helpers";
+import {
+  readReleasesIndexBlob,
+  writePatchedReleasesIndexBlob,
+} from "./releases-index-cache";
+
+/** issues event (close / reopen / edit) を blob 内の該当行に反映する。
+ *  行の特定は html_url 完全一致 (cross-repo 行も含めて全 card を走査)。
+ *  @returns true = 1 行以上 patch して blob を書いた (= WS reload して良い)。
+ *  false = 該当行なし or blob 不在 (= index 内容に影響なし、何もしない)。 */
+export async function applyIssueEventToReleasesIndex(
+  kv: KVNamespace,
+  payload: IssueWebhookPayload,
+): Promise<boolean> {
+  const blob = await readReleasesIndexBlob<RepoView[]>(kv);
+  if (!blob) return false;
+
+  const issue = payload.issue;
+  const labels = issue.labels.map((l) => l.name);
+  let patched = false;
+  for (const view of blob.views) {
+    for (const block of view.tagBlocks) {
+      for (const row of block.issues) {
+        if (row.url !== issue.html_url) continue;
+        row.state = issue.state;
+        row.title = issue.title;
+        row.labels = labels;
+        row.assignees = issue.assignees.map((a) => a.login);
+        row.updated_at = issue.updated_at;
+        row.warnings = computeWarnings({ state: issue.state, labels });
+        patched = true;
+      }
+    }
+  }
+  if (!patched) return false;
+  await writePatchedReleasesIndexBlob(kv, blob);
+  return true;
+}
+
+export type RefsPatchOutcome = "patched" | "noop" | "fallback";
+
+/** merge / default-branch push で参照された issue (`Refs #N`) を tagless repo
+ *  の synthetic / Unreleased block に挿入し、block の `<branch>@<sha7>` を
+ *  進める。行データは /issues KV cache から構成 (GitHub API 0 call)。
+ *
+ *  @returns "patched"  = blob を書いた (WS reload して良い)
+ *           "noop"     = index 内容に影響なし (非 tagless repo / 変更なし)
+ *           "fallback" = patch 不能 (blob/card 無し、KV に issue 無し等) —
+ *                        caller が stale 化 + 全集計に fallback する */
+export async function applyRefsPatchToReleasesIndex(
+  kv: KVNamespace,
+  repo: string,
+  refs: number[],
+  headSha: string | null,
+): Promise<RefsPatchOutcome> {
+  const blob = await readReleasesIndexBlob<RepoView[]>(kv);
+  if (!blob) return "fallback";
+
+  const view = blob.views.find((v) => v.repo === repo);
+  // Roster に未登場の repo は全集計でしか発見できない。
+  if (!view) return "fallback";
+  // 非 tagless repo の merge は index 内容を変えない (tag が出るまで
+  // close 候補にならない)。stale 化もしない。
+  if (!view.tagless) return "noop";
+
+  const block = view.tagBlocks.find((b) => b.synthetic);
+  if (!block) {
+    // tagless なのに synthetic block が無い形は loadRepoView が作らない
+    // はずだが、見つからなければ構造を推測せず全集計に任せる。
+    return refs.length === 0 ? "noop" : "fallback";
+  }
+
+  let changed = false;
+
+  for (const n of refs) {
+    // 既に載っている (same-repo 行 = repo field 無し) なら skip。
+    if (block.issues.some((r) => r.number === n && !r.repo)) continue;
+    const cached = await kv.get(issueKey(repo, n), "json") as OrgIssue | null;
+    if (!cached) {
+      // /issues KV に無い (closed 済 / 未配信)。中途半端に挿入せず全集計へ。
+      // ここまでの patch は書かずに捨てる (fallback の全集計が全部やり直す)。
+      return "fallback";
+    }
+    const row: IssueRow = {
+      number: cached.number,
+      title: cached.title,
+      state: cached.state,
+      labels: cached.labels,
+      assignees: cached.assignees,
+      url: cached.url,
+      updated_at: cached.updated_at,
+      warnings: computeWarnings({ state: cached.state, labels: cached.labels }),
+    };
+    block.issues.push(row);
+    changed = true;
+  }
+  block.issues.sort((a, b) => a.number - b.number);
+
+  // Synthetic block の identity (`<branch>@<sha7>` 等、形式は build 経路で
+  // 揺れる) は sha 部分だけを正規表現で差し替える — 形式を推測しない。
+  if (headSha) {
+    const sha7 = headSha.slice(0, 7);
+    const next = block.tag.replace(/\b[0-9a-f]{7,40}\b/, sha7);
+    if (next !== block.tag) {
+      block.tag = next;
+      changed = true;
+    }
+  }
+
+  if (!changed) return "noop";
+  await writePatchedReleasesIndexBlob(kv, blob);
+  return "patched";
+}

--- a/src/releases-page.ts
+++ b/src/releases-page.ts
@@ -120,7 +120,7 @@ function cacheControlFor(hasFlash: boolean, detail: boolean): string {
 // "Recent releases" landing page (no params)
 // --------------------------------------------------------------------------
 
-interface RepoView {
+export interface RepoView {
   repo: string;
   tagBlocks: TagBlock[];
   olderTags: string[];   // tags beyond the displayed top N
@@ -130,7 +130,7 @@ interface RepoView {
   tagless: boolean;
 }
 
-interface TagBlock {
+export interface TagBlock {
   tag: string;
   prevTag: string | null;
   issues: IssueRow[];    // already-fetched and warning-annotated
@@ -718,7 +718,7 @@ interface ReleasePayload {
   rows: IssueRow[];
 }
 
-interface IssueRow {
+export interface IssueRow {
   number: number;
   title: string;
   state: string;

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -21,6 +21,11 @@ import {
 } from "./release-cache";
 import { applyPullRequestEvent } from "./pr-map-cache";
 import { markReleasesIndexStale } from "./releases-index-cache";
+import {
+  applyIssueEventToReleasesIndex,
+  applyRefsPatchToReleasesIndex,
+} from "./releases-index-patch";
+import { extractRefIssues } from "./release-helpers";
 import { noteGitHubAuthBroken } from "./github-backoff";
 import { refreshReleasesIndex } from "./releases-page";
 
@@ -59,6 +64,17 @@ async function scheduleReleasesIndexRekick(env: Env): Promise<void> {
   } catch { /* 次の event / page view の enqueue に任せる */ }
 }
 
+/** /releases の WS reload を発火する (Refs #327/#339)。patch / 集計完了の
+ *  「内容が現になった」時だけ呼ぶ。失敗は fail-open (次の reload で追い付く)。 */
+async function broadcastReleasesUpdated(hub: DurableObjectStub, repo: string): Promise<void> {
+  try {
+    await hub.fetch(new Request("http://hub/releases-updated", {
+      method: "POST",
+      body: JSON.stringify({ repo }),
+    }));
+  } catch { /* fail-open */ }
+}
+
 /** /releases index の stale 化 + refresh job の即時投函 (Refs #327)。
  *  page view を待たずに consumer が再集計を始めるので、WS reload が届く頃には
  *  fresh blob が出来ている。queue binding 無し環境では stale 化のみ (次の
@@ -84,6 +100,10 @@ interface ReleaseWebhookPayload {
 
 interface PushWebhookPayload {
   ref: string;
+  // 直接 patch (Refs #339) 用。GitHub の実配信には常に載るが、最小 payload
+  // (テスト fixture) でも落ちないよう optional。
+  after?: string;
+  commits?: Array<{ message: string }>;
   repository: {
     full_name: string;
     default_branch: string;
@@ -431,9 +451,22 @@ async function processWebhookEvent(
         await invalidateRepoCompare(env.CI_STATUS, owner, name);
         await invalidateRepoCommits(env.CI_STATUS, owner, name);
       }
-      // merge は Unreleased zone / synthetic block の中身を変える → /releases
-      // index の stale 化 + refresh job 投函 (Refs #325 / #327)。
-      await staleAndKickReleasesIndex(env, repo);
+      // merge は Unreleased zone / synthetic block の中身を変える。
+      // webhook payload (PR title+body の Refs #N) で blob を直接 patch し、
+      // 行データは /issues KV から組む — 全集計しない (Refs #339)。
+      // patch 不能時のみ従来の stale 化 + 全集計に fallback。
+      {
+        const [prOwner, prName] = repo.split("/");
+        const refs = extractRefIssues(
+          `${payload.pull_request.title ?? ""}\n${payload.pull_request.body ?? ""}`,
+          prOwner && prName ? { owner: prOwner, name: prName } : undefined,
+        );
+        const outcome = await applyRefsPatchToReleasesIndex(
+          env.CI_STATUS, repo, refs, payload.pull_request.merge_commit_sha,
+        );
+        if (outcome === "patched") await broadcastReleasesUpdated(hub, repo);
+        else if (outcome === "fallback") await staleAndKickReleasesIndex(env, repo);
+      }
       // /issues の merged 紫チップも変わる (pr-map は applyPullRequestEvent で
       // patch 済み) → live reload を発火 (Refs #327)。
       try {
@@ -476,9 +509,13 @@ async function processWebhookEvent(
     if (owner && name) {
       await invalidateReleaseCacheIssue(env.CI_STATUS, owner, name, payload.issue.number);
     }
-    // /releases index は issue の open/close で close 候補の表示が変わる。
-    // stale 化 + refresh job 投函 (Refs #325 / #327)。
-    await staleAndKickReleasesIndex(env, payload.repository.full_name);
+    // /releases index は webhook payload で直接 patch する (Refs #339)。
+    // 該当行が無い (= index に出ていない issue) なら index 内容に影響なし —
+    // stale 化も全集計もしない (1h の安全網が答え合わせする)。
+    const releasesPatched = await applyIssueEventToReleasesIndex(env.CI_STATUS, payload);
+    if (releasesPatched) {
+      await broadcastReleasesUpdated(hub, payload.repository.full_name);
+    }
     // /issues page の live reload trigger (Refs #321)。KV upsert 完了後に
     // broadcast するので、reload 時の SSR read は必ず更新後の KV を見る。
     // 通知失敗は page 側の問題に留まる (次の手動 reload で追い付く) ため
@@ -548,7 +585,7 @@ async function processWebhookEvent(
       if (owner && name) {
         if (ref.startsWith("refs/tags/")) {
           await invalidateRepoTags(env.CI_STATUS, owner, name);
-          // 新 tag は index の tag blocks を変える (Refs #325 / #327)。
+          // 新 tag は compare が要る唯一のケース — 全集計に任せる (Refs #339)。
           await staleAndKickReleasesIndex(env, fullName);
         } else if (defaultBranch && ref === `refs/heads/${defaultBranch}`) {
           await invalidateRepoCommits(env.CI_STATUS, owner, name);
@@ -556,7 +593,18 @@ async function processWebhookEvent(
           // squash merge は default branch への push として届くので、これで
           // merge 単位の即時反映になる (60s TTL を待たない)。Refs #231。
           await invalidateRepoCompare(env.CI_STATUS, owner, name);
-          await staleAndKickReleasesIndex(env, fullName);
+          // commit message の Refs #N で blob を直接 patch (Refs #339)。
+          // squash merge では PR event と二重に届くが dedupe で冪等。
+          // direct-push repo (PR を経ない) もこの経路で即反映される。
+          const refs = new Set<number>();
+          for (const c of payload.commits ?? []) {
+            for (const n of extractRefIssues(c.message, { owner, name })) refs.add(n);
+          }
+          const outcome = await applyRefsPatchToReleasesIndex(
+            env.CI_STATUS, fullName, [...refs], payload.after ?? null,
+          );
+          if (outcome === "patched") await broadcastReleasesUpdated(hub, fullName);
+          else if (outcome === "fallback") await staleAndKickReleasesIndex(env, fullName);
         }
       }
     }

--- a/test/releases-page.test.ts
+++ b/test/releases-page.test.ts
@@ -1225,7 +1225,7 @@ describe("GET /releases — index SWR blob (Refs #325)", () => {
     // ため、blob 更新の検証は空 blob を seed して行う。
     vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
       new Response("not stubbed", { status: 500 }));
-    const oldStoredAt = Date.now() - 300_000;
+    const oldStoredAt = Date.now() - 2 * 60 * 60 * 1000;
     await seedIndexBlob(oldStoredAt, []);
 
     const ctx = createExecutionContext();
@@ -1246,7 +1246,7 @@ describe("GET /releases — index SWR blob (Refs #325)", () => {
   it("stale blob (non-empty) の即返し時も中身が render される", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
       new Response("not stubbed", { status: 500 }));
-    await seedIndexBlob(Date.now() - 300_000, [seededView]);
+    await seedIndexBlob(Date.now() - 2 * 60 * 60 * 1000, [seededView]);
 
     const ctx = createExecutionContext();
     const res = await worker.fetch(new Request("http://localhost/releases"), testEnv(), ctx);

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -1157,8 +1157,9 @@ describe("releases index blob (Refs #325)", () => {
     expect(updates[0].body).toEqual({ repo: "*" });
   });
 
-  it("issues event で blob が stale 化される (storedAt:0)", async () => {
+  it("index に出ていない issue の event は blob を stale 化しない (Refs #339)", async () => {
     await seedBlob();
+    const before = await blobStoredAt();
     const body = JSON.stringify({
       action: "opened",
       issue: {
@@ -1179,7 +1180,147 @@ describe("releases index blob (Refs #325)", () => {
       testEnv(), ctx,
     );
     await waitOnExecutionContext(ctx);
-    expect(await blobStoredAt()).toBe(0);
+    // 該当行が無い = index 内容に影響なし → 全集計の引き金にしない
+    expect(await blobStoredAt()).toBe(before);
+  });
+
+  it("index に出ている issue の close は blob を直接 patch して broadcast する (Refs #339)", async () => {
+    // blob に open 行を seed (synthetic block)
+    await env.CI_STATUS.put("releases:index:v1", JSON.stringify({
+      storedAt: 12345,
+      views: [{
+        repo: "ippoan/foo", tagless: true, olderTags: [],
+        tagBlocks: [{
+          tag: "main@abc1234", prevTag: null, synthetic: true,
+          issues: [{
+            number: 7, title: "t", state: "open",
+            labels: [], assignees: [], warnings: [],
+            url: "https://github.com/ippoan/foo/issues/7",
+            updated_at: "2026-06-11T00:00:00Z",
+          }],
+        }],
+      }],
+    }));
+    const body = JSON.stringify({
+      action: "closed",
+      issue: {
+        number: 7, title: "t", state: "closed", user: { login: "y" },
+        labels: [], assignees: [], comments: 0,
+        created_at: "2026-06-11T00:00:00Z", updated_at: "2026-06-11T01:00:00Z",
+        html_url: "https://github.com/ippoan/foo/issues/7",
+      },
+      repository: { full_name: "ippoan/foo" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST", body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "issues" },
+      }),
+      testEnv(), ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    const blob = await env.CI_STATUS.get("releases:index:v1", "json") as {
+      storedAt: number;
+      views: Array<{ tagBlocks: Array<{ issues: Array<{ state: string; warnings: string[] }> }> }>;
+    };
+    // 行が closed に書き換わり、storedAt (= full snapshot 時刻) は不変
+    expect(blob.views[0].tagBlocks[0].issues[0].state).toBe("closed");
+    expect(blob.storedAt).toBe(12345);
+    // /releases の WS reload が発火する
+    const updates = hubCalls.filter((c) => c.path === "/releases-updated");
+    expect(updates).toHaveLength(1);
+  });
+
+  it("PR merged は Refs #N を /issues KV から組んで synthetic block に挿入する (Refs #339)", async () => {
+    // /issues KV に open issue (行データの供給元)
+    await env.CI_STATUS.put("issue:ippoan/foo#9", JSON.stringify({
+      repo: "ippoan/foo", number: 9, title: "patched in", state: "open",
+      author: "y", labels: ["bug"], assignees: [], comments: 0,
+      created_at: "2026-06-11T00:00:00Z", updated_at: "2026-06-11T00:00:00Z",
+      url: "https://github.com/ippoan/foo/issues/9",
+    }));
+    // blob: 空の synthetic block を持つ tagless card
+    await env.CI_STATUS.put("releases:index:v1", JSON.stringify({
+      storedAt: 12345,
+      views: [{
+        repo: "ippoan/foo", tagless: true, olderTags: [],
+        tagBlocks: [{ tag: "main@abc1234", prevTag: null, synthetic: true, issues: [] }],
+      }],
+    }));
+    const body = JSON.stringify({
+      action: "closed",
+      pull_request: {
+        number: 50, merged: true, merge_commit_sha: "deadbeefcafe1234",
+        base: { ref: "main" }, title: "feat: x", body: "Refs #9",
+        draft: false, html_url: "https://github.com/ippoan/foo/pull/50",
+        updated_at: "2026-06-11T01:00:00Z",
+      },
+      repository: { full_name: "ippoan/foo", default_branch: "main" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST", body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "pull_request" },
+      }),
+      testEnv(), ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    const blob = await env.CI_STATUS.get("releases:index:v1", "json") as {
+      storedAt: number;
+      staleRepos?: string[];
+      views: Array<{ tagBlocks: Array<{ tag: string; issues: Array<{ number: number; title: string }> }> }>;
+    };
+    const block = blob.views[0].tagBlocks[0];
+    // 行が /issues KV から挿入され、block の sha が merge_commit_sha に進む
+    expect(block.issues.map((i) => i.number)).toEqual([9]);
+    expect(block.issues[0].title).toBe("patched in");
+    expect(block.tag).toBe("main@deadbee");
+    // 全集計の引き金 (stale 化) は不要
+    expect(blob.storedAt).toBe(12345);
+    expect(blob.staleRepos ?? []).toEqual([]);
+    const updates = hubCalls.filter((c) => c.path === "/releases-updated");
+    expect(updates).toHaveLength(1);
+  });
+
+  it("Refs 先が /issues KV に無い merge は全集計に fallback する (Refs #339)", async () => {
+    await env.CI_STATUS.put("releases:index:v1", JSON.stringify({
+      storedAt: 12345,
+      views: [{
+        repo: "ippoan/foo", tagless: true, olderTags: [],
+        tagBlocks: [{ tag: "main@abc1234", prevTag: null, synthetic: true, issues: [] }],
+      }],
+    }));
+    const body = JSON.stringify({
+      action: "closed",
+      pull_request: {
+        number: 51, merged: true, merge_commit_sha: "abc",
+        base: { ref: "main" }, title: "feat: y", body: "Refs #99",
+        draft: false, html_url: "https://github.com/ippoan/foo/pull/51",
+        updated_at: "2026-06-11T01:00:00Z",
+      },
+      repository: { full_name: "ippoan/foo", default_branch: "main" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST", body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "pull_request" },
+      }),
+      testEnv(), ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    const blob = await env.CI_STATUS.get("releases:index:v1", "json") as
+      { storedAt: number; staleRepos?: string[] };
+    expect(blob.storedAt).toBe(0);
+    expect(blob.staleRepos).toContain("ippoan/foo");
   });
 
   it("tag push で blob が stale 化される", async () => {


### PR DESCRIPTION
## 概要 (Refs #339 — operator 方針「webhooks を重視して」の本丸)

これまで /releases index にとって webhook は「**全集計 (12〜35s の GitHub fan-out) の引き金**」でしかなかった。merge / close のたびに重い再集計が走り、deploy kill (#337)・rate limit (#329)・auth 断 (#334) の影響を受け続ける構造が残っていた。

本 PR で /issues (upsertIssue) や PR チップ (applyPullRequestEvent) と同じ「**webhook が真実を書く**」形に揃える:

| event | before | after |
|---|---|---|
| issues (close/reopen/edit) | stale 化 → 全集計 | **blob 内の該当行を html_url 一致で即書き換え** (API 0 call) — release-close フローが全集計なしで即反映 |
| pull_request merged | stale 化 → 全集計 | **Refs #N を payload から抽出、行データを /issues KV から構成して synthetic block に dedupe 挿入** + `main@sha7` 更新 (API 0 call) |
| push (default branch) | stale 化 → 全集計 | commits[].message の Refs で同様に patch (direct-push repo 対応、squash merge の二重 event は冪等) |
| push (tag) | stale 化 → 全集計 | 変更なし (compare が要る唯一のケース) |
| 全集計 fresh 窓 | 180s | **1h の安全網** (#332 と同思想) |

## 整合規則

- patch は `storedAt` / `staleRepos` を**変えない** — full snapshot 時刻の意味を保ち、patch 成功時は内容が現なので「🔄 更新中」も出ない。完了後に WS broadcast → 即 reload
- patch 不能 (blob/card 無し、Refs 先が /issues KV 未収載等) は従来の stale 化 + 全集計に **fallback** (#338 の self-reschedule が完遂を保証)
- 非 tagless repo の merge は no-op (index 内容が変わらないので stale 化もしない)
- index に出ていない issue の event は何もしない (全集計の引き金にしない)
- release-close handler 側の markStale は撤去 (close の issues webhook patch が担う)

## 効果

merge / close での GitHub fan-out が**ゼロ**になり、反映は KV write + WS reload の数秒で完結。全集計は tag push と 1h の答え合わせのみ = quota 消費・障害感受性が最小化。

## 検証

```
$ npm run typecheck   # green
$ npm test            # 814 tests passed
```

- 新規: close patch (行書き換え + storedAt 不変 + broadcast) / merge patch (KV からの行構成 + sha 更新 + stale 化しない) / KV 未収載 Refs の fallback / 無関係 issue event の no-op

Refs #339

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhkgxKWTehmnLWqffude3z)_