### PR TITLE
fix(releases): close 経路で index blob を同期 patch して issue 復活を防ぐ

### DIFF
--- a/src/hub.ts
+++ b/src/hub.ts
@@ -10,6 +10,7 @@ import {
 import { parseRepo, tokenForOrg } from "./github-api";
 import { invalidateIssue } from "./release-cache";
 import {
+  applyCloseToReleasesIndex,
   applyIssueEventToReleasesIndex,
   applyRefsPatchToReleasesIndex,
 } from "./releases-index-patch";
@@ -293,6 +294,21 @@ export class CIDashboardHub extends DurableObject<Env> {
           type: "releases-updated",
           data: { repo: payload.repository.full_name },
         });
+      }
+      return Response.json({ patched });
+    }
+
+    // ダッシュボード起点 close の index blob 同期反映 (Refs #343)。issues
+    // webhook (apply-issue) が来ない repo でも close を即 blob に焼くため、
+    // handleReleaseClose から closed issue の url 群を委譲される。本 DO 内で
+    // 直列実行 (lost update 防止) + patch 成功時 broadcast を原子的に行う。
+    if (url.pathname === "/releases-index-apply-close") {
+      const { repo, urls } = await request.json<{ repo: string; urls: string[] }>();
+      const patched = await this.serializeReleasesPatch(() =>
+        applyCloseToReleasesIndex(this.env.CI_STATUS, urls),
+      );
+      if (patched) {
+        this.broadcastEnvelope({ type: "releases-updated", data: { repo } });
       }
       return Response.json({ patched });
     }

--- a/src/release-close.ts
+++ b/src/release-close.ts
@@ -112,9 +112,26 @@ export async function handleReleaseClose(
     await Promise.all(
       closed.map((n) => invalidateIssue(env.CI_STATUS, owner, name, n)),
     );
-    // /releases index は close で発火する issues webhook の直接 patch
-    // (Refs #339) が反映する — ここでの stale 化 (= 全集計の引き金) は不要に
-    // なった。redirect 直後の表示は flash 整合が担保する。
+  }
+
+  // /releases index blob を close 経路で同期 patch する (Refs #343)。issues
+  // webhook 直接 patch (#339) は per-repo 購読に依存し、未購読 repo では
+  // blob が patch されず closed issue が reload で復活する (= #343 の実害)。
+  // close handler は確定した closed[] を握っているので、redirect 前に hub
+  // 経由で blob を直す。flash 整合だけに頼らず blob 自体を closed にするので
+  // 2 回目以降の reload でも復活しない。hub 到達不能は fail-open (flash 整合
+  // + 1h 安全網が拾う)。webhook patch と二重に走っても Hub DO 直列化(#342) +
+  // last-write-wins で冪等。
+  if (hub && closed.length > 0) {
+    const closedUrls = closed.map(
+      (n) => `https://github.com/${owner}/${name}/issues/${n}`,
+    );
+    try {
+      await hub.fetch(new Request("http://hub/releases-index-apply-close", {
+        method: "POST",
+        body: JSON.stringify({ repo: repoParam, urls: closedUrls }),
+      }));
+    } catch { /* fail-open: flash 整合 + 1h 安全網が拾う */ }
   }
 
   // Kick the Hub to recompute the banner alert state for this repo when at

--- a/src/releases-index-patch.ts
+++ b/src/releases-index-patch.ts
@@ -56,6 +56,47 @@ export async function applyIssueEventToReleasesIndex(
   return true;
 }
 
+/** ダッシュボード起点の close (`handleReleaseClose`) が、確定した closed issue を
+ *  index blob に同期反映する (Refs #343)。issues webhook 直接 patch (#339) は
+ *  per-repo 購読 + GitHub 配信 + fail-open hub fetch の単一非同期チェーンに依存し、
+ *  webhook 未購読 repo では blob が patch されず closed issue が reload で復活する。
+ *  close handler は自分の結果 (closed[]) を握っているので、それを使って同期的に
+ *  blob を直す (webhook patch とは last-write-wins で冪等)。
+ *
+ *  行の特定は `applyIssueEventToReleasesIndex` と同じく url 完全一致。close の
+ *  対象 url は `https://github.com/<owner>/<name>/issues/<n>` で、同一 repo 行
+ *  (url がそれ自身) も cross-repo 行 (Refs #292、`row.repo` が close 対象 repo の
+ *  時その url を持つ) も同じ突合で拾える。
+ *
+ *  state 以外 (title / labels / assignees / updated_at) は GitHub を引き直さず
+ *  行の既存値を保持する — close は state しか変えないため。
+ *  @returns true = 1 行以上 patch して blob を書いた (WS reload して良い)。 */
+export async function applyCloseToReleasesIndex(
+  kv: KVNamespace,
+  closedUrls: string[],
+): Promise<boolean> {
+  if (closedUrls.length === 0) return false;
+  const blob = await readReleasesIndexBlob<RepoView[]>(kv);
+  if (!blob) return false;
+
+  const targets = new Set(closedUrls);
+  let patched = false;
+  for (const view of blob.views) {
+    for (const block of view.tagBlocks) {
+      for (const row of block.issues) {
+        if (!targets.has(row.url)) continue;
+        if (row.state === "closed") continue;
+        row.state = "closed";
+        row.warnings = computeWarnings({ state: "closed", labels: row.labels });
+        patched = true;
+      }
+    }
+  }
+  if (!patched) return false;
+  await writePatchedReleasesIndexBlob(kv, blob);
+  return true;
+}
+
 export type RefsPatchOutcome = "patched" | "noop" | "fallback";
 
 /** merge / default-branch push で参照された issue (`Refs #N`) を tagless repo

--- a/test/release-close.test.ts
+++ b/test/release-close.test.ts
@@ -3,6 +3,9 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import worker from "../src/index";
 import type { Env } from "../src/index";
 
+// hub.fetch の記録用。テストごとに reset する。
+const hubCalls: Array<{ url: string; body: unknown }> = [];
+
 function testEnv(): Env {
   return {
     CI_STATUS: env.CI_STATUS,
@@ -10,7 +13,14 @@ function testEnv(): Env {
     INTERNAL_SHARED_SECRET: { get: async () => "test-internal" } as unknown as SecretsStoreSecret,
     CI_HUB: {
       idFromName: () => ({}),
-      get: () => ({ fetch: async () => new Response("OK") }),
+      get: () => ({
+        fetch: async (req: Request) => {
+          let body: unknown = null;
+          try { body = await req.clone().json(); } catch { /* no body */ }
+          hubCalls.push({ url: req.url, body });
+          return Response.json({ patched: true });
+        },
+      }),
     } as unknown as DurableObjectNamespace,
     RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
     RELEASE_WAVE_WEBHOOK_SECRET: { get: async () => "test-webhook-secret" } as unknown as SecretsStoreSecret,
@@ -66,7 +76,54 @@ function formBody(pairs: Array<[string, string]>): string {
 }
 
 describe("POST /api/release-close", () => {
-  afterEach(() => { vi.restoreAllMocks(); });
+  afterEach(() => { vi.restoreAllMocks(); hubCalls.length = 0; });
+
+  it("delegates closed issues to the hub for synchronous blob patch (Refs #343)", async () => {
+    stubCloseFlow();
+    const req = new Request("http://localhost/api/release-close", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formBody([
+        ["repo", "ippoan/claude-skills"],
+        ["tag", "v1.2.0"],
+        ["issue", "68"],
+        ["issue", "70"],
+      ]),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(303);
+    const applyClose = hubCalls.find((c) => c.url.includes("/releases-index-apply-close"));
+    expect(applyClose).toBeDefined();
+    expect(applyClose!.body).toMatchObject({
+      repo: "ippoan/claude-skills",
+      urls: [
+        "https://github.com/ippoan/claude-skills/issues/68",
+        "https://github.com/ippoan/claude-skills/issues/70",
+      ],
+    });
+  });
+
+  it("does not call the close-patch hub when every issue fails to close", async () => {
+    stubCloseFlow({ failIssue: 68 });
+    const req = new Request("http://localhost/api/release-close", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formBody([
+        ["repo", "ippoan/claude-skills"],
+        ["tag", "v1.2.0"],
+        ["issue", "68"],
+      ]),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(303);
+    expect(hubCalls.find((c) => c.url.includes("/releases-index-apply-close"))).toBeUndefined();
+  });
 
   it("closes selected issues and redirects with the closed flash", async () => {
     const { calls } = stubCloseFlow();

--- a/test/releases-index-patch.test.ts
+++ b/test/releases-index-patch.test.ts
@@ -1,0 +1,159 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect, beforeEach } from "vitest";
+import { applyCloseToReleasesIndex } from "../src/releases-index-patch";
+import {
+  RELEASES_INDEX_KEY,
+  readReleasesIndexBlob,
+  writeReleasesIndexBlob,
+} from "../src/releases-index-cache";
+import type { RepoView } from "../src/releases-page";
+
+function row(number: number, url: string, state = "open") {
+  return {
+    number,
+    title: `issue ${number}`,
+    state,
+    labels: [] as string[],
+    assignees: [] as string[],
+    url,
+    updated_at: "2026-06-11T00:00:00Z",
+    warnings: [] as string[],
+  };
+}
+
+function seedBlob(views: RepoView[]): Promise<void> {
+  return writeReleasesIndexBlob(env.CI_STATUS, views);
+}
+
+describe("applyCloseToReleasesIndex", () => {
+  beforeEach(async () => {
+    await env.CI_STATUS.delete(RELEASES_INDEX_KEY);
+  });
+
+  it("flips a matched same-repo row to closed and recomputes warnings", async () => {
+    await seedBlob([
+      {
+        repo: "ippoan/claude-skills",
+        tagless: false,
+        tagBlocks: [
+          {
+            tag: "v1.0.0",
+            prevTag: null,
+            issues: [
+              row(68, "https://github.com/ippoan/claude-skills/issues/68"),
+              row(70, "https://github.com/ippoan/claude-skills/issues/70"),
+            ],
+          },
+        ],
+      },
+    ]);
+
+    const patched = await applyCloseToReleasesIndex(env.CI_STATUS, [
+      "https://github.com/ippoan/claude-skills/issues/68",
+    ]);
+    expect(patched).toBe(true);
+
+    const blob = await readReleasesIndexBlob<RepoView[]>(env.CI_STATUS);
+    const issues = blob!.views[0]!.tagBlocks[0]!.issues;
+    expect(issues.find((r) => r.number === 68)!.state).toBe("closed");
+    expect(issues.find((r) => r.number === 68)!.warnings).toContain("already closed");
+    // 非対象行は不変。
+    expect(issues.find((r) => r.number === 70)!.state).toBe("open");
+  });
+
+  it("matches a cross-repo row by url (Refs #292 cross-repo close target)", async () => {
+    await seedBlob([
+      {
+        repo: "ippoan/cdp-relay",
+        tagless: true,
+        tagBlocks: [
+          {
+            tag: "main@abc1234",
+            prevTag: null,
+            synthetic: true,
+            issues: [
+              // cross-repo 行: card は cdp-relay だが issue は mcp-cf-workers。
+              {
+                ...row(28, "https://github.com/ippoan/mcp-cf-workers/issues/28"),
+                repo: "ippoan/mcp-cf-workers",
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    const patched = await applyCloseToReleasesIndex(env.CI_STATUS, [
+      "https://github.com/ippoan/mcp-cf-workers/issues/28",
+    ]);
+    expect(patched).toBe(true);
+
+    const blob = await readReleasesIndexBlob<RepoView[]>(env.CI_STATUS);
+    expect(blob!.views[0]!.tagBlocks[0]!.issues[0]!.state).toBe("closed");
+  });
+
+  it("returns false (no write) when no row matches", async () => {
+    await seedBlob([
+      {
+        repo: "ippoan/claude-skills",
+        tagless: false,
+        tagBlocks: [
+          { tag: "v1.0.0", prevTag: null, issues: [row(70, "https://github.com/ippoan/claude-skills/issues/70")] },
+        ],
+      },
+    ]);
+
+    const patched = await applyCloseToReleasesIndex(env.CI_STATUS, [
+      "https://github.com/ippoan/claude-skills/issues/68",
+    ]);
+    expect(patched).toBe(false);
+  });
+
+  it("returns false when the issue row is already closed (idempotent re-close)", async () => {
+    await seedBlob([
+      {
+        repo: "ippoan/claude-skills",
+        tagless: false,
+        tagBlocks: [
+          {
+            tag: "v1.0.0",
+            prevTag: null,
+            issues: [row(68, "https://github.com/ippoan/claude-skills/issues/68", "closed")],
+          },
+        ],
+      },
+    ]);
+
+    const patched = await applyCloseToReleasesIndex(env.CI_STATUS, [
+      "https://github.com/ippoan/claude-skills/issues/68",
+    ]);
+    expect(patched).toBe(false);
+  });
+
+  it("returns false on empty input and when no blob exists", async () => {
+    expect(await applyCloseToReleasesIndex(env.CI_STATUS, [])).toBe(false);
+    expect(
+      await applyCloseToReleasesIndex(env.CI_STATUS, [
+        "https://github.com/ippoan/claude-skills/issues/68",
+      ]),
+    ).toBe(false);
+  });
+
+  it("preserves storedAt (patch must not masquerade as a fresh full snapshot)", async () => {
+    await seedBlob([
+      {
+        repo: "ippoan/claude-skills",
+        tagless: false,
+        tagBlocks: [
+          { tag: "v1.0.0", prevTag: null, issues: [row(68, "https://github.com/ippoan/claude-skills/issues/68")] },
+        ],
+      },
+    ]);
+    const before = await readReleasesIndexBlob<RepoView[]>(env.CI_STATUS);
+    await applyCloseToReleasesIndex(env.CI_STATUS, [
+      "https://github.com/ippoan/claude-skills/issues/68",
+    ]);
+    const after = await readReleasesIndexBlob<RepoView[]>(env.CI_STATUS);
+    expect(after!.storedAt).toBe(before!.storedAt);
+  });
+});


### PR DESCRIPTION
Refs #343

## 症状

`/releases` の close 確認 UI で issue を close しても、reload すると open 候補として「復活」する。hard reload (Ctrl+Shift+R) でも直らない。実例: ippoan/claude-skills#68 を close → GitHub 上は closed 確定なのに `/releases` では open 行のまま。

## 根本原因 (observability で確定)

- `handleReleaseClose` は close 成功後 index blob (`releases:index:v1`) に触れず、反映を **issues webhook 直接 patch (#339)** に委ねていた。
- flash 整合 (`releases-page.ts:196-205`) は redirect 1 回限りでメモリ上の表示だけ closed 化し、blob には書き戻さない → 2 回目以降の reload で生 blob の `state:"open"` が再表示 = 復活。hard reload が効かないのは真因がサーバ側 KV blob だから。
- close 時刻前後で hub の `/releases-index-apply-issue` は**過去2時間で発火ゼロ**、`/issues-updated` も発火なし (両者とも `webhook.ts` の `if (event === "issues")` 内で無条件に呼ばれる) → **claude-skills の `issues` webhook が ci-dashboard に未購読**であることを確認。

## 修正 (PR1)

close handler は確定した `closed[]` を握っているので、それを使って blob を**同期 patch** する:

- **`releases-index-patch.ts`**: `applyCloseToReleasesIndex(kv, closedUrls)` を追加。`applyIssueEventToReleasesIndex` と同じ url 完全一致で same-repo / cross-repo (Refs #292) 行を拾い、`state:"closed"` + warnings 再計算。state 以外 (title/labels 等) は既存値を保持し GitHub 追加 fetch は不要。`storedAt` 不変。
- **`hub.ts`**: 新 endpoint `/releases-index-apply-close` を追加。`serializeReleasesPatch` で本 DO 内直列実行 (#342 lost update 防止) + patch 成功時 `releases-updated` broadcast を原子的に行う。
- **`release-close.ts`**: `closed[]` を `https://github.com/<owner>/<name>/issues/<n>` に url 化し、redirect 前に hub へ await して委譲。hub 到達不能は fail-open。

これにより issues webhook が来ない repo でも close が即 blob に焼かれ、reload で復活しない。webhook patch と二重に走っても last-write-wins で冪等。

## テスト

- `test/releases-index-patch.test.ts` (新規 6 件): same-repo / cross-repo マッチ、不一致 false、既に closed の冪等 false、空入力・blob 不在、storedAt 保持。
- `test/release-close.test.ts` (新規 2 件): hub への `/releases-index-apply-close` 委譲 (url 群を検証)、全 issue 失敗時は委譲しない。
- `npx tsc --noEmit` 通過、対象 2 ファイル 14 tests passed。

## 残作業 (別 issue)

PR1 はダッシュボード起点の close を守る。GitHub UI からの直接 close は依然 webhook 頼みなので、別途 **PR2: `issues` webhook 購読の棚卸し / org-level webhook 化** が必要。PR3 (webhook fail-open の loud 化)・PR4 (flash の cross-repo 対応) も #343 に記載。

https://claude.ai/code/session_0176hTGBgdsQk9yQ8xUReteJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0176hTGBgdsQk9yQ8xUReteJ)_