### PR TITLE
fix(releases): blob patch を Hub DO で直列化 — batch close の lost update を防止

### DIFF
--- a/src/hub.ts
+++ b/src/hub.ts
@@ -9,6 +9,11 @@ import {
 } from "./release-alert";
 import { parseRepo, tokenForOrg } from "./github-api";
 import { invalidateIssue } from "./release-cache";
+import {
+  applyIssueEventToReleasesIndex,
+  applyRefsPatchToReleasesIndex,
+} from "./releases-index-patch";
+import type { IssueWebhookPayload } from "./issue-cache";
 
 // WebSocket message envelope. All broadcasts now share `{ type, data }` so
 // the dashboard JS can dispatch by type. Two channels currently:
@@ -49,6 +54,20 @@ export class CIDashboardHub extends DurableObject<Env> {
   // the tag alert in place when a fresh tag release fires.
   private alerts = new Map<string, ReleaseAlert>();
   private alertsLoaded = false;
+
+  // /releases index blob への mutation を直列化する instance 内 mutex
+  // (Refs #341)。queue consumer は並走 3 (#336) のため、batch close の
+  // issues event が同じ blob を同時 read-modify-write すると後勝ちで他の
+  // patch が消える (lost update)。本 DO は singleton なので promise chain で
+  // 確実に直列になる。
+  private releasesPatchChain: Promise<unknown> = Promise.resolve();
+
+  private serializeReleasesPatch<T>(work: () => Promise<T>): Promise<T> {
+    const run = this.releasesPatchChain.then(work);
+    // 後続は成功/失敗に関わらず続行 (失敗は caller に伝播)。
+    this.releasesPatchChain = run.then(() => undefined, () => undefined);
+    return run;
+  }
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
@@ -259,6 +278,38 @@ export class CIDashboardHub extends DurableObject<Env> {
       const data = await request.json<{ repo: string; number: number; state: string }>();
       this.broadcastEnvelope({ type: "issues-updated", data });
       return new Response("OK");
+    }
+
+    // /releases index blob への webhook 直接 patch (Refs #339/#341)。
+    // consumer から委譲され、本 DO 内で直列実行する (lost update 防止)。
+    // patch 成功時の WS broadcast もここで行う = patch → broadcast が原子的。
+    if (url.pathname === "/releases-index-apply-issue") {
+      const payload = await request.json<IssueWebhookPayload>();
+      const patched = await this.serializeReleasesPatch(() =>
+        applyIssueEventToReleasesIndex(this.env.CI_STATUS, payload),
+      );
+      if (patched) {
+        this.broadcastEnvelope({
+          type: "releases-updated",
+          data: { repo: payload.repository.full_name },
+        });
+      }
+      return Response.json({ patched });
+    }
+
+    if (url.pathname === "/releases-index-apply-refs") {
+      const { repo, refs, headSha } = await request.json<{
+        repo: string;
+        refs: number[];
+        headSha: string | null;
+      }>();
+      const outcome = await this.serializeReleasesPatch(() =>
+        applyRefsPatchToReleasesIndex(this.env.CI_STATUS, repo, refs, headSha),
+      );
+      if (outcome === "patched") {
+        this.broadcastEnvelope({ type: "releases-updated", data: { repo } });
+      }
+      return Response.json({ outcome });
     }
 
     // /releases page の live reload trigger (Refs #327)。

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -21,11 +21,8 @@ import {
 } from "./release-cache";
 import { applyPullRequestEvent } from "./pr-map-cache";
 import { markReleasesIndexStale } from "./releases-index-cache";
-import {
-  applyIssueEventToReleasesIndex,
-  applyRefsPatchToReleasesIndex,
-} from "./releases-index-patch";
 import { extractRefIssues } from "./release-helpers";
+import type { RefsPatchOutcome } from "./releases-index-patch";
 import { noteGitHubAuthBroken } from "./github-backoff";
 import { refreshReleasesIndex } from "./releases-page";
 
@@ -73,6 +70,27 @@ async function broadcastReleasesUpdated(hub: DurableObjectStub, repo: string): P
       body: JSON.stringify({ repo }),
     }));
   } catch { /* fail-open */ }
+}
+
+/** refs patch を Hub DO に委譲する (Refs #341 — blob RMW の直列化)。
+ *  hub 到達不能・応答異常は "fallback" 扱いで stale 化 + 全集計に倒す。 */
+async function applyRefsPatchViaHub(
+  hub: DurableObjectStub,
+  repo: string,
+  refs: number[],
+  headSha: string | null,
+): Promise<RefsPatchOutcome> {
+  try {
+    const res = await hub.fetch(new Request("http://hub/releases-index-apply-refs", {
+      method: "POST",
+      body: JSON.stringify({ repo, refs, headSha }),
+    }));
+    if (!res.ok) return "fallback";
+    const { outcome } = await res.json<{ outcome: RefsPatchOutcome }>();
+    return outcome ?? "fallback";
+  } catch {
+    return "fallback";
+  }
 }
 
 /** /releases index の stale 化 + refresh job の即時投函 (Refs #327)。
@@ -461,11 +479,10 @@ async function processWebhookEvent(
           `${payload.pull_request.title ?? ""}\n${payload.pull_request.body ?? ""}`,
           prOwner && prName ? { owner: prOwner, name: prName } : undefined,
         );
-        const outcome = await applyRefsPatchToReleasesIndex(
-          env.CI_STATUS, repo, refs, payload.pull_request.merge_commit_sha,
+        const outcome = await applyRefsPatchViaHub(
+          hub, repo, refs, payload.pull_request.merge_commit_sha,
         );
-        if (outcome === "patched") await broadcastReleasesUpdated(hub, repo);
-        else if (outcome === "fallback") await staleAndKickReleasesIndex(env, repo);
+        if (outcome === "fallback") await staleAndKickReleasesIndex(env, repo);
       }
       // /issues の merged 紫チップも変わる (pr-map は applyPullRequestEvent で
       // patch 済み) → live reload を発火 (Refs #327)。
@@ -510,12 +527,17 @@ async function processWebhookEvent(
       await invalidateReleaseCacheIssue(env.CI_STATUS, owner, name, payload.issue.number);
     }
     // /releases index は webhook payload で直接 patch する (Refs #339)。
+    // blob の read-modify-write は Hub DO で直列化する (Refs #341 — 並走
+    // consumer の lost update 防止)。broadcast も DO 内で原子的に行われる。
     // 該当行が無い (= index に出ていない issue) なら index 内容に影響なし —
-    // stale 化も全集計もしない (1h の安全網が答え合わせする)。
-    const releasesPatched = await applyIssueEventToReleasesIndex(env.CI_STATUS, payload);
-    if (releasesPatched) {
-      await broadcastReleasesUpdated(hub, payload.repository.full_name);
-    }
+    // stale 化も全集計もしない (1h の安全網が答え合わせする)。hub 到達不能は
+    // fail-open (安全網が拾う)。
+    try {
+      await hub.fetch(new Request("http://hub/releases-index-apply-issue", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      }));
+    } catch { /* fail-open */ }
     // /issues page の live reload trigger (Refs #321)。KV upsert 完了後に
     // broadcast するので、reload 時の SSR read は必ず更新後の KV を見る。
     // 通知失敗は page 側の問題に留まる (次の手動 reload で追い付く) ため
@@ -600,11 +622,10 @@ async function processWebhookEvent(
           for (const c of payload.commits ?? []) {
             for (const n of extractRefIssues(c.message, { owner, name })) refs.add(n);
           }
-          const outcome = await applyRefsPatchToReleasesIndex(
-            env.CI_STATUS, fullName, [...refs], payload.after ?? null,
+          const outcome = await applyRefsPatchViaHub(
+            hub, fullName, [...refs], payload.after ?? null,
           );
-          if (outcome === "patched") await broadcastReleasesUpdated(hub, fullName);
-          else if (outcome === "fallback") await staleAndKickReleasesIndex(env, fullName);
+          if (outcome === "fallback") await staleAndKickReleasesIndex(env, fullName);
         }
       }
     }

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -64,6 +64,21 @@ function mockHub(kv: KVNamespace): DurableObjectStub {
         hubCalls.push({ path: url.pathname, body: parsed });
       } catch { /* ignore */ }
 
+      // blob patch の DO 委譲 (Refs #341)。mock でも実 patch 関数を呼び、
+      // 「consumer → hub 委譲 → blob 反映」を integration として検証する。
+      if (url.pathname === "/releases-index-apply-issue") {
+        const { applyIssueEventToReleasesIndex } = await import("../src/releases-index-patch");
+        const payload = JSON.parse(await req.text());
+        const patched = await applyIssueEventToReleasesIndex(kv, payload);
+        return Response.json({ patched });
+      }
+      if (url.pathname === "/releases-index-apply-refs") {
+        const { applyRefsPatchToReleasesIndex } = await import("../src/releases-index-patch");
+        const { repo, refs, headSha } = JSON.parse(await req.text());
+        const outcome = await applyRefsPatchToReleasesIndex(kv, repo, refs, headSha);
+        return Response.json({ outcome });
+      }
+
       if (url.pathname === "/release-alert-detect") {
         // Side-channel for Tag Release completion. The real Hub fans out to
         // GitHub; the mock just acks.
@@ -1229,9 +1244,9 @@ describe("releases index blob (Refs #325)", () => {
     // 行が closed に書き換わり、storedAt (= full snapshot 時刻) は不変
     expect(blob.views[0].tagBlocks[0].issues[0].state).toBe("closed");
     expect(blob.storedAt).toBe(12345);
-    // /releases の WS reload が発火する
-    const updates = hubCalls.filter((c) => c.path === "/releases-updated");
-    expect(updates).toHaveLength(1);
+    // patch は Hub DO へ委譲される (broadcast は DO 内で原子的に行われる)
+    const applies = hubCalls.filter((c) => c.path === "/releases-index-apply-issue");
+    expect(applies).toHaveLength(1);
   });
 
   it("PR merged は Refs #N を /issues KV から組んで synthetic block に挿入する (Refs #339)", async () => {
@@ -1284,8 +1299,8 @@ describe("releases index blob (Refs #325)", () => {
     // 全集計の引き金 (stale 化) は不要
     expect(blob.storedAt).toBe(12345);
     expect(blob.staleRepos ?? []).toEqual([]);
-    const updates = hubCalls.filter((c) => c.path === "/releases-updated");
-    expect(updates).toHaveLength(1);
+    const applies = hubCalls.filter((c) => c.path === "/releases-index-apply-refs");
+    expect(applies).toHaveLength(1);
   });
 
   it("Refs 先が /issues KV に無い merge は全集計に fallback する (Refs #339)", async () => {


### PR DESCRIPTION
## 概要 (Refs #341 — operator 報告「close しても /issues は消えるが /releases では消えない」)

cache の **lost update race** でした:

```
batch close → issues.closed webhook が N 連発 → consumer 並走 3 (#336)
  consumer A: blob read (X,Y open) ─┐
  consumer B: blob read (X,Y open) ─┤ 同じ blob を同時 read-modify-write
  A: 「X closed の blob」write      │
  B: 「Y closed の blob」write ←── 後勝ちで A の patch が消える
```

/issues は per-issue KV キーなので無事。/releases だけ 1 blob 共有のため close patch が負けて open のまま残る。

## 変更

- **CIDashboardHub (singleton DO) に blob patch を集約**: `POST /releases-index-apply-issue` / `POST /releases-index-apply-refs` を追加し、instance 内 promise-chain mutex で確実に直列化 (DO は世界に 1 instance)
- **patch → broadcast を原子的に**: `releases-updated` の WS broadcast も DO 内で実施
- consumer は直接 RMW せず hub に委譲。hub 到達不能・応答異常は `fallback` 扱いで従来の stale 化 + 全集計に倒す (#338 の self-reschedule が完遂保証)
- `markStale` も同種の RMW だが、冪等で負けても staleRepos 1 件欠け (cosmetic) に留まるため現状維持

## 検証

```
$ npm run typecheck   # green
$ npm test            # 814 tests passed
```

- mockHub に新 endpoint を実装し (実 patch 関数を呼ぶ)、「consumer → hub 委譲 → blob 反映」を integration として検証 (close patch / merge 挿入 / KV 未収載 fallback / 無関係 issue no-op)

merge 後は batch close → 全行が確実に closed へ patch → WS reload で即消えます。

Refs #341

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhkgxKWTehmnLWqffude3z)_