### PR TITLE
hardening(releases): webhook の releases-index patch fail-open を loud 化する

### DIFF
--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -93,6 +93,32 @@ async function applyRefsPatchViaHub(
   }
 }
 
+/** issues event の blob patch を Hub DO に委譲する (Refs #339/#346)。
+ *  `applyRefsPatchViaHub` と同じく res.ok / 応答を検査し、結果を返す:
+ *    "patched"  = 1 行以上 closed 化して blob を書いた
+ *    "noop"     = 該当行なし (index に出ていない issue) — 正常、何もしない
+ *    "degraded" = hub 到達不能 / 非 OK / 応答 parse 失敗 — patch が落ちた疑い。
+ *                 caller が loud log + stale 化 fallback に倒す。
+ *  従来 (#339) は try/catch fail-open で degraded を無音 skip しており、
+ *  webhook は届いているのに blob 反映だけ落ちる無音経路になっていた (#346)。 */
+async function applyIssuePatchViaHub(
+  hub: DurableObjectStub,
+  payload: IssueWebhookPayload,
+): Promise<"patched" | "noop" | "degraded"> {
+  try {
+    const res = await hub.fetch(new Request("http://hub/releases-index-apply-issue", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    }));
+    if (!res.ok) return "degraded";
+    const { patched } = await res.json<{ patched?: boolean }>();
+    if (typeof patched !== "boolean") return "degraded";
+    return patched ? "patched" : "noop";
+  } catch {
+    return "degraded";
+  }
+}
+
 /** /releases index の stale 化 + refresh job の即時投函 (Refs #327)。
  *  page view を待たずに consumer が再集計を始めるので、WS reload が届く頃には
  *  fresh blob が出来ている。queue binding 無し環境では stale 化のみ (次の
@@ -529,15 +555,25 @@ async function processWebhookEvent(
     // /releases index は webhook payload で直接 patch する (Refs #339)。
     // blob の read-modify-write は Hub DO で直列化する (Refs #341 — 並走
     // consumer の lost update 防止)。broadcast も DO 内で原子的に行われる。
-    // 該当行が無い (= index に出ていない issue) なら index 内容に影響なし —
-    // stale 化も全集計もしない (1h の安全網が答え合わせする)。hub 到達不能は
-    // fail-open (安全網が拾う)。
-    try {
-      await hub.fetch(new Request("http://hub/releases-index-apply-issue", {
-        method: "POST",
-        body: JSON.stringify(payload),
+    // 該当行が無い ("noop" = index に出ていない issue) なら index 内容に
+    // 影響なし — 何もしない (1h の安全網が答え合わせする)。
+    // patch が落ちた ("degraded": hub 到達不能 / 非 OK / parse 失敗) 時は
+    // **無音にせず** loud log + stale 化 fallback に倒す (Refs #346)。従来の
+    // fail-open は blob 反映漏れを silent に放置し、webhook が動いていない
+    // という誤診の原因になっていた。
+    const issueOutcome = await applyIssuePatchViaHub(hub, payload);
+    if (issueOutcome === "degraded") {
+      console.log(JSON.stringify({
+        msg: "releases-index-apply-issue-degraded",
+        repo: payload.repository.full_name,
+        number: payload.issue.number,
+        action: payload.action,
       }));
-    } catch { /* fail-open */ }
+      // blob 反映が落ちた疑い → stale 化 + refresh enqueue で 1h 安全網より
+      // 早く整合させる (best-effort、失敗は次の page view が拾う)。
+      try { await staleAndKickReleasesIndex(env, payload.repository.full_name); }
+      catch { /* best-effort */ }
+    }
     // /issues page の live reload trigger (Refs #321)。KV upsert 完了後に
     // broadcast するので、reload 時の SSR read は必ず更新後の KV を見る。
     // 通知失敗は page 側の問題に留まる (次の手動 reload で追い付く) ため

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -4,6 +4,12 @@ import worker from "../src/index";
 import type { Env } from "../src/index";
 import type { CIStatus, JobStatus, WebhookQueueMessage } from "../src/webhook";
 import { consumeWebhookBatch } from "../src/webhook";
+import {
+  RELEASES_INDEX_KEY,
+  readReleasesIndexBlob,
+  writeReleasesIndexBlob,
+} from "../src/releases-index-cache";
+import type { RepoView } from "../src/releases-page";
 
 const WEBHOOK_SECRET = "test-secret";
 
@@ -857,6 +863,74 @@ describe("POST /webhook", () => {
     const updates = hubCalls.filter((c) => c.path === "/issues-updated");
     expect(updates).toHaveLength(1);
     expect(updates[0].body).toEqual({ repo: "ippoan/foo", number: 42, state: "closed" });
+  });
+
+  // Refs #346: hub の apply-issue が非 OK を返す (degraded) 時、従来は無音
+  // skip だったが、loud log + stale 化 fallback に倒す。stale 化が走ったことを
+  // blob の storedAt:0 + staleRepos で検証する。
+  it("issues event falls back to staling the index when the hub apply-issue is degraded", async () => {
+    // 既存の fresh blob を仕込む (markReleasesIndexStale は blob 不在なら no-op)。
+    await writeReleasesIndexBlob(env.CI_STATUS, [
+      {
+        repo: "ippoan/foo",
+        tagless: false,
+        tagBlocks: [{
+          tag: "v1", prevTag: null,
+          issues: [{
+            number: 42, title: "x", state: "open", labels: [], assignees: [],
+            url: "https://github.com/ippoan/foo/issues/42",
+            updated_at: "2026-05-27T01:00:00Z", warnings: [],
+          }],
+        }],
+      },
+    ] satisfies RepoView[]);
+    const before = await readReleasesIndexBlob<RepoView[]>(env.CI_STATUS);
+    expect(before!.storedAt).toBeGreaterThan(0);
+
+    // apply-issue だけ 500 を返す degraded hub。他経路は通常どおり。
+    const degradedHub = {
+      fetch: async (req: Request) => {
+        const url = new URL(req.url);
+        if (url.pathname === "/releases-index-apply-issue") {
+          return new Response("boom", { status: 500 });
+        }
+        return new Response("OK");
+      },
+    } as unknown as DurableObjectStub;
+    const degradedEnv: Env = {
+      ...testEnv(),
+      CI_HUB: { idFromName: () => ({}), get: () => degradedHub } as unknown as DurableObjectNamespace,
+    };
+
+    const body = JSON.stringify({
+      action: "closed",
+      issue: {
+        number: 42, title: "x", state: "closed", user: { login: "y" },
+        labels: [], assignees: [], comments: 0,
+        created_at: "2026-05-27T00:00:00Z",
+        updated_at: "2026-05-27T01:00:00Z",
+        html_url: "https://github.com/ippoan/foo/issues/42",
+      },
+      repository: { full_name: "ippoan/foo" },
+    });
+    const sig = await sign(body, WEBHOOK_SECRET);
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      new Request("http://localhost/webhook", {
+        method: "POST",
+        body,
+        headers: { "X-Hub-Signature-256": sig, "X-GitHub-Event": "issues" },
+      }),
+      degradedEnv,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(200);
+
+    // degraded fallback で blob が stale 化された (= 1h 安全網より早く再集計される)。
+    const after = await readReleasesIndexBlob<RepoView[]>(env.CI_STATUS);
+    expect(after!.storedAt).toBe(0);
+    expect(after!.staleRepos).toContain("ippoan/foo");
   });
 });
 


### PR DESCRIPTION
Refs #346

## 背景

`webhook.ts` の `issues` イベント処理で、index blob への patch を hub に委譲する `hub.fetch("/releases-index-apply-issue")` は `try { ... } catch { /* fail-open */ }` で囲まれており、hub 到達不能・非 OK 応答・parse 失敗時に **patch を無音で skip** し、queue retry も発火しなかった。webhook が届いていても blob 反映だけ落ちる無音経路で、#343 の調査時に「webhook が動いていない」という誤診の一因にもなった。

## 修正

既存の `applyRefsPatchViaHub`（`res.ok` 検査 + fallback）と同じパターンの `applyIssuePatchViaHub` を追加し、結果を `patched` / `noop` / `degraded` で返す:

- **`patched`**: 1 行以上 closed 化して blob を書いた
- **`noop`**: 該当行なし（index に出ていない issue）— 正常、何もしない
- **`degraded`**: hub 到達不能 / 非 OK / parse 失敗 — patch が落ちた疑い

`degraded` 時は **無音にせず** `console.log({ msg: "releases-index-apply-issue-degraded", repo, number, action })` で loud に記録し、`staleAndKickReleasesIndex` で blob を stale 化 + refresh enqueue（1h 安全網より早く再集計）に倒す。

## テスト

- `test/webhook.test.ts`（新規 1 件）: apply-issue が 500 を返す degraded hub で issues.closed を投げ、blob が stale 化される（`storedAt:0` + `staleRepos` に repo 追加）ことを検証。既存の issues / pull_request 経路テストは不変で全 43 件 green。
- `npx tsc --noEmit` 通過。

## 備考

無音失敗が起きてもダッシュボード起点 close は #344/#345 の同期 patch が blob を直すため実害は限定的。本 PR は GitHub UI 直接 close の webhook 経路の堅牢化＋診断性向上。`patched:false` の「該当行なし vs blob 不在」区別（#346 の3つ目のチェック）は hub 側 return の拡張が要るため別途。

https://claude.ai/code/session_0176hTGBgdsQk9yQ8xUReteJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0176hTGBgdsQk9yQ8xUReteJ)_