### PR TITLE
fix(releases): batch close も index blob を同期 patch（close 後すぐ消えず再更新が必要な問題）

### DIFF
--- a/src/release-close-batch.ts
+++ b/src/release-close-batch.ts
@@ -144,9 +144,34 @@ export async function handleReleaseCloseBatch(
         }
       }),
     );
-    // /releases index は close で発火する issues webhook の直接 patch
-    // (Refs #339) が反映する — ここでの stale 化 (= 全集計の引き金) は不要に
-    // なった。redirect 直後の表示は flash 整合が担保する。
+  }
+
+  // /releases index blob を close 経路で同期 patch する (Refs #343)。issues
+  // webhook 直接 patch (#339) は close の ~20s 後に届くため、redirect 直後の
+  // blob はまだ open で issue が候補に残り続け、operator が「もう一度更新」を
+  // 強いられていた。close handler は確定した closed[] を握っているので、
+  // redirect 前に hub 経由で該当行を同期 closed 化する (single close と同じ
+  // /releases-index-apply-close、url 突合なので cross-repo 行も拾う)。
+  // webhook patch と二重に走っても Hub DO 直列化 (#342) + last-write-wins で
+  // 冪等。hub 到達不能は fail-open (flash 整合 + webhook + 1h 安全網が拾う)。
+  if (hub && closedByRepo.size > 0) {
+    const closedUrls: string[] = [];
+    for (const [repo, nums] of closedByRepo) {
+      try {
+        const { owner, repo: name } = parseRepo(repo);
+        for (const n of nums) {
+          closedUrls.push(`https://github.com/${owner}/${name}/issues/${n}`);
+        }
+      } catch { /* malformed repo は skip (上の invalidate と同じ扱い) */ }
+    }
+    if (closedUrls.length > 0) {
+      try {
+        await hub.fetch(new Request("http://hub/releases-index-apply-close", {
+          method: "POST",
+          body: JSON.stringify({ repo: repoParam, urls: closedUrls }),
+        }));
+      } catch { /* fail-open: flash 整合 + webhook + 1h 安全網が拾う */ }
+    }
   }
 
   // Kick Hub to recompute alert state for each repo that had a successful close.

--- a/test/release-close-batch.test.ts
+++ b/test/release-close-batch.test.ts
@@ -3,6 +3,9 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import worker from "../src/index";
 import type { Env } from "../src/index";
 
+// hub.fetch の記録用。テストごとに reset する。
+const hubCalls: Array<{ url: string; body: unknown }> = [];
+
 function testEnv(): Env {
   return {
     CI_STATUS: env.CI_STATUS,
@@ -10,7 +13,14 @@ function testEnv(): Env {
     INTERNAL_SHARED_SECRET: { get: async () => "test-internal" } as unknown as SecretsStoreSecret,
     CI_HUB: {
       idFromName: () => ({}),
-      get: () => ({ fetch: async () => new Response("OK") }),
+      get: () => ({
+        fetch: async (req: Request) => {
+          let body: unknown = null;
+          try { body = await req.clone().json(); } catch { /* no body */ }
+          hubCalls.push({ url: req.url, body });
+          return Response.json({ patched: true });
+        },
+      }),
     } as unknown as DurableObjectNamespace,
     RELEASE_WAVE_HUB: { idFromName: () => ({}), get: () => ({ fetch: async () => new Response("OK") }) } as unknown as DurableObjectNamespace,
     RELEASE_WAVE_WEBHOOK_SECRET: { get: async () => "test-webhook-secret" } as unknown as SecretsStoreSecret,
@@ -52,7 +62,51 @@ function formBody(pairs: Array<[string, string]>): string {
 }
 
 describe("POST /api/release-close-batch", () => {
-  afterEach(() => { vi.restoreAllMocks(); });
+  afterEach(() => { vi.restoreAllMocks(); hubCalls.length = 0; });
+
+  it("synchronously patches the index blob for same-repo + cross-repo closes (Refs #343)", async () => {
+    stubCloseFlow();
+    const req = new Request("http://localhost/api/release-close-batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formBody([
+        ["repo", "ippoan/cdp-relay"],
+        // same-repo (card 上の issue) + cross-repo (別 repo の issue)
+        ["pair", "v1.0.0:12"],
+        ["pair", "main@abc1234:ippoan/mcp-cf-workers#28"],
+      ]),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(303);
+    const applyClose = hubCalls.find((c) => c.url.includes("/releases-index-apply-close"));
+    expect(applyClose).toBeDefined();
+    const body = applyClose!.body as { repo: string; urls: string[] };
+    expect(body.repo).toBe("ippoan/cdp-relay");
+    // url 突合: card repo の同一 repo 行も、別 repo の cross-repo 行も拾う。
+    expect(body.urls).toContain("https://github.com/ippoan/cdp-relay/issues/12");
+    expect(body.urls).toContain("https://github.com/ippoan/mcp-cf-workers/issues/28");
+  });
+
+  it("does not call the close-patch hub when every issue fails to close", async () => {
+    stubCloseFlow({ failIssue: 12 });
+    const req = new Request("http://localhost/api/release-close-batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formBody([
+        ["repo", "ippoan/cdp-relay"],
+        ["pair", "v1.0.0:12"],
+      ]),
+    });
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(req, testEnv(), ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(303);
+    expect(hubCalls.find((c) => c.url.includes("/releases-index-apply-close"))).toBeUndefined();
+  });
 
   it("groups pairs by tag and posts a tag-attributed comment + PATCH per issue", async () => {
     const { calls } = stubCloseFlow();


### PR DESCRIPTION
Refs #343 / follow-up of #344

## 症状

`/releases` で issue を close すると、**redirect 直後はまだ候補に残り、もう一度更新すると消える**（「すぐは残る、また更新が必要」）。

## 原因

#344 は単一 close（`handleReleaseClose` = `/api/release-close`）だけ同期 blob patch を入れたが、**`/releases` の主経路はバッチ close（`handleReleaseCloseBatch` = `/api/release-close-batch`）**で、こちらは対象外だった。バッチ close は invalidateIssue（release-cache のみ）と banner recompute だけで、index blob の closed 反映は **issues webhook 直接 patch (#339)** 任せ。webhook は close の **~20 秒後**に届く（実ログ: 12:50:09 issues.closed 受理 → 12:50:15 `/releases-index-apply-issue` 発火）ため、redirect 直後の blob はまだ `open` で issue が残り、webhook patch が landした後の再更新で初めて消えていた。

## 修正

バッチ close も、確定済みの `closedByRepo` から issue url を組み、#344 で追加した hub endpoint `/releases-index-apply-close` を **redirect 前に同期呼び出し**する。url 突合なので same-repo 行と cross-repo 行（Refs #292）の両方を closed 化できる。webhook patch と二重実行しても Hub DO 直列化(#342) + last-write-wins で冪等、hub 到達不能は fail-open。

## テスト

- `test/release-close-batch.test.ts`（新規 2 件）: same-repo + cross-repo pair を渡し、hub `/releases-index-apply-close` が両方の url（`.../cdp-relay/issues/12` と `.../mcp-cf-workers/issues/28`）で呼ばれることを検証 / 全 issue 失敗時は呼ばない。
- `npx tsc --noEmit` 通過、関連 3 ファイル 22 tests passed。

## 補足

webhook 経路（issues 購読・配送・受理 200・apply-issue 発火）は正常動作を実ログで確認済み（#343 参照）。本 PR は close 直後の**即時反映**を担保するもの。flash 整合の cross-repo 対応（`releases-page.ts:198`）は別途 #343 の PR4 として残す。

https://claude.ai/code/session_0176hTGBgdsQk9yQ8xUReteJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0176hTGBgdsQk9yQ8xUReteJ)_